### PR TITLE
Resolve Sentinel runner IPC socket at fixed /tmp with legacy $TMPDIR fallback

### DIFF
--- a/Sources/Application/SentinelIPCClient.swift
+++ b/Sources/Application/SentinelIPCClient.swift
@@ -41,7 +41,8 @@ final class SentinelIPCClient: Sendable {
 
     /// Resolves the runner IPC socket path.
     /// The socket lives at /tmp/phi-sentinel-<hash>/runner.sock where hash is
-    /// derived from the Sentinel's user-specific storage path.
+    /// derived from the Sentinel's user-specific storage path. Falls back to the
+    /// legacy $TMPDIR-rooted path when only a pre-migration Sentinel is running.
     private func socketPath() -> String? {
         guard let storagePath = sentinelStoragePath() else { return nil }
         return ipcSocketPath(for: storagePath)
@@ -95,13 +96,22 @@ final class SentinelIPCClient: Sendable {
         return result
     }
 
-    /// Mirrors FileSystemUtils.ipcSocketPath from Sentinel.
+    /// Mirrors FileSystemUtils.ipcSocketPath from Sentinel: the current path is
+    /// rooted at a fixed /tmp (keeps the UDS path under the 104-byte limit).
+    /// Falls back to the legacy NSTemporaryDirectory()/$TMPDIR root so a browser
+    /// updated ahead of Sentinel can still reach a pre-migration runner.
     private func ipcSocketPath(for storagePath: String) -> String {
         let data = Data(storagePath.utf8)
         let hash = SHA256.hash(data: data)
         let shortHash = hash.prefix(8).map { String(format: "%02x", $0) }.joined()
-        let socketDir = (NSTemporaryDirectory() as NSString).appendingPathComponent("phi-sentinel-\(shortHash)")
-        return (socketDir as NSString).appendingPathComponent("runner.sock")
+        let dirName = "phi-sentinel-\(shortHash)"
+        let current = (("/tmp" as NSString).appendingPathComponent(dirName) as NSString)
+            .appendingPathComponent("runner.sock")
+        if FileManager.default.fileExists(atPath: current) { return current }
+        let legacy = ((NSTemporaryDirectory() as NSString).appendingPathComponent(dirName) as NSString)
+            .appendingPathComponent("runner.sock")
+        if FileManager.default.fileExists(atPath: legacy) { return legacy }
+        return current
     }
 
     // MARK: - IPC Transport


### PR DESCRIPTION
Sentinel commit 21c261c moved the runner IPC socket dir from `$TMPDIR/phi-sentinel-<hash>/` to a fixed `/tmp/phi-sentinel-<hash>/` (keeps the UDS path under the 104-byte macOS limit). The browser-side `SentinelIPCClient` still derived the old `NSTemporaryDirectory()`-rooted path, so runner IPC (e.g. `getComponentExports`) would stop resolving once Sentinel updates.

`ipcSocketPath(for:)` now resolves the fixed `/tmp` path first and falls back to the legacy `$TMPDIR` path, so a browser updated via OTA ahead of Sentinel can still reach a pre-migration runner (Sentinel only adopts a new build on user-initiated restart, so that skew window can be long).

Verified with a `PhiBrowser-canary` Debug build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)