### PR TITLE
feat: add customizable New Conversation shortcut for Sidecar

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -840,6 +840,9 @@
     "Name is too long (maximum 100 characters)" : {
       "comment" : "Set name page - Error message when user name exceeds 100 characters"
     },
+    "New Conversation" : {
+      "comment" : "View menu - Menu item to start a new AI conversation in the sidebar"
+    },
     "New Folder" : {
       "comment" : "Bookmark New Folder menu item\nBookmark editor - Inline new folder creation title\nFolder creator - Title of the sheet to create a new folder\nNew folder dialog title\nSidebar context menu title\nTab area context menu - Create a new bookmark folder\nTab multi-selection context menu - bookmark selected tabs into a newly created folder"
     },

--- a/Sources/Application/AppController+Menu.swift
+++ b/Sources/Application/AppController+Menu.swift
@@ -123,6 +123,15 @@ extension AppController {
                 Shortcuts.updateShortcut(for: toggleChatbarItem)
                 toggleChatbarItem.target = self
                 submenu.addItem(toggleChatbarItem)
+
+                let newConversationItem = NSMenuItem(title: NSLocalizedString("New Conversation", comment: "View menu - Menu item to start a new AI conversation in the sidebar"),
+                                                   action: #selector(newConversation(_:)),
+                                                   keyEquivalent: "o")
+                newConversationItem.keyEquivalentModifierMask = [.command, .shift]
+                newConversationItem.tag = CommandWrapper.PHI_NEW_CONVERSATION.rawValue
+                Shortcuts.updateShortcut(for: newConversationItem)
+                newConversationItem.target = self
+                submenu.addItem(newConversationItem)
             } else
             
             if menuItem.title == "Phi", let subMenu = menuItem.submenu {
@@ -338,6 +347,28 @@ extension AppController {
     
     @objc func toggleChatbar(_ sendar: Any?) {
         MainBrowserWindowControllersManager.shared.activeWindowController?.browserState.toggleAIChat()
+    }
+
+    /// Starts a new AI conversation in the focused window's sidebar.
+    ///
+    /// The actual "new conversation" logic lives inside the Sidecar extension
+    /// (React), so we can't run it natively. Instead we broadcast a message the
+    /// extension listens for. Validation (`validateUserInterfaceItem`) already
+    /// guarantees focus is inside the AI sidebar when this fires, so the sidebar
+    /// is open and visible — no need to open it here. `windowId` lets only the
+    /// focused window's Sidecar respond to the broadcast.
+    @MainActor
+    @objc func newConversation(_ sender: Any?) {
+        guard let windowController = MainBrowserWindowControllersManager.shared.activeWindowController else {
+            return
+        }
+        let windowId = windowController.browserState.focusingTab?.windowId ?? 0
+        let payload = ["windowId": windowId]
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let json = String(data: data, encoding: .utf8) else {
+            return
+        }
+        ExtensionMessaging.shared.broadcast(type: "newConversation", payload: json)
     }
 
     @objc func toggleBookmarkBar(_ sender: Any?) {
@@ -593,7 +624,23 @@ extension AppController {
                 return false
             }
         }
-        
+
+        // New Conversation only applies while focus is inside the AI sidebar;
+        // otherwise disable the item so its shortcut falls through to the
+        // original behavior.
+        if item.action == #selector(newConversation(_:)) {
+            let phiAIEnabled = UserDefaults.standard.bool(forKey: PhiPreferences.AISettings.phiAIEnabled.rawValue)
+            let state = MainBrowserWindowControllersManager.shared.getActiveWindowState()
+            guard phiAIEnabled,
+                  let state,
+                  !state.isIncognito,
+                  state.groupOverviewState == nil,
+                  state.focusingTab?.aiChatEnabled == true,
+                  state.focusingTab?.lastFocusTarget == .aiChat else {
+                return false
+            }
+        }
+
         // Toggle Sidebar is unavailable in the traditional layout.
         if item.action == #selector(toggleSidebar(_:)) {
             if PhiPreferences.GeneralSettings.loadLayoutMode().isTraditional {

--- a/Sources/UserInterface/Preferences/Shortcuts/README.md
+++ b/Sources/UserInterface/Preferences/Shortcuts/README.md
@@ -51,6 +51,28 @@
 - Related docs:
   - `docs/mac/about_hotkeys_and_keycodes.md`
 
+## Phi Extension-Bridged Commands
+
+Some `PHI_*` commands act on the Sidecar extension instead of a native target.
+`PHI_NEW_CONVERSATION` (raw value `90004`, default `⇧⌘O`) is one: its logic lives
+in the extension (React), so the native selector only broadcasts a message.
+
+- Defined like any other shortcut: `CommandWrapper` case + `DefaultShortcuts` in
+  `Shortcuts.swift`, plus `Group.view` membership and `presentationOverrides` in
+  `Shortcuts+Custom.swift` (this is what makes it appear/customizable in the
+  Shortcuts settings panel).
+- Wired as a View menu item with selector `newConversation(_:)` in
+  `AppController+Menu.swift`, which calls
+  `ExtensionMessaging.shared.broadcast(type: "newConversation", payload:)`. The
+  payload carries the focused window's chrome window id so only that window's
+  Sidecar reacts.
+- Scoped via `validateUserInterfaceItem(_:)`: enabled only while focus is in the
+  AI sidebar (`focusingTab.lastFocusTarget == .aiChat`, plus the same AI-enabled
+  checks as Toggle Chatbar). When disabled, the key equivalent falls through to
+  its original behavior.
+- The extension side listens on `chrome.phinomenonPrivate.onAppMessage`. See the
+  ai-extension repo `docs/sidecar-new-conversation-shortcut.md`.
+
 ## Notes
 
 - When applying custom shortcuts, do not overwrite original action/target for items such as Preferences; only update `keyEquivalent`.

--- a/Sources/UserInterface/Preferences/Shortcuts/Shortcuts+Custom.swift
+++ b/Sources/UserInterface/Preferences/Shortcuts/Shortcuts+Custom.swift
@@ -71,7 +71,8 @@ extension Shortcuts {
                         .IDC_DEV_TOOLS_INSPECT,
                         .IDC_DEV_TOOLS_CONSOLE,
                         .PHI_TOGGLE_SIDEBAR,
-                        .PHI_TOGGLE_CHATBAR]
+                        .PHI_TOGGLE_CHATBAR,
+                        .PHI_NEW_CONVERSATION]
             case .history:
                 return [.IDC_HOME,
                         .IDC_BACK,
@@ -324,6 +325,7 @@ extension CommandWrapper {
         .PHI_TOGGLE_CHATBAR: .init(title: "Toggle Chatbar", keywords: ["togglechatbar","ai"]),
         .PHI_TAB_SWITCHER_FORWARD: .init(title: "Show Tab Switcher", keywords: ["tab switcher", "forward"]),
         .PHI_TAB_SWITCHER_BACKWARD: .init(title: "Show Tab Switcher(Reverse)", keywords: ["tab switcher", "backward"]),
+        .PHI_NEW_CONVERSATION: .init(title: "New Conversation", keywords: ["new conversation", "new chat", "ai", "chat"]),
         
         .IDS_HIDE_OTHERS_MAC: .init(title: "Hide Others", keywords: []),
         .IDS_CLOSE_ALL_WINDOWS_MAC: .init(title: "Close All", keywords: []),

--- a/Sources/UserInterface/Preferences/Shortcuts/Shortcuts.swift
+++ b/Sources/UserInterface/Preferences/Shortcuts/Shortcuts.swift
@@ -111,6 +111,7 @@ enum CommandWrapper: Int, Equatable {
     case PHI_TOGGLE_CHATBAR          = 90001
     case PHI_TAB_SWITCHER_FORWARD    = 90002
     case PHI_TAB_SWITCHER_BACKWARD   = 90003
+    case PHI_NEW_CONVERSATION        = 90004
     
     // System Preserved
     case IDS_HIDE_OTHERS_MAC         = 110
@@ -217,6 +218,7 @@ extension Shortcuts {
         .PHI_TOGGLE_CHATBAR: .init(characters: "s", modifiers: [.command, .shift]),
         .PHI_TAB_SWITCHER_FORWARD: .init(characters: "\t", modifiers: .control),
         .PHI_TAB_SWITCHER_BACKWARD: .init(characters: "\t", modifiers: [.control, .shift]),
+        .PHI_NEW_CONVERSATION: .init(characters: "o", modifiers: [.command, .shift]),
         
         // System Preserved Shortcuts
         .IDS_HIDE_OTHERS_MAC: .init(characters: "h", modifiers: [.command, .option]),


### PR DESCRIPTION
Add a PHI_NEW_CONVERSATION command (default Shift+Cmd+O) that starts a new AI conversation in the focused window's Sidecar. The action's logic lives in the Sidecar extension, so the native selector broadcasts a "newConversation" message (carrying the focused window's chrome window id) that the extension listens for.

Follows the existing PHI_TOGGLE_SIDEBAR pattern: a View menu item plus selector, registered in Shortcuts.swift / Shortcuts+Custom.swift so the Shortcuts settings panel lists and remaps it automatically, with the menu title localized in Localizable.xcstrings. A validateUserInterfaceItem gate keeps the command effective only while focus is inside the AI sidebar (lastFocusTarget == .aiChat); otherwise the key equivalent falls through to its original behavior.