### PR TITLE
Fix Sentinel shutdown before browser updates

### DIFF
--- a/Sources/Application/AppController+Sparkle.swift
+++ b/Sources/Application/AppController+Sparkle.swift
@@ -64,7 +64,7 @@ extension AppController: SPUUpdaterDelegate {
     }
     
     func updaterShouldRelaunchApplication(_ updater: SPUUpdater) -> Bool {
-        SentinelHelper.terminateAll()
+        SentinelHelper.requestTerminationForBrowserUpdate()
         return true
     }
     

--- a/Sources/Application/SentinelHelper.swift
+++ b/Sources/Application/SentinelHelper.swift
@@ -8,6 +8,35 @@ import Foundation
 import ServiceManagement
 import CocoaLumberjackSwift
 
+struct SentinelBrowserUpdateTerminationRequest: Equatable {
+    static let notificationName = Notification.Name("com.phibrowser.sentinel.prepareForBrowserUpdate")
+    static let reason = "browser_update_install"
+
+    let requestID: String
+    let sentinelBundleID: String
+    let browserBundleID: String
+
+    var userInfo: [String: String] {
+        [
+            "requestID": requestID,
+            "browserBundleID": browserBundleID,
+            "reason": Self.reason
+        ]
+    }
+
+    static func make(
+        sentinelBundleID: String,
+        browserBundleID: String,
+        requestID: String = UUID().uuidString
+    ) -> SentinelBrowserUpdateTerminationRequest {
+        SentinelBrowserUpdateTerminationRequest(
+            requestID: requestID,
+            sentinelBundleID: sentinelBundleID,
+            browserBundleID: browserBundleID
+        )
+    }
+}
+
 enum SentinelHelper {
     struct RunningInfo: Equatable {
         let bundleID: String
@@ -92,6 +121,37 @@ enum SentinelHelper {
             app.terminate()
             AppLogInfo("Sent terminate signal to Sentinel (pid \(app.processIdentifier), bundleID \(app.bundleIdentifier ?? ""))")
         }
+    }
+
+    static func requestTerminationForBrowserUpdate(timeout: TimeInterval = 8) {
+        let identifier = loginItemIdentifier()
+        guard runningApplication(identifier: identifier) != nil else {
+            AppLogInfo("Sentinel is not running; no browser update termination request needed")
+            return
+        }
+
+        let request = SentinelBrowserUpdateTerminationRequest.make(
+            sentinelBundleID: identifier,
+            browserBundleID: Bundle.main.bundleIdentifier ?? ""
+        )
+        DistributedNotificationCenter.default().postNotificationName(
+            SentinelBrowserUpdateTerminationRequest.notificationName,
+            object: request.sentinelBundleID,
+            userInfo: request.userInfo,
+            deliverImmediately: true
+        )
+        AppLogInfo("Requested Sentinel termination for browser update (requestID \(request.requestID), bundleID \(identifier))")
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if runningApplication(identifier: identifier) == nil {
+                AppLogInfo("Sentinel exited before browser update installation (requestID \(request.requestID))")
+                return
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.1))
+        }
+
+        AppLogWarn("Timed out waiting for Sentinel to exit before browser update installation (requestID \(request.requestID))")
     }
 
     private static func loginItemIdentifier() -> String {

--- a/Tests/PhiBrowserTests/SentinelBrowserUpdateTerminationRequestTests.swift
+++ b/Tests/PhiBrowserTests/SentinelBrowserUpdateTerminationRequestTests.swift
@@ -1,0 +1,35 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import XCTest
+@testable import Phi
+
+final class SentinelBrowserUpdateTerminationRequestTests: XCTestCase {
+    func testBuildsStableBrowserUpdateTerminationRequest() {
+        let request = SentinelBrowserUpdateTerminationRequest.make(
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            requestID: "request-1"
+        )
+
+        XCTAssertEqual(SentinelBrowserUpdateTerminationRequest.notificationName.rawValue, "com.phibrowser.sentinel.prepareForBrowserUpdate")
+        XCTAssertEqual(request.sentinelBundleID, "com.phibrowser.Sentinel")
+        XCTAssertEqual(request.userInfo["requestID"], "request-1")
+        XCTAssertEqual(request.userInfo["browserBundleID"], "com.phibrowser.Mac")
+        XCTAssertEqual(request.userInfo["reason"], "browser_update_install")
+    }
+
+    func testBuildsCanaryBrowserUpdateTerminationRequest() {
+        let request = SentinelBrowserUpdateTerminationRequest.make(
+            sentinelBundleID: "com.phibrowser.canary.Sentinel",
+            browserBundleID: "com.phibrowser.canary.Mac",
+            requestID: "request-2"
+        )
+
+        XCTAssertEqual(request.sentinelBundleID, "com.phibrowser.canary.Sentinel")
+        XCTAssertEqual(request.userInfo["browserBundleID"], "com.phibrowser.canary.Mac")
+        XCTAssertEqual(request.userInfo["reason"], "browser_update_install")
+    }
+}


### PR DESCRIPTION
## Summary
- request Sentinel shutdown through the browser-update distributed notification before Sparkle relaunches
- wait briefly for Sentinel to exit before continuing installation
- add tests for stable and canary termination request payloads

## Verification
- xcodebuild build -project Phi.xcodeproj -scheme PhiBrowser -configuration Debug CODE_SIGNING_ALLOWED=NO
- xcodebuild build-for-testing -project Phi.xcodeproj -scheme PhiBrowser -configuration Debug CODE_SIGNING_ALLOWED=NO

Note: the focused XCTest target built, but the host app exited before attaching to the test runner in this local environment.