### PR TITLE
Feature/diffable outlineview

### DIFF
--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		3741AC652F7BBF62009B5E40 /* ivy-presto-headline-light.otf in Copy Fonts */ = {isa = PBXBuildFile; fileRef = 3741AC632F7BBF48009B5E40 /* ivy-presto-headline-light.otf */; };
 		374BCE992F7157FD0043C656 /* TabAreaContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */; };
 		D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */; };
+		D1F600042FD6000000000004 /* DiffableOutlineDiffPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */; };
 		374BD1062F739D5F0043C656 /* NativeTabDecisionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374BD1052F739D5F0043C656 /* NativeTabDecisionEngine.swift */; };
 		3756AB282F31ABA300FFA686 /* WebContentAddressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756AB272F31ABA300FFA686 /* WebContentAddressBar.swift */; };
 		3758B1E52F962BA50036F2AF /* AuthManager+Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3758B1E42F962BA50036F2AF /* AuthManager+Provider.swift */; };
@@ -514,6 +515,7 @@
 		3741AC632F7BBF48009B5E40 /* ivy-presto-headline-light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ivy-presto-headline-light.otf"; sourceTree = "<group>"; };
 		374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabAreaContextMenuHelper.swift; sourceTree = "<group>"; };
 		D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineSnapshot.swift; sourceTree = "<group>"; };
+		D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineDiffPlanner.swift; sourceTree = "<group>"; };
 		374BD1052F739D5F0043C656 /* NativeTabDecisionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTabDecisionEngine.swift; sourceTree = "<group>"; };
 		3756AB272F31ABA300FFA686 /* WebContentAddressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentAddressBar.swift; sourceTree = "<group>"; };
 		3758B1E42F962BA50036F2AF /* AuthManager+Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthManager+Provider.swift"; sourceTree = "<group>"; };
@@ -1953,6 +1955,7 @@
 				8EF36C022F4E9E7000FCC91E /* Tabs */,
 				374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */,
 				D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */,
+				D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */,
 				37B9780F2EF403AB007E0568 /* GradientBorderButton.swift */,
 				B0F370D92E433F0E000B51F9 /* OverlayWindowController.swift */,
 				B0F370C82E43242F000B51F9 /* PhiSplitView.swift */,
@@ -2315,6 +2318,7 @@
 				CC9AF3442EC192BC00C27C98 /* AppControlle+LaunchInfo.swift in Sources */,
 				CCBF8F622E65719600B9A99E /* SideBarOutlineView.swift in Sources */,
 				D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */,
+				D1F600042FD6000000000004 /* DiffableOutlineDiffPlanner.swift in Sources */,
 				CCEB64CB2E98DD520036C763 /* InsetTableRowView.swift in Sources */,
 				37C1B1E42EDEA03400DD4496 /* FeedbackView.swift in Sources */,
 				FBD200012FD0000000000001 /* FeedbackOutbox.swift in Sources */,

--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		373D84052F9D500100000001 /* AuthManager+Reauthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373D84042F9D500100000001 /* AuthManager+Reauthentication.swift */; };
 		3741AC652F7BBF62009B5E40 /* ivy-presto-headline-light.otf in Copy Fonts */ = {isa = PBXBuildFile; fileRef = 3741AC632F7BBF48009B5E40 /* ivy-presto-headline-light.otf */; };
 		374BCE992F7157FD0043C656 /* TabAreaContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */; };
+		D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */; };
 		374BD1062F739D5F0043C656 /* NativeTabDecisionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374BD1052F739D5F0043C656 /* NativeTabDecisionEngine.swift */; };
 		3756AB282F31ABA300FFA686 /* WebContentAddressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756AB272F31ABA300FFA686 /* WebContentAddressBar.swift */; };
 		3758B1E52F962BA50036F2AF /* AuthManager+Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3758B1E42F962BA50036F2AF /* AuthManager+Provider.swift */; };
@@ -512,6 +513,7 @@
 		3741A9DE2F7B8158009B5E40 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3741AC632F7BBF48009B5E40 /* ivy-presto-headline-light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ivy-presto-headline-light.otf"; sourceTree = "<group>"; };
 		374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabAreaContextMenuHelper.swift; sourceTree = "<group>"; };
+		D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineSnapshot.swift; sourceTree = "<group>"; };
 		374BD1052F739D5F0043C656 /* NativeTabDecisionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTabDecisionEngine.swift; sourceTree = "<group>"; };
 		3756AB272F31ABA300FFA686 /* WebContentAddressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentAddressBar.swift; sourceTree = "<group>"; };
 		3758B1E42F962BA50036F2AF /* AuthManager+Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthManager+Provider.swift"; sourceTree = "<group>"; };
@@ -1950,6 +1952,7 @@
 				CD1100050000000000000001 /* IconPicker */,
 				8EF36C022F4E9E7000FCC91E /* Tabs */,
 				374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */,
+				D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */,
 				37B9780F2EF403AB007E0568 /* GradientBorderButton.swift */,
 				B0F370D92E433F0E000B51F9 /* OverlayWindowController.swift */,
 				B0F370C82E43242F000B51F9 /* PhiSplitView.swift */,
@@ -2311,6 +2314,7 @@
 				37E6AF402EEC30E80078CCD8 /* ChatButton.swift in Sources */,
 				CC9AF3442EC192BC00C27C98 /* AppControlle+LaunchInfo.swift in Sources */,
 				CCBF8F622E65719600B9A99E /* SideBarOutlineView.swift in Sources */,
+				D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */,
 				CCEB64CB2E98DD520036C763 /* InsetTableRowView.swift in Sources */,
 				37C1B1E42EDEA03400DD4496 /* FeedbackView.swift in Sources */,
 				FBD200012FD0000000000001 /* FeedbackOutbox.swift in Sources */,

--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		374BCE992F7157FD0043C656 /* TabAreaContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */; };
 		D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */; };
 		D1F600042FD6000000000004 /* DiffableOutlineDiffPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */; };
+		D1F600062FD6000000000006 /* DiffableOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600052FD6000000000005 /* DiffableOutlineView.swift */; };
 		374BD1062F739D5F0043C656 /* NativeTabDecisionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374BD1052F739D5F0043C656 /* NativeTabDecisionEngine.swift */; };
 		3756AB282F31ABA300FFA686 /* WebContentAddressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756AB272F31ABA300FFA686 /* WebContentAddressBar.swift */; };
 		3758B1E52F962BA50036F2AF /* AuthManager+Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3758B1E42F962BA50036F2AF /* AuthManager+Provider.swift */; };
@@ -516,6 +517,7 @@
 		374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabAreaContextMenuHelper.swift; sourceTree = "<group>"; };
 		D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineSnapshot.swift; sourceTree = "<group>"; };
 		D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineDiffPlanner.swift; sourceTree = "<group>"; };
+		D1F600052FD6000000000005 /* DiffableOutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineView.swift; sourceTree = "<group>"; };
 		374BD1052F739D5F0043C656 /* NativeTabDecisionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTabDecisionEngine.swift; sourceTree = "<group>"; };
 		3756AB272F31ABA300FFA686 /* WebContentAddressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentAddressBar.swift; sourceTree = "<group>"; };
 		3758B1E42F962BA50036F2AF /* AuthManager+Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthManager+Provider.swift"; sourceTree = "<group>"; };
@@ -1956,6 +1958,7 @@
 				374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */,
 				D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */,
 				D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */,
+				D1F600052FD6000000000005 /* DiffableOutlineView.swift */,
 				37B9780F2EF403AB007E0568 /* GradientBorderButton.swift */,
 				B0F370D92E433F0E000B51F9 /* OverlayWindowController.swift */,
 				B0F370C82E43242F000B51F9 /* PhiSplitView.swift */,
@@ -2319,6 +2322,7 @@
 				CCBF8F622E65719600B9A99E /* SideBarOutlineView.swift in Sources */,
 				D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */,
 				D1F600042FD6000000000004 /* DiffableOutlineDiffPlanner.swift in Sources */,
+				D1F600062FD6000000000006 /* DiffableOutlineView.swift in Sources */,
 				CCEB64CB2E98DD520036C763 /* InsetTableRowView.swift in Sources */,
 				37C1B1E42EDEA03400DD4496 /* FeedbackView.swift in Sources */,
 				FBD200012FD0000000000001 /* FeedbackOutbox.swift in Sources */,

--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -1706,6 +1706,7 @@
 				C0D1D0012FEA000000000001 /* SidebarTabListViewController+MultiSelectionDragPreview.swift */,
 				CCBF8F492E6543E800B9A99E /* BookmarkSectionController.swift */,
 				CCBF8F432E653F3400B9A99E /* SidebarItem.swift */,
+				D1F600072FD6000000000007 /* SidebarDiffableSnapshotBuilder.swift */,
 				CCBF8F6A2E66A2C300B9A99E /* Views */,
 			);
 			path = TabList;

--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -34,9 +34,6 @@
 		373D84052F9D500100000001 /* AuthManager+Reauthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373D84042F9D500100000001 /* AuthManager+Reauthentication.swift */; };
 		3741AC652F7BBF62009B5E40 /* ivy-presto-headline-light.otf in Copy Fonts */ = {isa = PBXBuildFile; fileRef = 3741AC632F7BBF48009B5E40 /* ivy-presto-headline-light.otf */; };
 		374BCE992F7157FD0043C656 /* TabAreaContextMenuHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */; };
-		D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */; };
-		D1F600042FD6000000000004 /* DiffableOutlineDiffPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */; };
-		D1F600062FD6000000000006 /* DiffableOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600052FD6000000000005 /* DiffableOutlineView.swift */; };
 		374BD1062F739D5F0043C656 /* NativeTabDecisionEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374BD1052F739D5F0043C656 /* NativeTabDecisionEngine.swift */; };
 		3756AB282F31ABA300FFA686 /* WebContentAddressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3756AB272F31ABA300FFA686 /* WebContentAddressBar.swift */; };
 		3758B1E52F962BA50036F2AF /* AuthManager+Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3758B1E42F962BA50036F2AF /* AuthManager+Provider.swift */; };
@@ -405,6 +402,10 @@
 		D10000000000000000000007 /* ImagePreviewOverlayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000017 /* ImagePreviewOverlayViewController.swift */; };
 		D10000000000000000000008 /* ExtensionDialogManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000031 /* ExtensionDialogManager.swift */; };
 		D10000000000000000000009 /* ExtensionDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000000032 /* ExtensionDialogViewController.swift */; };
+		D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */; };
+		D1F600042FD6000000000004 /* DiffableOutlineDiffPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */; };
+		D1F600062FD6000000000006 /* DiffableOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600052FD6000000000005 /* DiffableOutlineView.swift */; };
+		D1F600082FD6000000000008 /* SidebarDiffableSnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600072FD6000000000007 /* SidebarDiffableSnapshotBuilder.swift */; };
 		FBD200012FD0000000000001 /* FeedbackOutbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD200012FD0000000000002 /* FeedbackOutbox.swift */; };
 		FBD200012FD0000000000003 /* FeedbackV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD200012FD0000000000004 /* FeedbackV2.swift */; };
 /* End PBXBuildFile section */
@@ -515,9 +516,6 @@
 		3741A9DE2F7B8158009B5E40 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		3741AC632F7BBF48009B5E40 /* ivy-presto-headline-light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ivy-presto-headline-light.otf"; sourceTree = "<group>"; };
 		374BCE982F7157FD0043C656 /* TabAreaContextMenuHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabAreaContextMenuHelper.swift; sourceTree = "<group>"; };
-		D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineSnapshot.swift; sourceTree = "<group>"; };
-		D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineDiffPlanner.swift; sourceTree = "<group>"; };
-		D1F600052FD6000000000005 /* DiffableOutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineView.swift; sourceTree = "<group>"; };
 		374BD1052F739D5F0043C656 /* NativeTabDecisionEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeTabDecisionEngine.swift; sourceTree = "<group>"; };
 		3756AB272F31ABA300FFA686 /* WebContentAddressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentAddressBar.swift; sourceTree = "<group>"; };
 		3758B1E42F962BA50036F2AF /* AuthManager+Provider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AuthManager+Provider.swift"; sourceTree = "<group>"; };
@@ -901,6 +899,10 @@
 		D10000000000000000000031 /* ExtensionDialogManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDialogManager.swift; sourceTree = "<group>"; };
 		D10000000000000000000032 /* ExtensionDialogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDialogViewController.swift; sourceTree = "<group>"; };
 		D1B584F695BF7833FAA99558 /* AISettingHostingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingHostingViewController.swift; sourceTree = "<group>"; };
+		D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineSnapshot.swift; sourceTree = "<group>"; };
+		D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineDiffPlanner.swift; sourceTree = "<group>"; };
+		D1F600052FD6000000000005 /* DiffableOutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineView.swift; sourceTree = "<group>"; };
+		D1F600072FD6000000000007 /* SidebarDiffableSnapshotBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarDiffableSnapshotBuilder.swift; sourceTree = "<group>"; };
 		D8FCAEAE328C802016D87943 /* AISettingsConnectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AISettingsConnectorViewModel.swift; sourceTree = "<group>"; };
 		E10000000000000000000001 /* PhiBrowser-OpenSource.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "PhiBrowser-OpenSource.entitlements"; sourceTree = "<group>"; };
 		FBD200012FD0000000000002 /* FeedbackOutbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackOutbox.swift; sourceTree = "<group>"; };
@@ -2324,6 +2326,7 @@
 				D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */,
 				D1F600042FD6000000000004 /* DiffableOutlineDiffPlanner.swift in Sources */,
 				D1F600062FD6000000000006 /* DiffableOutlineView.swift in Sources */,
+				D1F600082FD6000000000008 /* SidebarDiffableSnapshotBuilder.swift in Sources */,
 				CCEB64CB2E98DD520036C763 /* InsetTableRowView.swift in Sources */,
 				37C1B1E42EDEA03400DD4496 /* FeedbackView.swift in Sources */,
 				FBD200012FD0000000000001 /* FeedbackOutbox.swift in Sources */,

--- a/Phi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Phi.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1d351b9042a7ce6759b76e81445d51bb99745f846d3c8e2626504655cb213f7b",
+  "originHash" : "67916fbadf309c976509a1e71be2d9dc5642ee4a5c114000c709d47d44550bab",
   "pins" : [
     {
       "identity" : "alamofire",

--- a/Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift
@@ -1,0 +1,136 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+
+enum DiffableOutlineOperation<ItemID: Hashable>: Equatable {
+    case remove(id: ItemID, parentID: ItemID?, index: Int)
+    case move(id: ItemID, parentID: ItemID?, from: Int, to: Int)
+    case insert(id: ItemID, parentID: ItemID?, index: Int)
+    case replace(id: ItemID, parentID: ItemID?, index: Int)
+    case reload(id: ItemID)
+}
+
+struct DiffableOutlinePlan<ItemID: Hashable> {
+    let operations: [DiffableOutlineOperation<ItemID>]
+    let isSafe: Bool
+
+    static var unsafe: DiffableOutlinePlan<ItemID> {
+        DiffableOutlinePlan(operations: [], isSafe: false)
+    }
+}
+
+enum DiffableOutlineDiffPlanner {
+    static func plan<ItemID: Hashable>(
+        from old: DiffableOutlineSnapshot<ItemID>,
+        to new: DiffableOutlineSnapshot<ItemID>
+    ) -> DiffableOutlinePlan<ItemID> {
+        guard old.validationError == nil, new.validationError == nil else {
+            return .unsafe
+        }
+
+        let oldIDs = Set(old.nodes.keys)
+        let newIDs = Set(new.nodes.keys)
+        let removedIDs = oldIDs.subtracting(newIDs)
+        let insertedIDs = newIDs.subtracting(oldIDs)
+
+        let highestRemoved = Set(removedIDs.filter { !old.hasAncestor(of: $0, in: removedIDs) })
+        let highestInserted = Set(insertedIDs.filter { !new.hasAncestor(of: $0, in: insertedIDs) })
+        let structuralChanges = structuralOperations(
+            old: old,
+            new: new,
+            highestRemoved: highestRemoved,
+            highestInserted: highestInserted
+        )
+
+        return DiffableOutlinePlan(operations: structuralChanges, isSafe: true)
+    }
+
+    private static func structuralOperations<ItemID: Hashable>(
+        old: DiffableOutlineSnapshot<ItemID>,
+        new: DiffableOutlineSnapshot<ItemID>,
+        highestRemoved: Set<ItemID>,
+        highestInserted: Set<ItemID>
+    ) -> [DiffableOutlineOperation<ItemID>] {
+        var removes: [DiffableOutlineOperation<ItemID>] = []
+        var inserts: [DiffableOutlineOperation<ItemID>] = []
+
+        for parentID in parentIDsForSiblingDiff(old: old, new: new) {
+            let oldChildren = old.childIDs(of: parentID)
+            let newChildren = new.childIDs(of: parentID)
+            guard oldChildren != newChildren else { continue }
+
+            let difference = newChildren.difference(from: oldChildren)
+            for change in difference {
+                switch change {
+                case .remove(let offset, let id, _):
+                    guard highestRemoved.contains(id) else { continue }
+                    removes.append(.remove(id: id, parentID: parentID, index: offset))
+                case .insert(let offset, let id, _):
+                    guard highestInserted.contains(id) else { continue }
+                    inserts.append(.insert(id: id, parentID: parentID, index: offset))
+                }
+            }
+        }
+
+        return sortedRemoves(removes, in: old) + sortedInserts(inserts, in: new)
+    }
+
+    private static func parentIDsForSiblingDiff<ItemID: Hashable>(
+        old: DiffableOutlineSnapshot<ItemID>,
+        new: DiffableOutlineSnapshot<ItemID>
+    ) -> [ItemID?] {
+        let parentIDs = Set([nil] + old.nodes.keys.map(Optional.some) + new.nodes.keys.map(Optional.some))
+        return parentIDs.sorted { lhs, rhs in
+            String(describing: lhs) < String(describing: rhs)
+        }
+    }
+
+    private static func sortedRemoves<ItemID: Hashable>(
+        _ operations: [DiffableOutlineOperation<ItemID>],
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> [DiffableOutlineOperation<ItemID>] {
+        operations.sorted { lhs, rhs in
+            let left = removeSortKey(lhs, in: snapshot)
+            let right = removeSortKey(rhs, in: snapshot)
+            if left.depth != right.depth { return left.depth > right.depth }
+            if left.parent != right.parent { return left.parent < right.parent }
+            return left.index > right.index
+        }
+    }
+
+    private static func sortedInserts<ItemID: Hashable>(
+        _ operations: [DiffableOutlineOperation<ItemID>],
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> [DiffableOutlineOperation<ItemID>] {
+        operations.sorted { lhs, rhs in
+            let left = insertSortKey(lhs, in: snapshot)
+            let right = insertSortKey(rhs, in: snapshot)
+            if left.depth != right.depth { return left.depth < right.depth }
+            if left.parent != right.parent { return left.parent < right.parent }
+            return left.index < right.index
+        }
+    }
+
+    private static func removeSortKey<ItemID: Hashable>(
+        _ operation: DiffableOutlineOperation<ItemID>,
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> (depth: Int, parent: String, index: Int) {
+        guard case .remove(let id, let parentID, let index) = operation else {
+            return (0, "", 0)
+        }
+        return (snapshot.depth(of: id), String(describing: parentID), index)
+    }
+
+    private static func insertSortKey<ItemID: Hashable>(
+        _ operation: DiffableOutlineOperation<ItemID>,
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> (depth: Int, parent: String, index: Int) {
+        guard case .insert(let id, let parentID, let index) = operation else {
+            return (0, "", 0)
+        }
+        return (snapshot.depth(of: id), String(describing: parentID), index)
+    }
+}

--- a/Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift
@@ -35,17 +35,29 @@ enum DiffableOutlineDiffPlanner {
         let newIDs = Set(new.nodes.keys)
         let removedIDs = oldIDs.subtracting(newIDs)
         let insertedIDs = newIDs.subtracting(oldIDs)
+        let commonIDs = oldIDs.intersection(newIDs)
+        let crossParentMovedIDs = Set(commonIDs.filter { old.parentID(of: $0) != new.parentID(of: $0) })
 
-        let highestRemoved = Set(removedIDs.filter { !old.hasAncestor(of: $0, in: removedIDs) })
-        let highestInserted = Set(insertedIDs.filter { !new.hasAncestor(of: $0, in: insertedIDs) })
+        let structuralRemovedIDs = removedIDs.union(crossParentMovedIDs)
+        let structuralInsertedIDs = insertedIDs.union(crossParentMovedIDs)
+        let highestRemoved = Set(structuralRemovedIDs.filter { !old.hasAncestor(of: $0, in: structuralRemovedIDs) })
+        let highestInserted = Set(structuralInsertedIDs.filter { !new.hasAncestor(of: $0, in: structuralInsertedIDs) })
+        let structuralCoveredIDs = coveredIDs(highestRemoved, in: old)
+            .union(coveredIDs(highestInserted, in: new))
         let structuralChanges = structuralOperations(
             old: old,
             new: new,
             highestRemoved: highestRemoved,
             highestInserted: highestInserted
         )
+        let moves = sameParentMoves(old: old, new: new, excludedIDs: structuralCoveredIDs)
+        let replacements = replacements(old: old, new: new, excludedIDs: structuralCoveredIDs)
+        let reloads = reloads(in: new)
 
-        return DiffableOutlinePlan(operations: structuralChanges, isSafe: true)
+        return DiffableOutlinePlan(
+            operations: structuralChanges.removes + moves + structuralChanges.inserts + replacements + reloads,
+            isSafe: true
+        )
     }
 
     private static func structuralOperations<ItemID: Hashable>(
@@ -53,7 +65,7 @@ enum DiffableOutlineDiffPlanner {
         new: DiffableOutlineSnapshot<ItemID>,
         highestRemoved: Set<ItemID>,
         highestInserted: Set<ItemID>
-    ) -> [DiffableOutlineOperation<ItemID>] {
+    ) -> DiffableOutlineStructuralOperations<ItemID> {
         var removes: [DiffableOutlineOperation<ItemID>] = []
         var inserts: [DiffableOutlineOperation<ItemID>] = []
 
@@ -75,7 +87,92 @@ enum DiffableOutlineDiffPlanner {
             }
         }
 
-        return sortedRemoves(removes, in: old) + sortedInserts(inserts, in: new)
+        return DiffableOutlineStructuralOperations(
+            removes: sortedRemoves(removes, in: old),
+            inserts: sortedInserts(inserts, in: new)
+        )
+    }
+
+    private static func sameParentMoves<ItemID: Hashable>(
+        old: DiffableOutlineSnapshot<ItemID>,
+        new: DiffableOutlineSnapshot<ItemID>,
+        excludedIDs: Set<ItemID>
+    ) -> [DiffableOutlineOperation<ItemID>] {
+        var operations: [DiffableOutlineOperation<ItemID>] = []
+
+        for parentID in parentIDsForSiblingDiff(old: old, new: new) {
+            let oldChildren = old.childIDs(of: parentID).filter {
+                !excludedIDs.contains($0) && new.parentID(of: $0) == parentID
+            }
+            let newChildren = new.childIDs(of: parentID).filter {
+                !excludedIDs.contains($0) && old.parentID(of: $0) == parentID
+            }
+            guard oldChildren != newChildren else { continue }
+
+            let difference = newChildren.difference(from: oldChildren).inferringMoves()
+            guard difference.containsAssociatedMove else { continue }
+
+            var working = oldChildren
+            for targetIndex in newChildren.indices {
+                let targetID = newChildren[targetIndex]
+                guard working.indices.contains(targetIndex), working[targetIndex] != targetID else {
+                    continue
+                }
+                guard let fromIndex = working.firstIndex(of: targetID) else { continue }
+
+                working.remove(at: fromIndex)
+                working.insert(targetID, at: targetIndex)
+                operations.append(.move(id: targetID, parentID: parentID, from: fromIndex, to: targetIndex))
+            }
+        }
+
+        return operations
+    }
+
+    private static func replacements<ItemID: Hashable>(
+        old: DiffableOutlineSnapshot<ItemID>,
+        new: DiffableOutlineSnapshot<ItemID>,
+        excludedIDs: Set<ItemID>
+    ) -> [DiffableOutlineOperation<ItemID>] {
+        let replacedIDs = Set(old.nodes.keys).intersection(new.nodes.keys).filter { id in
+            guard !excludedIDs.contains(id) else { return false }
+            guard let oldItem = old.item(for: id), let newItem = new.item(for: id) else { return false }
+            return oldItem !== newItem
+        }
+        let highestReplaced = replacedIDs.filter { !new.hasAncestor(of: $0, in: replacedIDs) }
+
+        return highestReplaced
+            .compactMap { id -> DiffableOutlineOperation<ItemID>? in
+                guard let index = new.index(of: id) else { return nil }
+                return .replace(id: id, parentID: new.parentID(of: id), index: index)
+            }
+            .sorted { lhs, rhs in
+                let left = replacementSortKey(lhs, in: new)
+                let right = replacementSortKey(rhs, in: new)
+                if left.depth != right.depth { return left.depth < right.depth }
+                if left.parent != right.parent { return left.parent < right.parent }
+                return left.index < right.index
+            }
+    }
+
+    private static func reloads<ItemID: Hashable>(
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> [DiffableOutlineOperation<ItemID>] {
+        snapshot.reloadIDs
+            .filter { snapshot.contains($0) }
+            .sorted { String(describing: $0) < String(describing: $1) }
+            .map { DiffableOutlineOperation.reload(id: $0) }
+    }
+
+    private static func coveredIDs<ItemID: Hashable>(
+        _ ids: Set<ItemID>,
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> Set<ItemID> {
+        var result = ids
+        for id in ids {
+            result.formUnion(snapshot.descendants(of: id))
+        }
+        return result
     }
 
     private static func parentIDsForSiblingDiff<ItemID: Hashable>(
@@ -132,5 +229,31 @@ enum DiffableOutlineDiffPlanner {
             return (0, "", 0)
         }
         return (snapshot.depth(of: id), String(describing: parentID), index)
+    }
+
+    private static func replacementSortKey<ItemID: Hashable>(
+        _ operation: DiffableOutlineOperation<ItemID>,
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> (depth: Int, parent: String, index: Int) {
+        guard case .replace(let id, let parentID, let index) = operation else {
+            return (0, "", 0)
+        }
+        return (snapshot.depth(of: id), String(describing: parentID), index)
+    }
+}
+
+private struct DiffableOutlineStructuralOperations<ItemID: Hashable> {
+    let removes: [DiffableOutlineOperation<ItemID>]
+    let inserts: [DiffableOutlineOperation<ItemID>]
+}
+
+private extension CollectionDifference {
+    var containsAssociatedMove: Bool {
+        contains { change in
+            switch change {
+            case .insert(_, _, let associatedWith), .remove(_, _, let associatedWith):
+                return associatedWith != nil
+            }
+        }
     }
 }

--- a/Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift
@@ -40,8 +40,22 @@ enum DiffableOutlineDiffPlanner {
 
         let structuralRemovedIDs = removedIDs.union(crossParentMovedIDs)
         let structuralInsertedIDs = insertedIDs.union(crossParentMovedIDs)
-        let highestRemoved = Set(structuralRemovedIDs.filter { !old.hasAncestor(of: $0, in: structuralRemovedIDs) })
-        let highestInserted = Set(structuralInsertedIDs.filter { !new.hasAncestor(of: $0, in: structuralInsertedIDs) })
+        let initialHighestRemoved = Set(structuralRemovedIDs.filter { !old.hasAncestor(of: $0, in: structuralRemovedIDs) })
+        let initialHighestInserted = Set(structuralInsertedIDs.filter { !new.hasAncestor(of: $0, in: structuralInsertedIDs) })
+        let initialStructuralCoveredIDs = coveredIDs(initialHighestRemoved, in: old)
+            .union(coveredIDs(initialHighestInserted, in: new))
+        let highestReplaced = highestReplacementIDs(
+            replacementIDs(old: old, new: new, excludedIDs: initialStructuralCoveredIDs),
+            in: new
+        )
+        let replacementCoveredOldIDs = coveredIDs(highestReplaced, in: old)
+        let replacementCoveredNewIDs = coveredIDs(highestReplaced, in: new)
+        let highestRemoved = Set(initialHighestRemoved.filter { id in
+            crossParentMovedIDs.contains(id) || !replacementCoveredOldIDs.contains(id)
+        })
+        let highestInserted = Set(initialHighestInserted.filter { id in
+            !replacementCoveredNewIDs.contains(id)
+        })
         let structuralCoveredIDs = coveredIDs(highestRemoved, in: old)
             .union(coveredIDs(highestInserted, in: new))
         let structuralChanges = structuralOperations(
@@ -50,8 +64,11 @@ enum DiffableOutlineDiffPlanner {
             highestRemoved: highestRemoved,
             highestInserted: highestInserted
         )
-        let moves = sameParentMoves(old: old, new: new, excludedIDs: structuralCoveredIDs)
-        let replacements = replacements(old: old, new: new, excludedIDs: structuralCoveredIDs)
+        let moveExcludedIDs = structuralCoveredIDs
+            .union(replacementCoveredOldIDs)
+            .union(replacementCoveredNewIDs)
+        let moves = sameParentMoves(old: old, new: new, excludedIDs: moveExcludedIDs)
+        let replacements = replacementOperations(highestReplaced, in: new)
         let reloads = reloads(in: new)
 
         return DiffableOutlinePlan(
@@ -129,26 +146,37 @@ enum DiffableOutlineDiffPlanner {
         return operations
     }
 
-    private static func replacements<ItemID: Hashable>(
+    private static func replacementIDs<ItemID: Hashable>(
         old: DiffableOutlineSnapshot<ItemID>,
         new: DiffableOutlineSnapshot<ItemID>,
         excludedIDs: Set<ItemID>
-    ) -> [DiffableOutlineOperation<ItemID>] {
-        let replacedIDs = Set(old.nodes.keys).intersection(new.nodes.keys).filter { id in
+    ) -> Set<ItemID> {
+        Set(old.nodes.keys).intersection(new.nodes.keys).filter { id in
             guard !excludedIDs.contains(id) else { return false }
             guard let oldItem = old.item(for: id), let newItem = new.item(for: id) else { return false }
             return oldItem !== newItem
         }
-        let highestReplaced = replacedIDs.filter { !new.hasAncestor(of: $0, in: replacedIDs) }
+    }
 
+    private static func highestReplacementIDs<ItemID: Hashable>(
+        _ replacedIDs: Set<ItemID>,
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> Set<ItemID> {
+        Set(replacedIDs.filter { !snapshot.hasAncestor(of: $0, in: replacedIDs) })
+    }
+
+    private static func replacementOperations<ItemID: Hashable>(
+        _ highestReplaced: Set<ItemID>,
+        in snapshot: DiffableOutlineSnapshot<ItemID>
+    ) -> [DiffableOutlineOperation<ItemID>] {
         return highestReplaced
             .compactMap { id -> DiffableOutlineOperation<ItemID>? in
-                guard let index = new.index(of: id) else { return nil }
-                return .replace(id: id, parentID: new.parentID(of: id), index: index)
+                guard let index = snapshot.index(of: id) else { return nil }
+                return .replace(id: id, parentID: snapshot.parentID(of: id), index: index)
             }
             .sorted { lhs, rhs in
-                let left = replacementSortKey(lhs, in: new)
-                let right = replacementSortKey(rhs, in: new)
+                let left = replacementSortKey(lhs, in: snapshot)
+                let right = replacementSortKey(rhs, in: snapshot)
                 if left.depth != right.depth { return left.depth < right.depth }
                 if left.parent != right.parent { return left.parent < right.parent }
                 return left.index < right.index

--- a/Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift
@@ -68,6 +68,18 @@ enum DiffableOutlineDiffPlanner {
             .union(replacementCoveredOldIDs)
             .union(replacementCoveredNewIDs)
         let moves = sameParentMoves(old: old, new: new, excludedIDs: moveExcludedIDs)
+        let replacementSiblingParentIDs = replacementSiblingParentIDs(
+            old: old,
+            new: new,
+            replacementCoveredOldIDs: replacementCoveredOldIDs,
+            replacementCoveredNewIDs: replacementCoveredNewIDs
+        )
+        if moves.contains(where: { operation in
+            guard case .move(_, let parentID, _, _) = operation else { return false }
+            return replacementSiblingParentIDs.contains(parentID)
+        }) {
+            return .unsafe
+        }
         let replacements = replacementOperations(highestReplaced, in: new)
         let reloads = reloads(in: new)
 
@@ -144,6 +156,29 @@ enum DiffableOutlineDiffPlanner {
         }
 
         return operations
+    }
+
+    private static func replacementSiblingParentIDs<ItemID: Hashable>(
+        old: DiffableOutlineSnapshot<ItemID>,
+        new: DiffableOutlineSnapshot<ItemID>,
+        replacementCoveredOldIDs: Set<ItemID>,
+        replacementCoveredNewIDs: Set<ItemID>
+    ) -> Set<ItemID?> {
+        var parentIDs = Set<ItemID?>()
+
+        for parentID in parentIDsForSiblingDiff(old: old, new: new) {
+            let oldContainsReplacement = old.childIDs(of: parentID).contains {
+                replacementCoveredOldIDs.contains($0)
+            }
+            let newContainsReplacement = new.childIDs(of: parentID).contains {
+                replacementCoveredNewIDs.contains($0)
+            }
+            if oldContainsReplacement || newContainsReplacement {
+                parentIDs.insert(parentID)
+            }
+        }
+
+        return parentIDs
     }
 
     private static func replacementIDs<ItemID: Hashable>(

--- a/Sources/UserInterface/Common/DiffableOutlineSnapshot.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineSnapshot.swift
@@ -1,0 +1,168 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+
+struct DiffableOutlineSnapshot<ItemID: Hashable> {
+    struct Node {
+        let id: ItemID
+        let item: AnyObject
+        let parentID: ItemID?
+        let childIDs: [ItemID]
+    }
+
+    let rootIDs: [ItemID]
+    let nodes: [ItemID: Node]
+    let reloadIDs: Set<ItemID>
+
+    init(rootIDs: [ItemID], nodes: [ItemID: Node], reloadIDs: Set<ItemID> = []) {
+        self.rootIDs = rootIDs
+        self.nodes = nodes
+        self.reloadIDs = reloadIDs
+    }
+
+    var validationError: DiffableOutlineSnapshotValidationError<ItemID>? {
+        validate()
+    }
+
+    func item(for id: ItemID) -> AnyObject? {
+        nodes[id]?.item
+    }
+
+    func parentID(of id: ItemID) -> ItemID? {
+        nodes[id]?.parentID
+    }
+
+    func childIDs(of parentID: ItemID?) -> [ItemID] {
+        guard let parentID else { return rootIDs }
+        return nodes[parentID]?.childIDs ?? []
+    }
+
+    func index(of id: ItemID) -> Int? {
+        childIDs(of: parentID(of: id)).firstIndex(of: id)
+    }
+
+    func contains(_ id: ItemID) -> Bool {
+        nodes[id] != nil
+    }
+
+    func depth(of id: ItemID) -> Int {
+        var depth = 0
+        var current = parentID(of: id)
+        while let parent = current {
+            depth += 1
+            current = parentID(of: parent)
+        }
+        return depth
+    }
+
+    func descendants(of id: ItemID) -> [ItemID] {
+        var result: [ItemID] = []
+
+        func walk(_ current: ItemID) {
+            for child in childIDs(of: current) {
+                result.append(child)
+                walk(child)
+            }
+        }
+
+        walk(id)
+        return result
+    }
+
+    func hasAncestor(of id: ItemID, in ids: Set<ItemID>) -> Bool {
+        var current = parentID(of: id)
+        while let parent = current {
+            if ids.contains(parent) { return true }
+            current = parentID(of: parent)
+        }
+        return false
+    }
+
+    private func validate() -> DiffableOutlineSnapshotValidationError<ItemID>? {
+        var referencedIDs = Set<ItemID>()
+
+        for rootID in rootIDs {
+            guard nodes[rootID] != nil else { return .missingRoot(rootID) }
+            if !referencedIDs.insert(rootID).inserted { return .duplicateChildID(rootID) }
+            if nodes[rootID]?.parentID != nil { return .rootHasParent(rootID) }
+        }
+
+        for id in orderedNodeIDs {
+            guard let node = nodes[id] else { continue }
+            guard node.id == id else { return .nodeKeyMismatch(key: id, nodeID: node.id) }
+
+            if let parentID = node.parentID, nodes[parentID] == nil {
+                return .missingParent(id: id, parentID: parentID)
+            }
+
+            for childID in node.childIDs {
+                guard let child = nodes[childID] else {
+                    return .missingChild(id: id, childID: childID)
+                }
+
+                if child.parentID != id {
+                    return .parentMismatch(
+                        id: childID,
+                        expectedParentID: id,
+                        actualParentID: child.parentID
+                    )
+                }
+
+                if !referencedIDs.insert(childID).inserted {
+                    return .duplicateChildID(childID)
+                }
+            }
+        }
+
+        for id in orderedNodeIDs where !referencedIDs.contains(id) {
+            if detectsCycle(startingAt: id) { return .cycleDetected(id) }
+            if nodes[id]?.parentID == nil { return .unreachableNode(id) }
+        }
+
+        for id in orderedNodeIDs where detectsCycle(startingAt: id) {
+            return .cycleDetected(id)
+        }
+
+        if let missingReloadID = reloadIDs.sortedForStableDiagnostics().first(where: { nodes[$0] == nil }) {
+            return .missingReloadID(missingReloadID)
+        }
+
+        return nil
+    }
+
+    private var orderedNodeIDs: [ItemID] {
+        nodes.keys.sortedForStableDiagnostics()
+    }
+
+    private func detectsCycle(startingAt id: ItemID) -> Bool {
+        var seen = Set<ItemID>()
+        var current: ItemID? = id
+        while let next = current {
+            if !seen.insert(next).inserted { return true }
+            current = parentID(of: next)
+        }
+        return false
+    }
+}
+
+enum DiffableOutlineSnapshotValidationError<ItemID: Hashable>: Error, Equatable {
+    case missingRoot(ItemID)
+    case rootHasParent(ItemID)
+    case missingParent(id: ItemID, parentID: ItemID)
+    case missingChild(id: ItemID, childID: ItemID)
+    case parentMismatch(id: ItemID, expectedParentID: ItemID, actualParentID: ItemID?)
+    case duplicateChildID(ItemID)
+    case nodeKeyMismatch(key: ItemID, nodeID: ItemID)
+    case unreachableNode(ItemID)
+    case cycleDetected(ItemID)
+    case missingReloadID(ItemID)
+}
+
+private extension Sequence where Element: Hashable {
+    func sortedForStableDiagnostics() -> [Element] {
+        sorted { String(describing: $0) < String(describing: $1) }
+    }
+}

--- a/Sources/UserInterface/Common/DiffableOutlineView.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineView.swift
@@ -6,8 +6,17 @@
 import AppKit
 
 class DiffableOutlineView: NSOutlineView {
+    private struct ReloadRequest {
+        let snapshot: DiffableOutlineSnapshot<AnyHashable>
+        let animated: Bool
+        let updateDataSource: () -> Void
+        let prepareReloadData: (() -> Void)?
+        let completion: (() -> Void)?
+    }
+
     private var currentSnapshot: DiffableOutlineSnapshot<AnyHashable>?
     private var isApplyingSnapshot = false
+    private var pendingReloadRequest: ReloadRequest?
 
     func reloadWith(
         _ snapshot: DiffableOutlineSnapshot<AnyHashable>,
@@ -16,65 +25,75 @@ class DiffableOutlineView: NSOutlineView {
         prepareReloadData: (() -> Void)? = nil,
         completion: (() -> Void)? = nil
     ) {
+        let request = ReloadRequest(
+            snapshot: snapshot,
+            animated: animated,
+            updateDataSource: updateDataSource,
+            prepareReloadData: prepareReloadData,
+            completion: completion
+        )
+
         guard Thread.isMainThread else {
             DispatchQueue.main.async { [weak self] in
-                self?.reloadWith(
-                    snapshot,
-                    animated: animated,
-                    updateDataSource: updateDataSource,
-                    prepareReloadData: prepareReloadData,
-                    completion: completion
-                )
+                self?.applyOrQueue(request)
             }
             return
         }
 
+        applyOrQueue(request)
+    }
+
+    private func applyOrQueue(_ request: ReloadRequest) {
         guard !isApplyingSnapshot else {
-            DispatchQueue.main.async { [weak self] in
-                self?.reloadWith(
-                    snapshot,
-                    animated: animated,
-                    updateDataSource: updateDataSource,
-                    prepareReloadData: prepareReloadData,
-                    completion: completion
-                )
-            }
+            pendingReloadRequest = request
             return
         }
 
-        if let validationError = snapshot.validationError {
+        apply(request)
+        applyPendingReloads()
+    }
+
+    private func applyPendingReloads() {
+        while !isApplyingSnapshot, let request = pendingReloadRequest {
+            pendingReloadRequest = nil
+            apply(request)
+        }
+    }
+
+    private func apply(_ request: ReloadRequest) {
+        if let validationError = request.snapshot.validationError {
             reportInvalidSnapshot(validationError)
-            completion?()
+            request.completion?()
             return
         }
 
         guard let oldSnapshot = currentSnapshot else {
-            updateDataSource()
-            prepareReloadData?()
+            request.updateDataSource()
+            request.prepareReloadData?()
             reloadData()
-            currentSnapshot = snapshot
-            completion?()
+            currentSnapshot = request.snapshot
+            request.completion?()
             return
         }
 
-        let plan = DiffableOutlineDiffPlanner.plan(from: oldSnapshot, to: snapshot)
+        let plan = DiffableOutlineDiffPlanner.plan(from: oldSnapshot, to: request.snapshot)
         guard plan.isSafe else {
-            updateDataSource()
-            prepareReloadData?()
+            request.updateDataSource()
+            request.prepareReloadData?()
             reloadData()
-            currentSnapshot = snapshot
-            completion?()
+            currentSnapshot = request.snapshot
+            request.completion?()
             return
         }
 
         isApplyingSnapshot = true
-        updateDataSource()
-        apply(plan.operations, oldSnapshot: oldSnapshot, newSnapshot: snapshot, animated: animated)
-        currentSnapshot = snapshot
+        request.updateDataSource()
+        apply(plan.operations, oldSnapshot: oldSnapshot, newSnapshot: request.snapshot, animated: request.animated)
+        currentSnapshot = request.snapshot
         isApplyingSnapshot = false
 
         DispatchQueue.main.async {
-            completion?()
+            request.completion?()
         }
     }
 

--- a/Sources/UserInterface/Common/DiffableOutlineView.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineView.swift
@@ -42,7 +42,8 @@ class DiffableOutlineView: NSOutlineView {
             return
         }
 
-        guard snapshot.validationError == nil else {
+        if let validationError = snapshot.validationError {
+            reportInvalidSnapshot(validationError)
             completion?()
             return
         }
@@ -79,6 +80,13 @@ class DiffableOutlineView: NSOutlineView {
 
     func resetDiffableSnapshot(_ snapshot: DiffableOutlineSnapshot<AnyHashable>? = nil) {
         currentSnapshot = snapshot
+    }
+
+    func reportInvalidSnapshot(_ error: DiffableOutlineSnapshotValidationError<AnyHashable>) {
+        AppLogWarn("[DiffableOutlineView] invalid snapshot: \(error)")
+#if DEBUG
+        assertionFailure("Invalid DiffableOutlineSnapshot: \(error)")
+#endif
     }
 
     func applyRemove(

--- a/Sources/UserInterface/Common/DiffableOutlineView.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineView.swift
@@ -13,6 +13,7 @@ class DiffableOutlineView: NSOutlineView {
         _ snapshot: DiffableOutlineSnapshot<AnyHashable>,
         animated: Bool = true,
         updateDataSource: @escaping () -> Void,
+        prepareReloadData: (() -> Void)? = nil,
         completion: (() -> Void)? = nil
     ) {
         guard Thread.isMainThread else {
@@ -21,6 +22,7 @@ class DiffableOutlineView: NSOutlineView {
                     snapshot,
                     animated: animated,
                     updateDataSource: updateDataSource,
+                    prepareReloadData: prepareReloadData,
                     completion: completion
                 )
             }
@@ -33,6 +35,7 @@ class DiffableOutlineView: NSOutlineView {
                     snapshot,
                     animated: animated,
                     updateDataSource: updateDataSource,
+                    prepareReloadData: prepareReloadData,
                     completion: completion
                 )
             }
@@ -46,6 +49,7 @@ class DiffableOutlineView: NSOutlineView {
 
         guard let oldSnapshot = currentSnapshot else {
             updateDataSource()
+            prepareReloadData?()
             reloadData()
             currentSnapshot = snapshot
             completion?()
@@ -55,6 +59,7 @@ class DiffableOutlineView: NSOutlineView {
         let plan = DiffableOutlineDiffPlanner.plan(from: oldSnapshot, to: snapshot)
         guard plan.isSafe else {
             updateDataSource()
+            prepareReloadData?()
             reloadData()
             currentSnapshot = snapshot
             completion?()
@@ -70,6 +75,10 @@ class DiffableOutlineView: NSOutlineView {
         DispatchQueue.main.async {
             completion?()
         }
+    }
+
+    func resetDiffableSnapshot(_ snapshot: DiffableOutlineSnapshot<AnyHashable>? = nil) {
+        currentSnapshot = snapshot
     }
 
     func applyRemove(

--- a/Sources/UserInterface/Common/DiffableOutlineView.swift
+++ b/Sources/UserInterface/Common/DiffableOutlineView.swift
@@ -1,0 +1,173 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import AppKit
+
+class DiffableOutlineView: NSOutlineView {
+    private var currentSnapshot: DiffableOutlineSnapshot<AnyHashable>?
+    private var isApplyingSnapshot = false
+
+    func reloadWith(
+        _ snapshot: DiffableOutlineSnapshot<AnyHashable>,
+        animated: Bool = true,
+        updateDataSource: @escaping () -> Void,
+        completion: (() -> Void)? = nil
+    ) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.reloadWith(
+                    snapshot,
+                    animated: animated,
+                    updateDataSource: updateDataSource,
+                    completion: completion
+                )
+            }
+            return
+        }
+
+        guard !isApplyingSnapshot else {
+            DispatchQueue.main.async { [weak self] in
+                self?.reloadWith(
+                    snapshot,
+                    animated: animated,
+                    updateDataSource: updateDataSource,
+                    completion: completion
+                )
+            }
+            return
+        }
+
+        guard snapshot.validationError == nil else {
+            completion?()
+            return
+        }
+
+        guard let oldSnapshot = currentSnapshot else {
+            updateDataSource()
+            reloadData()
+            currentSnapshot = snapshot
+            completion?()
+            return
+        }
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: oldSnapshot, to: snapshot)
+        guard plan.isSafe else {
+            updateDataSource()
+            reloadData()
+            currentSnapshot = snapshot
+            completion?()
+            return
+        }
+
+        isApplyingSnapshot = true
+        updateDataSource()
+        apply(plan.operations, oldSnapshot: oldSnapshot, newSnapshot: snapshot, animated: animated)
+        currentSnapshot = snapshot
+        isApplyingSnapshot = false
+
+        DispatchQueue.main.async {
+            completion?()
+        }
+    }
+
+    func applyRemove(
+        at indexes: IndexSet,
+        inParent parent: Any?,
+        animation: NSOutlineView.AnimationOptions
+    ) {
+        removeItems(at: indexes, inParent: parent, withAnimation: animation)
+    }
+
+    func applyInsert(
+        at indexes: IndexSet,
+        inParent parent: Any?,
+        animation: NSOutlineView.AnimationOptions
+    ) {
+        insertItems(at: indexes, inParent: parent, withAnimation: animation)
+    }
+
+    func applyMove(
+        from fromIndex: Int,
+        inParent oldParent: Any?,
+        to toIndex: Int,
+        inParent newParent: Any?
+    ) {
+        moveItem(at: fromIndex, inParent: oldParent, to: toIndex, inParent: newParent)
+    }
+
+    func applyReload(rowIndexes: IndexSet) {
+        guard !rowIndexes.isEmpty, numberOfColumns > 0 else { return }
+        reloadData(forRowIndexes: rowIndexes, columnIndexes: IndexSet(integersIn: 0..<numberOfColumns))
+    }
+
+    private func apply(
+        _ operations: [DiffableOutlineOperation<AnyHashable>],
+        oldSnapshot: DiffableOutlineSnapshot<AnyHashable>,
+        newSnapshot: DiffableOutlineSnapshot<AnyHashable>,
+        animated: Bool
+    ) {
+        guard !operations.isEmpty else { return }
+
+        let animation: NSOutlineView.AnimationOptions = animated ? [.effectFade, .effectGap] : []
+        beginUpdates()
+        for operation in operations {
+            apply(
+                operation,
+                oldSnapshot: oldSnapshot,
+                newSnapshot: newSnapshot,
+                animation: animation
+            )
+        }
+        endUpdates()
+    }
+
+    private func apply(
+        _ operation: DiffableOutlineOperation<AnyHashable>,
+        oldSnapshot: DiffableOutlineSnapshot<AnyHashable>,
+        newSnapshot: DiffableOutlineSnapshot<AnyHashable>,
+        animation: NSOutlineView.AnimationOptions
+    ) {
+        switch operation {
+        case .remove(_, let parentID, let index):
+            applyRemove(
+                at: IndexSet(integer: index),
+                inParent: oldSnapshot.item(forOptionalID: parentID),
+                animation: animation
+            )
+        case .move(_, let parentID, let from, let to):
+            let parent = oldSnapshot.item(forOptionalID: parentID)
+            applyMove(from: from, inParent: parent, to: to, inParent: parent)
+        case .insert(_, let parentID, let index):
+            applyInsert(
+                at: IndexSet(integer: index),
+                inParent: newSnapshot.item(forOptionalID: parentID),
+                animation: animation
+            )
+        case .replace(_, let parentID, let index):
+            applyRemove(
+                at: IndexSet(integer: index),
+                inParent: oldSnapshot.item(forOptionalID: parentID),
+                animation: animation
+            )
+            applyInsert(
+                at: IndexSet(integer: index),
+                inParent: newSnapshot.item(forOptionalID: parentID),
+                animation: animation
+            )
+        case .reload(let id):
+            guard let item = newSnapshot.item(for: id) else { return }
+            let row = row(forItem: item)
+            guard row >= 0 else { return }
+            applyReload(rowIndexes: IndexSet(integer: row))
+        }
+    }
+}
+
+private extension DiffableOutlineSnapshot where ItemID == AnyHashable {
+    func item(forOptionalID id: ItemID?) -> AnyObject? {
+        guard let id else { return nil }
+        return item(for: id)
+    }
+}

--- a/Sources/UserInterface/Sidebar/TabList/BookmarkModel.swift
+++ b/Sources/UserInterface/Sidebar/TabList/BookmarkModel.swift
@@ -102,6 +102,20 @@ class Bookmark: WebContentRepresentable {
         let bookmark = children.remove(at: sourceIndex)
         children.insert(bookmark, at: min(destinationIndex, children.count))
     }
+
+    fileprivate func replaceChildren(_ newChildren: [Bookmark]) {
+        guard isFolder else { return }
+
+        let newChildGUIDs = Set(newChildren.map(\.guid))
+        for child in children where !newChildGUIDs.contains(child.guid) {
+            child.parent = nil
+        }
+
+        children = newChildren
+        for child in children {
+            child.parent = self
+        }
+    }
     
     var hasChildren: Bool {
         return isFolder && !children.isEmpty
@@ -283,7 +297,8 @@ class BookmarkManager: ObservableObject {
                     }
 
                     self.saveExpandedState()
-                    self.rootFolder = Bookmark(title: "Bookmarks", children: bookmarks)
+                    let reusedBookmarks = self.mappedModels(from: bookmarkModels, reusingExistingBookmarks: true)
+                    self.rootFolder = Bookmark(title: "Bookmarks", children: reusedBookmarks)
                     self.rebuildIndex()
                     self.browserState?.syncAllBookmarksOpenedState()
                 }
@@ -648,7 +663,7 @@ class BookmarkManager: ObservableObject {
 }
 
 extension BookmarkManager {
-    func mappedModels(from models: [TabDataModel]) -> [Bookmark] {
+    func mappedModels(from models: [TabDataModel], reusingExistingBookmarks: Bool = false) -> [Bookmark] {
         let bookmarkModels = models.filter { $0.dataType == .bookmark || $0.dataType == .bookmarkFolder }
         guard !bookmarkModels.isEmpty else { return [] }
         
@@ -663,11 +678,19 @@ extension BookmarkManager {
         
         var bookmarkMap: [String: Bookmark] = [:]
         for model in sortedModels {
-            let bookmark = Bookmark(model)
+            let bookmark = reusableBookmark(for: model, reusingExistingBookmarks: reusingExistingBookmarks) ?? Bookmark(model)
+            bookmark.updateSidebarFields(from: model)
             bookmark.setFaviconSnapshotUpdater { [weak self] data in
                 self?.browserState?.localStore.updateTabFavicon(model.guid, favicon: data)
             }
             bookmarkMap[model.guid] = bookmark
+        }
+
+        for bookmark in bookmarkMap.values {
+            bookmark.parent = nil
+            if bookmark.isFolder {
+                bookmark.replaceChildren([])
+            }
         }
         
         for model in sortedModels {
@@ -708,17 +731,26 @@ extension BookmarkManager {
         }
         return topLevel
     }
+
+    private func reusableBookmark(for model: TabDataModel, reusingExistingBookmarks: Bool) -> Bookmark? {
+        guard reusingExistingBookmarks, let existing = bookmarkIndex[model.guid] else { return nil }
+
+        let modelIsFolder = model.dataType == .bookmarkFolder
+        let modelProfileId = model.profile?.profileId ?? model.profileId
+        guard existing.isFolder == modelIsFolder, existing.profileId == modelProfileId else { return nil }
+
+        return existing
+    }
 }
 
 extension Bookmark {
     convenience init(_ model: TabDataModel) {
-        let displayTitle = (model.overrideTitle?.isEmpty == false ? model.overrideTitle! : model.title)
         let isFolder = (model.dataType == .bookmarkFolder)
         let resolvedURL = isFolder ? nil : model.url.absoluteString
         let resolvedSecondary = isFolder ? nil : model.secondaryUrl?.absoluteString
         let resolvedSecondaryTitle = isFolder ? nil : model.secondaryTitle
         self.init(guid: model.guid,
-                  title: displayTitle,
+                  title: Self.sidebarTitle(from: model),
                   url: resolvedURL,
                   secondaryUrl: resolvedSecondary,
                   secondaryTitle: resolvedSecondaryTitle,
@@ -726,5 +758,18 @@ extension Bookmark {
                   faviconData: model.favicon,
                   lastSeen: isFolder ? nil : model.lastSeen,
                   isFolder: isFolder)
+    }
+
+    fileprivate func updateSidebarFields(from model: TabDataModel) {
+        title = Self.sidebarTitle(from: model)
+        url = isFolder ? nil : model.url.absoluteString
+        secondaryUrl = isFolder ? nil : model.secondaryUrl?.absoluteString
+        secondaryTitle = isFolder ? nil : model.secondaryTitle
+        cachedFaviconData = model.favicon
+        lastSeen = isFolder ? nil : model.lastSeen
+    }
+
+    private static func sidebarTitle(from model: TabDataModel) -> String {
+        model.overrideTitle?.isEmpty == false ? model.overrideTitle! : model.title
     }
 }

--- a/Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift
+++ b/Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift
@@ -53,7 +53,15 @@ struct SidebarDiffableSnapshotBuilder {
     }
 
     private func children(of parent: SidebarItem?) -> [SidebarItem] {
-        var children = parent?.childrenItems ?? rootItems
+        let baseChildren: [SidebarItem]
+        if let parent {
+            guard parent.isExpandable else { return [] }
+            baseChildren = parent.childrenItems
+        } else {
+            baseChildren = rootItems
+        }
+
+        var children = baseChildren
         if let hiddenItemID {
             children.removeAll { $0.id == hiddenItemID }
         }

--- a/Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift
+++ b/Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift
@@ -1,0 +1,70 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+
+struct SidebarDiffableSnapshotBuilder {
+    struct VirtualInsertion {
+        let item: SidebarItem
+        let parentID: AnyHashable?
+        let index: Int
+    }
+
+    let rootItems: [SidebarItem]
+    var virtualInsertion: VirtualInsertion?
+    var hiddenItemID: AnyHashable?
+
+    init(
+        rootItems: [SidebarItem],
+        virtualInsertion: VirtualInsertion? = nil,
+        hiddenItemID: AnyHashable? = nil
+    ) {
+        self.rootItems = rootItems
+        self.virtualInsertion = virtualInsertion
+        self.hiddenItemID = hiddenItemID
+    }
+
+    func makeSnapshot() -> DiffableOutlineSnapshot<AnyHashable> {
+        var nodes: [AnyHashable: DiffableOutlineSnapshot<AnyHashable>.Node] = [:]
+        var visited = Set<AnyHashable>()
+
+        func append(_ item: SidebarItem, parentID: AnyHashable?) {
+            guard visited.insert(item.id).inserted else { return }
+            let children = children(of: item)
+            nodes[item.id] = .init(
+                id: item.id,
+                item: item as AnyObject,
+                parentID: parentID,
+                childIDs: children.map(\.id)
+            )
+            for child in children {
+                append(child, parentID: item.id)
+            }
+        }
+
+        let roots = children(of: nil)
+        for root in roots {
+            append(root, parentID: nil)
+        }
+
+        return DiffableOutlineSnapshot(rootIDs: roots.map(\.id), nodes: nodes)
+    }
+
+    private func children(of parent: SidebarItem?) -> [SidebarItem] {
+        var children = parent?.childrenItems ?? rootItems
+        if let hiddenItemID {
+            children.removeAll { $0.id == hiddenItemID }
+        }
+
+        guard let virtualInsertion,
+              virtualInsertion.parentID == parent?.id else {
+            return children
+        }
+
+        let index = min(max(0, virtualInsertion.index), children.count)
+        children.insert(virtualInsertion.item, at: index)
+        return children
+    }
+}

--- a/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
+++ b/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
@@ -396,7 +396,7 @@ class SidebarTabListViewController: NSViewController {
     }
     
     // MARK: - Data Management
-    private func refreshAllItems() {
+    private func refreshAllItems(afterReload: (() -> Void)? = nil) {
         guard isActive else { return }
         let items = makeAllItems()
         let floatingState = nextFloatingBookmarkPresentationState(rootItems: items)
@@ -423,8 +423,10 @@ class SidebarTabListViewController: NSViewController {
                 self.applyFocusingSelection(for: self.browserState.focusingTab)
 
                 DispatchQueue.main.async { [weak self] in
-                    self?.updateVisibleBookmarkTabs()
-                    self?.updateFloatingNewTabVisibility()
+                    guard let self else { return }
+                    self.updateVisibleBookmarkTabs()
+                    self.updateFloatingNewTabVisibility()
+                    afterReload?()
                 }
             }
         )
@@ -2570,6 +2572,7 @@ extension SidebarTabListViewController: NSOutlineViewDataSource {
     
     private func dataSourceChildren(of parent: SidebarItem?) -> [SidebarItem] {
         if let parent {
+            guard parent.isExpandable else { return [] }
             var children = visibleChildren(for: parent)
             if let presentation = focusedBookmarkPresentation,
                let insertionParent = presentation.insertionParent,
@@ -3079,127 +3082,12 @@ extension SidebarTabListViewController: TabSectionDelegate {
     
     func tabSectionDidUpdate(with change: TabSectionChange) {
         guard isActive else { return }
-        if change.needsFullReload {
-            refreshAllItems()
-            updateNewTabCleanupVisibility()
-            clearFloatingProxyIfTabClosed()
-            return
-        }
-        
-        applyIncrementalTabChange(change)
-        updateNewTabCleanupVisibility()
-        clearFloatingProxyIfTabClosed()
-    }
-    
-    /// Applies incremental tab changes to avoid cell flicker from full reloadData.
-    private func applyIncrementalTabChange(_ change: TabSectionChange) {
-        var items: [SidebarItem] = []
-        if showBookmarks {
-            items.append(contentsOf: bookmarkSectionController.bookmarkItems)
-            if !bookmarkSectionController.bookmarkItems.isEmpty && !tabSectionController.tabItems.isEmpty {
-                items.append(separatorItem)
-            }
-        }
-        items.append(contentsOf: tabSectionController.tabItems)
-        
-        let tabSectionStart: Int
-        if showBookmarks {
-            let bookmarkCount = bookmarkSectionController.bookmarkItems.count
-            let separatorCount = (!bookmarkSectionController.bookmarkItems.isEmpty && !tabSectionController.tabItems.isEmpty) ? 1 : 0
-            tabSectionStart = tabSectionStartIndexInRootChildren(bookmarkCount: bookmarkCount, separatorCount: separatorCount)
-        } else {
-            tabSectionStart = 0
-        }
-        
-        // Fallback to full reload if outline view has no data yet (e.g. layout mode just switched).
-        let currentOutlineChildCount = outlineView.numberOfChildren(ofItem: nil)
-        if currentOutlineChildCount == 0 && !items.isEmpty {
-            self.allItems = items
-            rebuildFloatingBookmarkPresentationIfNeeded()
-            outlineView.reloadData()
-            syncDiffableSnapshotToCurrentDataSource()
-            selectActiveTab()
-            applyFocusingSelection(for: browserState.focusingTab)
-            DispatchQueue.main.async { [weak self] in
-                self?.updateVisibleBookmarkTabs()
-            }
-            return
-        }
-        
-        let hasStructuralChanges = change.moveOperation != nil
-            || !change.removedIndices.isEmpty
-            || !change.insertedIndices.isEmpty
-
-        // When there are no structural changes, skip updating allItems. Modifying allItems
-        // without a matching NSOutlineView structural call creates an inconsistency:
-        // outlineView.row(forItem:) would return indices based on the NEW allItems while
-        // NSOutlineView still renders the OLD layout. scrollRowToVisible would then request
-        // a row beyond the current layout, triggering a spurious viewFor:item: call that
-        // creates a duplicate SidebarTabCellView for the same Tab, causing the two-label
-        // flicker bug.
-        if !hasStructuralChanges {
-            selectActiveTab()
-            applyFocusingSelection(for: browserState.focusingTab)
-            // Visual-only paths reach here: rename / recolor / collapse
-            // (cells refresh via VM subscriptions, no reload needed) AND
-            // tab-removed-from-still-existing-group / intra-group reorder
-            // (need a member-table refresh on the affected cell). The
-            // affected-token filter keeps unrelated groups quiet during
-            // pure metadata edits.
-            pushMemberUpdatesToGroupCells(change.affectedGroupTokens)
-            pushPaneUpdatesToSplitPairCells(change.affectedSplitIds)
-            return
-        }
-
-        self.allItems = items
-
-        outlineView.beginUpdates()
-
-        if let moveOp = change.moveOperation {
-            let adjustedFrom = moveOp.from + tabSectionStart
-            let adjustedTo = moveOp.to + tabSectionStart
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = 1
-                context.allowsImplicitAnimation = true
-                outlineView.moveItem(at: adjustedFrom, inParent: nil, to: adjustedTo, inParent: nil)
-            }
-        } else {
-            if !change.removedIndices.isEmpty {
-                let adjustedRemovedIndices = IndexSet(change.removedIndices.map { $0 + tabSectionStart })
-                outlineView.removeItems(at: adjustedRemovedIndices, inParent: nil, withAnimation: [.effectFade])
-            }
-
-            if !change.insertedIndices.isEmpty {
-                let adjustedInsertedIndices = IndexSet(change.insertedIndices.map { $0 + tabSectionStart })
-                outlineView.insertItems(at: adjustedInsertedIndices, inParent: nil, withAnimation: [.effectFade])
-            }
-        }
-
-        outlineView.endUpdates()
-        syncDiffableSnapshotToCurrentDataSource()
-
-        // Tabs that joined or left a still-existing group surface as a
-        // root-level insert/remove of the moved tab's guid; the group's
-        // token stays at the same root position. Push the new member
-        // arrays into each affected `TabGroupCellView` so its inner
-        // diffable table animates the row delta and re-notes its
-        // height in the same animation tick.
-        pushMemberUpdatesToGroupCells(change.affectedGroupTokens)
-        // Same for pair rows whose pane membership changed alongside the
-        // structural delta (drag-to-replace inserts the evicted tab's row
-        // while the pair row id stays put).
-        pushPaneUpdatesToSplitPairCells(change.affectedSplitIds)
-
-        // Defer selection to the next run loop so NSOutlineView finishes its
-        // insert/remove animation layout pass first. Calling row(forItem:) or
-        // selectRowIndexes while animations are in flight can trigger a spurious
-        // viewFor:item: call, creating a duplicate cell for the same Tab.
-        DispatchQueue.main.async { [weak self] in
+        refreshAllItems { [weak self] in
             guard let self else { return }
-            self.selectActiveTab()
-            self.applyFocusingSelection(for: self.browserState.focusingTab)
-            self.updateVisibleBookmarkTabs()
-            self.updateFloatingNewTabVisibility()
+            self.pushMemberUpdatesToGroupCells(change.affectedGroupTokens)
+            self.pushPaneUpdatesToSplitPairCells(change.affectedSplitIds)
+            self.updateNewTabCleanupVisibility()
+            self.clearFloatingProxyIfTabClosed()
         }
     }
 

--- a/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
+++ b/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
@@ -364,6 +364,7 @@ class SidebarTabListViewController: NSViewController {
         removeFloatingNewTabCell()
         outlineView.deselectAll(nil)
         outlineView.reloadData()
+        outlineView.resetDiffableSnapshot()
         browserState.visibleBookmarkTabs = []
     }
     
@@ -388,15 +389,33 @@ class SidebarTabListViewController: NSViewController {
         self.allItems = items
 
         rebuildFloatingBookmarkPresentationIfNeeded()
-        invalidateExistingTabCells()
-        outlineView.reloadData()
-        selectActiveTab()
-        applyFocusingSelection(for: browserState.focusingTab)
+        let focusedPresentation = focusedBookmarkPresentation
+        let snapshot = makeDiffableSnapshot(
+            rootItems: items,
+            focusedPresentation: focusedPresentation
+        )
 
-        DispatchQueue.main.async { [weak self] in
-            self?.updateVisibleBookmarkTabs()
-            self?.updateFloatingNewTabVisibility()
-        }
+        outlineView.reloadWith(
+            snapshot,
+            updateDataSource: { [weak self] in
+                guard let self else { return }
+                self.allItems = items
+                self.focusedBookmarkPresentation = focusedPresentation
+            },
+            prepareReloadData: { [weak self] in
+                self?.invalidateExistingTabCells()
+            },
+            completion: { [weak self] in
+                guard let self else { return }
+                self.selectActiveTab()
+                self.applyFocusingSelection(for: self.browserState.focusingTab)
+
+                DispatchQueue.main.async { [weak self] in
+                    self?.updateVisibleBookmarkTabs()
+                    self?.updateFloatingNewTabVisibility()
+                }
+            }
+        )
     }
 
     private func makeAllItems() -> [SidebarItem] {
@@ -437,6 +456,15 @@ class SidebarTabListViewController: NSViewController {
             virtualInsertion: virtualInsertion,
             hiddenItemID: temporarilyHiddenRealBookmarkGuid.map(AnyHashable.init)
         ).makeSnapshot()
+    }
+
+    private func syncDiffableSnapshotToCurrentDataSource() {
+        outlineView.resetDiffableSnapshot(
+            makeDiffableSnapshot(
+                rootItems: allItems,
+                focusedPresentation: focusedBookmarkPresentation
+            )
+        )
     }
 
     /// Cancel Combine subscriptions on all visible tab cells before reloadData.
@@ -2893,17 +2921,20 @@ extension SidebarTabListViewController: SidebarTabListItemOwner {
                         focusedBookmarkPresentation = desired
                         outlineView.insertItems(at: IndexSet(integer: desired.insertionIndex), inParent: desired.insertionParent, withAnimation: [.effectFade, .effectGap])
                         outlineView.endUpdates()
+                        syncDiffableSnapshotToCurrentDataSource()
                     } else {
                         focusedBookmarkPresentation = desired
                         outlineView.beginUpdates()
                         outlineView.insertItems(at: IndexSet(integer: desired.insertionIndex), inParent: desired.insertionParent, withAnimation: [.effectFade, .effectGap])
                         outlineView.endUpdates()
+                        syncDiffableSnapshotToCurrentDataSource()
                     }
                 } else {
                     focusedBookmarkPresentation = desired
                     outlineView.beginUpdates()
                     outlineView.insertItems(at: IndexSet(integer: desired.insertionIndex), inParent: desired.insertionParent, withAnimation: [.effectFade, .effectGap])
                     outlineView.endUpdates()
+                    syncDiffableSnapshotToCurrentDataSource()
                 }
                 
                 outlineView.animator().collapseItem(item)
@@ -3074,6 +3105,7 @@ extension SidebarTabListViewController: TabSectionDelegate {
             self.allItems = items
             rebuildFloatingBookmarkPresentationIfNeeded()
             outlineView.reloadData()
+            syncDiffableSnapshotToCurrentDataSource()
             selectActiveTab()
             applyFocusingSelection(for: browserState.focusingTab)
             DispatchQueue.main.async { [weak self] in
@@ -3132,6 +3164,7 @@ extension SidebarTabListViewController: TabSectionDelegate {
         }
 
         outlineView.endUpdates()
+        syncDiffableSnapshotToCurrentDataSource()
 
         // Tabs that joined or left a still-existing group surface as a
         // root-level insert/remove of the moved tab's guid; the group's
@@ -3254,9 +3287,11 @@ extension SidebarTabListViewController {
            old.proxy.underlyingBookmark.guid == new.proxy.underlyingBookmark.guid,
            old.insertionParent?.id == new.insertionParent?.id,
            old.insertionIndex == new.insertionIndex {
+            syncDiffableSnapshotToCurrentDataSource()
             return
         }
         if old == nil, new == nil {
+            syncDiffableSnapshotToCurrentDataSource()
             return
         }
         
@@ -3281,6 +3316,7 @@ extension SidebarTabListViewController {
         }
         
         outlineView.endUpdates()
+        syncDiffableSnapshotToCurrentDataSource()
     }
     private func rebuildFloatingBookmarkPresentationIfNeeded() {
         guard let bookmarkGuid = floatingBookmarkGuid,
@@ -3481,11 +3517,13 @@ extension SidebarTabListViewController {
            old.proxy.underlyingBookmark.guid == new.proxy.underlyingBookmark.guid,
            old.insertionParent?.id == new.insertionParent?.id,
            old.insertionIndex == new.insertionIndex {
+            syncDiffableSnapshotToCurrentDataSource()
             applyFocusingSelection(for: tab)
             updateVisibleBookmarkTabs()
             return
         }
         if old == nil, new == nil {
+            syncDiffableSnapshotToCurrentDataSource()
             applyFocusingSelection(for: tab)
             updateVisibleBookmarkTabs()
             return
@@ -3514,6 +3552,7 @@ extension SidebarTabListViewController {
         }
         
         outlineView.endUpdates()
+        syncDiffableSnapshotToCurrentDataSource()
         
         applyFocusingSelection(for: tab)
         updateVisibleBookmarkTabs()
@@ -3548,6 +3587,7 @@ extension SidebarTabListViewController {
             outlineView.reloadData()
         }
         outlineView.endUpdates()
+        syncDiffableSnapshotToCurrentDataSource()
 
         updateVisibleBookmarkTabs()
     }

--- a/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
+++ b/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
@@ -68,6 +68,20 @@ class SidebarTabListViewController: NSViewController {
             underlyingBookmark.makeContextMenu(on: menu, source: .sidebar)
         }
     }
+
+    private struct FloatingBookmarkPresentationState {
+        let focusedPresentation: (proxy: FocusedBookmarkSidebarItem, insertionParent: SidebarItem?, insertionIndex: Int)?
+        let floatingBookmarkGuid: String?
+        let floatingAnchorFolderGuid: String?
+
+        static var cleared: FloatingBookmarkPresentationState {
+            FloatingBookmarkPresentationState(
+                focusedPresentation: nil,
+                floatingBookmarkGuid: nil,
+                floatingAnchorFolderGuid: nil
+            )
+        }
+    }
     
     private var outlineView: SideBarOutlineView!
     private var scrollView: NSScrollView!
@@ -385,14 +399,10 @@ class SidebarTabListViewController: NSViewController {
     private func refreshAllItems() {
         guard isActive else { return }
         let items = makeAllItems()
-
-        self.allItems = items
-
-        rebuildFloatingBookmarkPresentationIfNeeded()
-        let focusedPresentation = focusedBookmarkPresentation
+        let floatingState = nextFloatingBookmarkPresentationState(rootItems: items)
         let snapshot = makeDiffableSnapshot(
             rootItems: items,
-            focusedPresentation: focusedPresentation
+            focusedPresentation: floatingState.focusedPresentation
         )
 
         outlineView.reloadWith(
@@ -400,7 +410,9 @@ class SidebarTabListViewController: NSViewController {
             updateDataSource: { [weak self] in
                 guard let self else { return }
                 self.allItems = items
-                self.focusedBookmarkPresentation = focusedPresentation
+                self.focusedBookmarkPresentation = floatingState.focusedPresentation
+                self.floatingBookmarkGuid = floatingState.floatingBookmarkGuid
+                self.floatingAnchorFolderGuid = floatingState.floatingAnchorFolderGuid
             },
             prepareReloadData: { [weak self] in
                 self?.invalidateExistingTabCells()
@@ -3318,13 +3330,10 @@ extension SidebarTabListViewController {
         outlineView.endUpdates()
         syncDiffableSnapshotToCurrentDataSource()
     }
-    private func rebuildFloatingBookmarkPresentationIfNeeded() {
+    private func nextFloatingBookmarkPresentationState(rootItems: [SidebarItem]) -> FloatingBookmarkPresentationState {
         guard let bookmarkGuid = floatingBookmarkGuid,
               let bookmark = browserState.bookmarkManager.bookmark(withGuid: bookmarkGuid) else {
-            focusedBookmarkPresentation = nil
-            floatingBookmarkGuid = nil
-            floatingAnchorFolderGuid = nil
-            return
+            return .cleared
         }
         
         var parents: [Bookmark] = []
@@ -3335,24 +3344,31 @@ extension SidebarTabListViewController {
         }
         
         guard let firstCollapsed = parents.first(where: { $0.isFolder && !outlineView.isItemExpanded($0) }) else {
-            focusedBookmarkPresentation = nil
-            floatingBookmarkGuid = nil
-            floatingAnchorFolderGuid = nil
-            return
+            return .cleared
         }
         
-        floatingAnchorFolderGuid = firstCollapsed.guid
-        
-        guard let expected = expectedProxyInsertionAfterCollapsedFolder(firstCollapsed) else {
-            focusedBookmarkPresentation = nil
-            floatingBookmarkGuid = nil
-            floatingAnchorFolderGuid = nil
-            return
+        guard let expected = expectedProxyInsertionAfterCollapsedFolder(firstCollapsed, rootItems: rootItems) else {
+            return .cleared
         }
         
         let indentationLevel = max(0, firstCollapsed.depth) + 1
         let proxy = FocusedBookmarkSidebarItem(bookmark: bookmark, indentationLevelOverride: indentationLevel)
-        focusedBookmarkPresentation = (proxy: proxy, insertionParent: expected.insertionParent, insertionIndex: expected.insertionIndex)
+        return FloatingBookmarkPresentationState(
+            focusedPresentation: (
+                proxy: proxy,
+                insertionParent: expected.insertionParent,
+                insertionIndex: expected.insertionIndex
+            ),
+            floatingBookmarkGuid: bookmarkGuid,
+            floatingAnchorFolderGuid: firstCollapsed.guid
+        )
+    }
+
+    private func rebuildFloatingBookmarkPresentationIfNeeded() {
+        let state = nextFloatingBookmarkPresentationState(rootItems: allItems)
+        focusedBookmarkPresentation = state.focusedPresentation
+        floatingBookmarkGuid = state.floatingBookmarkGuid
+        floatingAnchorFolderGuid = state.floatingAnchorFolderGuid
     }
 
     /// Updates `browserState.visibleBookmarkTabs` based on what bookmark items are currently visible in the outline view.
@@ -3419,14 +3435,18 @@ extension SidebarTabListViewController {
     /// The proxy is always inserted as a sibling right after the first-collapsed folder.
     /// This helper computes that expected insertion location for a given collapsed folder,
     /// matching the data source's indexing rules (including `visibleChildren` filtering).
-    private func expectedProxyInsertionAfterCollapsedFolder(_ folder: Bookmark) -> (insertionParent: SidebarItem?, insertionIndex: Int)? {
+    private func expectedProxyInsertionAfterCollapsedFolder(
+        _ folder: Bookmark,
+        rootItems: [SidebarItem]? = nil
+    ) -> (insertionParent: SidebarItem?, insertionIndex: Int)? {
         if let parent = folder.parent {
             let siblings = visibleChildren(for: parent)
             let idx = siblings.firstIndex(where: { $0.id == folder.id }) ?? siblings.count
             return (insertionParent: parent, insertionIndex: min(idx + 1, siblings.count))
         } else {
-            let idx = allItems.firstIndex(where: { $0.id == folder.id }) ?? 0
-            return (insertionParent: nil, insertionIndex: min(idx + 1, allItems.count))
+            let effectiveRootItems = rootItems ?? allItems
+            let idx = effectiveRootItems.firstIndex(where: { $0.id == folder.id }) ?? 0
+            return (insertionParent: nil, insertionIndex: min(idx + 1, effectiveRootItems.count))
         }
     }
     

--- a/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
+++ b/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
@@ -73,13 +73,30 @@ class SidebarTabListViewController: NSViewController {
         let focusedPresentation: (proxy: FocusedBookmarkSidebarItem, insertionParent: SidebarItem?, insertionIndex: Int)?
         let floatingBookmarkGuid: String?
         let floatingAnchorFolderGuid: String?
+        let hiddenBookmarkGuid: String?
 
         static var cleared: FloatingBookmarkPresentationState {
             FloatingBookmarkPresentationState(
                 focusedPresentation: nil,
                 floatingBookmarkGuid: nil,
-                floatingAnchorFolderGuid: nil
+                floatingAnchorFolderGuid: nil,
+                hiddenBookmarkGuid: nil
             )
+        }
+    }
+
+    private final class OneShotAction {
+        private var didRun = false
+        private let action: () -> Void
+
+        init(_ action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        func run() {
+            guard !didRun else { return }
+            didRun = true
+            action()
         }
     }
     
@@ -396,29 +413,44 @@ class SidebarTabListViewController: NSViewController {
     }
     
     // MARK: - Data Management
-    private func refreshAllItems(afterReload: (() -> Void)? = nil) {
-        guard isActive else { return }
+    @discardableResult
+    private func refreshAllItems(
+        presentationState: FloatingBookmarkPresentationState? = nil,
+        animated: Bool = true,
+        afterReload: (() -> Void)? = nil
+    ) -> Bool {
+        guard isActive else { return false }
         let items = makeAllItems()
-        let floatingState = nextFloatingBookmarkPresentationState(rootItems: items)
+        let resolvedPresentationState = presentationState
+            ?? nextFloatingBookmarkPresentationState(
+                rootItems: items,
+                hiddenBookmarkGuid: temporarilyHiddenRealBookmarkGuid
+            )
         let snapshot = makeDiffableSnapshot(
             rootItems: items,
-            focusedPresentation: floatingState.focusedPresentation
+            focusedPresentation: resolvedPresentationState.focusedPresentation,
+            hiddenBookmarkGuid: resolvedPresentationState.hiddenBookmarkGuid
         )
 
+        var didUpdateDataSource = false
         outlineView.reloadWith(
             snapshot,
+            animated: animated,
             updateDataSource: { [weak self] in
                 guard let self else { return }
                 self.allItems = items
-                self.focusedBookmarkPresentation = floatingState.focusedPresentation
-                self.floatingBookmarkGuid = floatingState.floatingBookmarkGuid
-                self.floatingAnchorFolderGuid = floatingState.floatingAnchorFolderGuid
+                self.focusedBookmarkPresentation = resolvedPresentationState.focusedPresentation
+                self.floatingBookmarkGuid = resolvedPresentationState.floatingBookmarkGuid
+                self.floatingAnchorFolderGuid = resolvedPresentationState.floatingAnchorFolderGuid
+                self.temporarilyHiddenRealBookmarkGuid = resolvedPresentationState.hiddenBookmarkGuid
+                didUpdateDataSource = true
             },
             prepareReloadData: { [weak self] in
                 self?.invalidateExistingTabCells()
             },
             completion: { [weak self] in
                 guard let self else { return }
+                guard didUpdateDataSource else { return }
                 self.selectActiveTab()
                 self.applyFocusingSelection(for: self.browserState.focusingTab)
 
@@ -430,6 +462,7 @@ class SidebarTabListViewController: NSViewController {
                 }
             }
         )
+        return didUpdateDataSource
     }
 
     private func makeAllItems() -> [SidebarItem] {
@@ -452,7 +485,8 @@ class SidebarTabListViewController: NSViewController {
             proxy: FocusedBookmarkSidebarItem,
             insertionParent: SidebarItem?,
             insertionIndex: Int
-        )?
+        )?,
+        hiddenBookmarkGuid: String?
     ) -> DiffableOutlineSnapshot<AnyHashable> {
         let virtualInsertion: SidebarDiffableSnapshotBuilder.VirtualInsertion?
         if let focusedPresentation {
@@ -468,17 +502,8 @@ class SidebarTabListViewController: NSViewController {
         return SidebarDiffableSnapshotBuilder(
             rootItems: rootItems,
             virtualInsertion: virtualInsertion,
-            hiddenItemID: temporarilyHiddenRealBookmarkGuid.map(AnyHashable.init)
+            hiddenItemID: hiddenBookmarkGuid.map(AnyHashable.init)
         ).makeSnapshot()
-    }
-
-    private func syncDiffableSnapshotToCurrentDataSource() {
-        outlineView.resetDiffableSnapshot(
-            makeDiffableSnapshot(
-                rootItems: allItems,
-                focusedPresentation: focusedBookmarkPresentation
-            )
-        )
     }
 
     /// Cancel Combine subscriptions on all visible tab cells before reloadData.
@@ -2074,14 +2099,17 @@ extension SidebarTabListViewController: NSOutlineViewDataSource {
         guard focusedBookmarkPresentation != nil else { return }
         if let floatingGuid = floatingBookmarkGuid,
            let bookmark = browserState.bookmarkManager.bookmark(withGuid: floatingGuid) {
-            removeFocusedBookmarkPresentation(animated: false)
-            floatingBookmarkGuid = nil
-            floatingAnchorFolderGuid = nil
-            allowExpandDuringDrag = true
-            expandParents(of: bookmark)
-            allowExpandDuringDrag = false
+            let expandAfterClear = OneShotAction { [weak self] in
+                guard let self else { return }
+                self.allowExpandDuringDrag = true
+                self.expandParents(of: bookmark)
+                self.allowExpandDuringDrag = false
+            }
+            if clearFocusedBookmarkPresentation(animated: false, afterReload: expandAfterClear.run) {
+                expandAfterClear.run()
+            }
         } else {
-            removeFocusedBookmarkPresentation(animated: false)
+            clearFocusedBookmarkPresentation(animated: false)
         }
     }
     
@@ -2863,13 +2891,8 @@ extension SidebarTabListViewController: NSOutlineViewDelegate {
         // Defer to next run loop to avoid conflicting with NSOutlineView's expand animation.
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            let oldPresentation = self.focusedBookmarkPresentation
             self.restoreExpandedDescendantsIfNeeded(of: bookmark)
-            self.rebuildFloatingBookmarkPresentationIfNeeded()
-            self.updateVisibleBookmarkTabs()
-            let newPresentation = self.focusedBookmarkPresentation
-            self.applyFloatingPresentation(from: oldPresentation, to: newPresentation, animated: false)
-            self.updateFloatingNewTabVisibility()
+            self.refreshAllItems(animated: false)
         }
     }
     
@@ -2884,12 +2907,7 @@ extension SidebarTabListViewController: NSOutlineViewDelegate {
         temporarilyHiddenRealBookmarkGuid = nil
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
-            let oldPresentation = self.focusedBookmarkPresentation
-            self.rebuildFloatingBookmarkPresentationIfNeeded()
-            self.updateVisibleBookmarkTabs()
-            let newPresentation = self.focusedBookmarkPresentation
-            self.applyFloatingPresentation(from: oldPresentation, to: newPresentation, animated: false)
-            self.updateFloatingNewTabVisibility()
+            self.refreshAllItems(animated: false)
         }
     }
     
@@ -2920,40 +2938,21 @@ extension SidebarTabListViewController: SidebarTabListItemOwner {
                 
                 let desired = computeFocusedBookmarkPresentation(for: focusingTab, treatingFolderAsCollapsed: folder)
                 guard let desired else {
-            outlineView.animator().collapseItem(item)
+                    outlineView.animator().collapseItem(item)
                     return
                 }
                 
-                floatingBookmarkGuid = focusingBookmark.guid
-                floatingAnchorFolderGuid = folder.guid
-                
-                if let parent = focusingBookmark.parent {
-                    let siblings = visibleChildren(for: parent)
-                    if let idx = siblings.firstIndex(where: { $0.id == focusingBookmark.id }) {
-                        outlineView.beginUpdates()
-                        temporarilyHiddenRealBookmarkGuid = focusingBookmark.guid
-                        outlineView.removeItems(at: IndexSet(integer: idx), inParent: parent, withAnimation: [.effectFade])
-                        focusedBookmarkPresentation = desired
-                        outlineView.insertItems(at: IndexSet(integer: desired.insertionIndex), inParent: desired.insertionParent, withAnimation: [.effectFade, .effectGap])
-                        outlineView.endUpdates()
-                        syncDiffableSnapshotToCurrentDataSource()
-                    } else {
-                        focusedBookmarkPresentation = desired
-                        outlineView.beginUpdates()
-                        outlineView.insertItems(at: IndexSet(integer: desired.insertionIndex), inParent: desired.insertionParent, withAnimation: [.effectFade, .effectGap])
-                        outlineView.endUpdates()
-                        syncDiffableSnapshotToCurrentDataSource()
-                    }
-                } else {
-                    focusedBookmarkPresentation = desired
-                    outlineView.beginUpdates()
-                    outlineView.insertItems(at: IndexSet(integer: desired.insertionIndex), inParent: desired.insertionParent, withAnimation: [.effectFade, .effectGap])
-                    outlineView.endUpdates()
-                    syncDiffableSnapshotToCurrentDataSource()
+                let presentationState = FloatingBookmarkPresentationState(
+                    focusedPresentation: desired,
+                    floatingBookmarkGuid: focusingBookmark.guid,
+                    floatingAnchorFolderGuid: folder.guid,
+                    hiddenBookmarkGuid: focusingBookmark.guid
+                )
+                refreshAllItems(presentationState: presentationState) { [weak self] in
+                    guard let self else { return }
+                    self.outlineView.animator().collapseItem(item)
+                    self.applyFocusingSelection(for: focusingTab)
                 }
-                
-                outlineView.animator().collapseItem(item)
-                applyFocusingSelection(for: focusingTab)
                 return
             }
             
@@ -2976,18 +2975,22 @@ extension SidebarTabListViewController: SidebarTabListItemOwner {
                    existing.insertionIndex == expected.insertionIndex,
                    existing.proxy.underlyingBookmark.guid == focusingBookmark.guid {
                     
-                    removeFocusedBookmarkPresentation(animated: false)
-                    temporarilyHiddenRealBookmarkGuid = nil
-                    outlineView.expandItem(item)
-                    DispatchQueue.main.async { [weak self] in
-                        self?.updateVisibleBookmarkTabs()
+                    let expandAfterClear = OneShotAction { [weak self] in
+                        guard let self else { return }
+                        self.outlineView.expandItem(item)
+                        DispatchQueue.main.async { [weak self] in
+                            self?.updateVisibleBookmarkTabs()
+                        }
+                        self.applyFocusingSelection(for: focusingTab)
                     }
-                    applyFocusingSelection(for: focusingTab)
+                    if clearFocusedBookmarkPresentation(animated: false, afterReload: expandAfterClear.run) {
+                        expandAfterClear.run()
+                    }
                     return
                 }
                 
                 temporarilyHiddenRealBookmarkGuid = nil
-            outlineView.animator().expandItem(item)
+                outlineView.animator().expandItem(item)
                 
                 DispatchQueue.main.async { [weak self] in
                     self?.updateVisibleBookmarkTabs()
@@ -3176,49 +3179,19 @@ extension SidebarTabListViewController {
         traverse(folder)
     }
     
-    private func applyFloatingPresentation(
-        from old: (proxy: FocusedBookmarkSidebarItem, insertionParent: SidebarItem?, insertionIndex: Int)?,
-        to new: (proxy: FocusedBookmarkSidebarItem, insertionParent: SidebarItem?, insertionIndex: Int)?,
-        animated: Bool
-    ) {
-        let anim: NSOutlineView.AnimationOptions = animated ? [.effectFade, .effectGap] : []
-        
-        if let old, let new,
-           old.proxy.underlyingBookmark.guid == new.proxy.underlyingBookmark.guid,
-           old.insertionParent?.id == new.insertionParent?.id,
-           old.insertionIndex == new.insertionIndex {
-            syncDiffableSnapshotToCurrentDataSource()
-            return
-        }
-        if old == nil, new == nil {
-            syncDiffableSnapshotToCurrentDataSource()
-            return
-        }
-        
-        outlineView.beginUpdates()
-        
-        if let old {
-            focusedBookmarkPresentation = nil
-            if canApplyFocusedPresentationMutation(parent: old.insertionParent, index: old.insertionIndex, isInsertion: false) {
-                outlineView.removeItems(at: IndexSet(integer: old.insertionIndex), inParent: old.insertionParent, withAnimation: anim)
-            } else {
-                outlineView.reloadData()
-            }
-        }
-        
-        if let new {
-            focusedBookmarkPresentation = new
-            if canApplyFocusedPresentationMutation(parent: new.insertionParent, index: new.insertionIndex, isInsertion: true) {
-                outlineView.insertItems(at: IndexSet(integer: new.insertionIndex), inParent: new.insertionParent, withAnimation: anim)
-            } else {
-                outlineView.reloadData()
-            }
-        }
-        
-        outlineView.endUpdates()
-        syncDiffableSnapshotToCurrentDataSource()
+    @discardableResult
+    private func clearFocusedBookmarkPresentation(animated: Bool, afterReload: (() -> Void)? = nil) -> Bool {
+        refreshAllItems(
+            presentationState: .cleared,
+            animated: animated,
+            afterReload: afterReload
+        )
     }
-    private func nextFloatingBookmarkPresentationState(rootItems: [SidebarItem]) -> FloatingBookmarkPresentationState {
+
+    private func nextFloatingBookmarkPresentationState(
+        rootItems: [SidebarItem],
+        hiddenBookmarkGuid: String? = nil
+    ) -> FloatingBookmarkPresentationState {
         guard let bookmarkGuid = floatingBookmarkGuid,
               let bookmark = browserState.bookmarkManager.bookmark(withGuid: bookmarkGuid) else {
             return .cleared
@@ -3248,15 +3221,9 @@ extension SidebarTabListViewController {
                 insertionIndex: expected.insertionIndex
             ),
             floatingBookmarkGuid: bookmarkGuid,
-            floatingAnchorFolderGuid: firstCollapsed.guid
+            floatingAnchorFolderGuid: firstCollapsed.guid,
+            hiddenBookmarkGuid: hiddenBookmarkGuid
         )
-    }
-
-    private func rebuildFloatingBookmarkPresentationIfNeeded() {
-        let state = nextFloatingBookmarkPresentationState(rootItems: allItems)
-        focusedBookmarkPresentation = state.focusedPresentation
-        floatingBookmarkGuid = state.floatingBookmarkGuid
-        floatingAnchorFolderGuid = state.floatingAnchorFolderGuid
     }
 
     /// Updates `browserState.visibleBookmarkTabs` based on what bookmark items are currently visible in the outline view.
@@ -3417,55 +3384,6 @@ extension SidebarTabListViewController {
         }
     }
 
-    private func applyFocusedBookmarkPresentation(for tab: Tab?, animated: Bool) {
-        let old = focusedBookmarkPresentation
-        let new = computeFocusedBookmarkPresentation(for: tab)
-        
-        if let old, let new,
-           old.proxy.underlyingBookmark.guid == new.proxy.underlyingBookmark.guid,
-           old.insertionParent?.id == new.insertionParent?.id,
-           old.insertionIndex == new.insertionIndex {
-            syncDiffableSnapshotToCurrentDataSource()
-            applyFocusingSelection(for: tab)
-            updateVisibleBookmarkTabs()
-            return
-        }
-        if old == nil, new == nil {
-            syncDiffableSnapshotToCurrentDataSource()
-            applyFocusingSelection(for: tab)
-            updateVisibleBookmarkTabs()
-            return
-        }
-        
-        let anim: NSOutlineView.AnimationOptions = animated ? [.effectFade, .effectGap] : []
-        
-        outlineView.beginUpdates()
-        
-        if let old {
-            focusedBookmarkPresentation = nil
-            if canApplyFocusedPresentationMutation(parent: old.insertionParent, index: old.insertionIndex, isInsertion: false) {
-                outlineView.removeItems(at: IndexSet(integer: old.insertionIndex), inParent: old.insertionParent, withAnimation: anim)
-            } else {
-                outlineView.reloadData()
-            }
-        }
-        
-        if let new {
-            focusedBookmarkPresentation = new
-            if canApplyFocusedPresentationMutation(parent: new.insertionParent, index: new.insertionIndex, isInsertion: true) {
-                outlineView.insertItems(at: IndexSet(integer: new.insertionIndex), inParent: new.insertionParent, withAnimation: anim)
-            } else {
-                outlineView.reloadData()
-            }
-        }
-        
-        outlineView.endUpdates()
-        syncDiffableSnapshotToCurrentDataSource()
-        
-        applyFocusingSelection(for: tab)
-        updateVisibleBookmarkTabs()
-    }
-    
     private func clearFloatingProxyIfTabClosed() {
         guard let floatingGuid = floatingBookmarkGuid else { return }
         guard let bookmark = browserState.bookmarkManager.bookmark(withGuid: floatingGuid) else {
@@ -3478,46 +3396,7 @@ extension SidebarTabListViewController {
     }
     
     private func clearFloatingProxyState() {
-        removeFocusedBookmarkPresentation(animated: true)
-        floatingBookmarkGuid = nil
-        floatingAnchorFolderGuid = nil
-    }
-    
-    private func removeFocusedBookmarkPresentation(animated: Bool) {
-        guard let old = focusedBookmarkPresentation else { return }
-        let anim: NSOutlineView.AnimationOptions = animated ? [.effectFade, .effectGap] : []
-        
-        outlineView.beginUpdates()
-        focusedBookmarkPresentation = nil
-        if canApplyFocusedPresentationMutation(parent: old.insertionParent, index: old.insertionIndex, isInsertion: false) {
-            outlineView.removeItems(at: IndexSet(integer: old.insertionIndex), inParent: old.insertionParent, withAnimation: anim)
-        } else {
-            outlineView.reloadData()
-        }
-        outlineView.endUpdates()
-        syncDiffableSnapshotToCurrentDataSource()
-
-        updateVisibleBookmarkTabs()
-    }
-    
-    /// Bounds-check helper to prevent occasional crashes when NSOutlineView structural updates
-    /// race with animations or external data refresh.
-    private func canApplyFocusedPresentationMutation(parent: SidebarItem?, index: Int, isInsertion: Bool) -> Bool {
-        if let parent {
-            let count = outlineView(outlineView, numberOfChildrenOfItem: parent)
-            if isInsertion {
-                return index >= 0 && index <= count
-            } else {
-                return index >= 0 && index < count
-            }
-        } else {
-            let count = outlineView(outlineView, numberOfChildrenOfItem: nil)
-            if isInsertion {
-                return index >= 0 && index <= count
-            } else {
-                return index >= 0 && index < count
-            }
-        }
+        clearFocusedBookmarkPresentation(animated: true)
     }
 
     private var newTabButtonItem: SidebarItem? {
@@ -4383,9 +4262,9 @@ extension SidebarTabListViewController: NSDraggingSource {
 ///
 /// #### 1) Implementation (UI-only, real hierarchy untouched)
 /// - `Bookmark.parent` / `Bookmark.children` are **never** mutated.
-/// - A `FocusedBookmarkSidebarItem` (conforming to `UnderlyingBookmarkProviding`) is injected
-///   into a parent's children via `insertItems/removeItems + beginUpdates/endUpdates` to avoid
-///   breaking animations with `reloadData()`.
+/// - A `FocusedBookmarkSidebarItem` (conforming to `UnderlyingBookmarkProviding`) is passed
+///   to `SidebarDiffableSnapshotBuilder` as a virtual insertion, so proxy insert/remove/move
+///   operations use the same diffable outline path as the rest of the sidebar.
 ///
 /// #### 2) Sticky state (follows collapse/expand, not focusing)
 /// Once a floating proxy appears (e.g. Tab1 floats when F1 collapses), it persists even if the
@@ -4408,7 +4287,7 @@ extension SidebarTabListViewController: NSDraggingSource {
 /// - F1 expanded, F2 collapsed: Tab1 moves to after F2 (under F1)
 /// - Both expanded: Tab1 visible at its real position, proxy removed
 ///
-/// Implemented by `rebuildFloatingBookmarkPresentationIfNeeded()`:
+/// Implemented by `nextFloatingBookmarkPresentationState(rootItems:)` during `refreshAllItems`:
 /// - Walks the parent chain from `floatingBookmarkGuid` to find the first collapsed folder.
 /// - If none found: clear floating state + remove proxy.
 /// - If found: update `floatingAnchorFolderGuid` and reposition proxy after that folder.

--- a/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
+++ b/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
@@ -383,19 +383,10 @@ class SidebarTabListViewController: NSViewController {
     // MARK: - Data Management
     private func refreshAllItems() {
         guard isActive else { return }
-        var items: [SidebarItem] = []
-        
-        if showBookmarks {
-            items.append(contentsOf: bookmarkSectionController.bookmarkItems)
-            if !bookmarkSectionController.bookmarkItems.isEmpty && !tabSectionController.tabItems.isEmpty {
-                items.append(separatorItem)
-            }
-        }
-        
-        items.append(contentsOf: tabSectionController.tabItems)
-        
+        let items = makeAllItems()
+
         self.allItems = items
-        
+
         rebuildFloatingBookmarkPresentationIfNeeded()
         invalidateExistingTabCells()
         outlineView.reloadData()
@@ -406,6 +397,46 @@ class SidebarTabListViewController: NSViewController {
             self?.updateVisibleBookmarkTabs()
             self?.updateFloatingNewTabVisibility()
         }
+    }
+
+    private func makeAllItems() -> [SidebarItem] {
+        var items: [SidebarItem] = []
+
+        if showBookmarks {
+            items.append(contentsOf: bookmarkSectionController.bookmarkItems)
+            if !bookmarkSectionController.bookmarkItems.isEmpty && !tabSectionController.tabItems.isEmpty {
+                items.append(separatorItem)
+            }
+        }
+
+        items.append(contentsOf: tabSectionController.tabItems)
+        return items
+    }
+
+    private func makeDiffableSnapshot(
+        rootItems: [SidebarItem],
+        focusedPresentation: (
+            proxy: FocusedBookmarkSidebarItem,
+            insertionParent: SidebarItem?,
+            insertionIndex: Int
+        )?
+    ) -> DiffableOutlineSnapshot<AnyHashable> {
+        let virtualInsertion: SidebarDiffableSnapshotBuilder.VirtualInsertion?
+        if let focusedPresentation {
+            virtualInsertion = .init(
+                item: focusedPresentation.proxy,
+                parentID: focusedPresentation.insertionParent?.id,
+                index: focusedPresentation.insertionIndex
+            )
+        } else {
+            virtualInsertion = nil
+        }
+
+        return SidebarDiffableSnapshotBuilder(
+            rootItems: rootItems,
+            virtualInsertion: virtualInsertion,
+            hiddenItemID: temporarilyHiddenRealBookmarkGuid.map(AnyHashable.init)
+        ).makeSnapshot()
     }
 
     /// Cancel Combine subscriptions on all visible tab cells before reloadData.

--- a/Sources/UserInterface/Sidebar/TabList/TabSectionController.swift
+++ b/Sources/UserInterface/Sidebar/TabList/TabSectionController.swift
@@ -6,26 +6,20 @@
 import Cocoa
 import Combine
 
-/// Describes an incremental change in the tab section.
+/// Describes tab-section rows whose cells need extra rebinding after the
+/// root sidebar snapshot has been applied.
 struct TabSectionChange {
-    /// Inserted tab indices relative to `tabItems`, including `newTabButton`.
-    let insertedIndices: IndexSet
-    /// Removed tab indices relative to the previous `tabItems`.
-    let removedIndices: IndexSet
-    /// A single-tab move operation relative to `tabItems`, including `newTabButton`.
-    let moveOperation: (from: Int, to: Int)?
-    /// Whether a full reload is required.
-    let needsFullReload: Bool
     /// Group tokens whose live `state.normalTabs.filter { groupToken == token }`
     /// child list changed (membership added/removed or intra-group reorder).
-    /// The consumer reloads only these wrappers' children — adding an
+    /// The consumer updates only these wrappers' cells — adding an
     /// ungrouped tab leaves this empty so unrelated groups don't repaint.
     let affectedGroupTokens: Set<String>
     /// Split ids whose merged pair row kept its identity but changed pane
     /// membership (drag-to-replace swaps one pane's Tab object in place on
     /// the cached `SplitPairSidebarItem`). The row id is keyed on the split
-    /// id alone, so the flat diff sees a no-op; the consumer re-binds these
-    /// rows' cells so titles/favicons/subscriptions attach to the new Tab.
+    /// id alone, so the root snapshot can keep the same row identity while
+    /// the consumer re-binds these rows' cells so titles/favicons/subscriptions
+    /// attach to the new Tab.
     let affectedSplitIds: Set<String>
 }
 
@@ -62,13 +56,9 @@ class TabSectionController: NSObject {
     /// split group disappears.
     private var splitPairWrappers: [String: SplitPairSidebarItem] = [:]
 
-    /// Previous root-level item ids used to compute diffs. Holds tab guid
-    /// (`Int`) for ungrouped tabs and group token (`String`) for group rows.
-    private var previousItemIds: [AnyHashable] = []
-
     /// Per-token ordered guid list captured from the previous frame's
     /// `normalTabs`. Used to detect membership / order changes inside any
-    /// given group so the consumer can reload exactly the affected wrappers
+    /// given group so the consumer can update exactly the affected wrappers
     /// (and leave unrelated groups untouched on edits like creating a new
     /// ungrouped tab).
     private var previousGroupMembers: [String: [Int]] = [:]
@@ -89,7 +79,7 @@ class TabSectionController: NSObject {
     init(state: BrowserState? = nil) {
         self.browserState = state
         super.init()
-        refreshTabItems([], isInitial: true)
+        refreshTabItems([])
     }
 
     private func setupBindings() {
@@ -100,22 +90,22 @@ class TabSectionController: NSObject {
 
         guard let browserState else {
             tabItems = []
-            previousItemIds = []
             previousGroupMembers = [:]
+            previousSplitMembers = [:]
             groupWrappers.removeAll()
             splitPairWrappers.removeAll()
             return
         }
 
-        // Sync tabItems and previousItemIds with current state immediately, without
-        // notifying the delegate. This prevents a spurious tabSectionDidUpdate call
+        // Sync tabItems with current state immediately, without notifying
+        // the delegate. This prevents a spurious tabSectionDidUpdate call
         // (from @Published's synchronous initial delivery) that races with the
         // refreshAllItems() call in viewWillAppear and causes duplicate cell creation.
         let currentTabs = browserState.normalTabs
         let initialItems = buildItems(from: currentTabs, groups: browserState.groups, state: browserState)
         tabItems = initialItems
-        previousItemIds = initialItems.map { $0.id }
         previousGroupMembers = Self.computeGroupMembers(tabs: currentTabs)
+        previousSplitMembers = Self.computeSplitMembers(items: initialItems)
 
         // dropFirst() skips the initial synchronous delivery we already handled
         // above. receive(on: .main) defers until after @Published's willSet
@@ -126,7 +116,7 @@ class TabSectionController: NSObject {
             .dropFirst()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] tabs in
-                self?.refreshTabItems(tabs, isInitial: false)
+                self?.refreshTabItems(tabs)
             }
             .store(in: &cancellables)
 
@@ -141,7 +131,7 @@ class TabSectionController: NSObject {
             .sink { [weak self] _ in
                 guard let self else { return }
                 self.subscribeToGroupContents()
-                self.refreshTabItems(self.browserState?.normalTabs ?? [], isInitial: false)
+                self.refreshTabItems(self.browserState?.normalTabs ?? [])
             }
             .store(in: &cancellables)
 
@@ -165,7 +155,7 @@ class TabSectionController: NSObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                self.refreshTabItems(self.browserState?.normalTabs ?? [], isInitial: false)
+                self.refreshTabItems(self.browserState?.normalTabs ?? [])
             }
             .store(in: &cancellables)
     }
@@ -185,7 +175,7 @@ class TabSectionController: NSObject {
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] in
                     guard let self else { return }
-                    self.refreshTabItems(self.browserState?.normalTabs ?? [], isInitial: false)
+                    self.refreshTabItems(self.browserState?.normalTabs ?? [])
                 }
                 .store(in: &groupContentsCancellables)
         }
@@ -300,17 +290,12 @@ class TabSectionController: NSObject {
         return items
     }
 
-    private func refreshTabItems(_ tabs: [Tab], isInitial: Bool) {
+    private func refreshTabItems(_ tabs: [Tab]) {
         guard let browserState else {
             tabItems = []
-            previousItemIds = []
             previousGroupMembers = [:]
             previousSplitMembers = [:]
             delegate?.tabSectionDidUpdate(with: TabSectionChange(
-                insertedIndices: [],
-                removedIndices: [],
-                moveOperation: nil,
-                needsFullReload: true,
                 affectedGroupTokens: [],
                 affectedSplitIds: []
             ))
@@ -318,7 +303,6 @@ class TabSectionController: NSObject {
         }
         let groups = browserState.groups
         let items = buildItems(from: tabs, groups: groups, state: browserState)
-        let newIds = items.map { $0.id }
         let newGroupMembers = Self.computeGroupMembers(tabs: tabs)
         let affectedTokens = Self.affectedGroupTokens(old: previousGroupMembers,
                                                       new: newGroupMembers)
@@ -326,38 +310,14 @@ class TabSectionController: NSObject {
         let affectedSplits = Self.affectedSplitIds(old: previousSplitMembers,
                                                    new: newSplitMembers)
 
-        // Single diff path for all cases (with or without groups). Group
-        // rows participate as ordinary root-level ids (their token), so
-        // `computeFlatChange` correctly emits insertions/removals when a
-        // group is created/closed and moveOperation when a group row
-        // reorders past an ungrouped tab. Tab join/leave a still-existing
-        // group leaves the group's token in both frames; only the moved
-        // tab's id surfaces in the root diff. The consumer reloads exactly
-        // the wrappers listed in `affectedGroupTokens` so unrelated edits
-        // (e.g. creating an ungrouped tab) do not repaint other groups,
-        // and we never call `reloadData()` — which would also rebuild the
-        // bookmark section above and cause a visible flicker there.
-        let change: TabSectionChange
-        if isInitial || delegate == nil {
-            change = TabSectionChange(insertedIndices: [],
-                                      removedIndices: [],
-                                      moveOperation: nil,
-                                      needsFullReload: true,
-                                      affectedGroupTokens: [],
-                                      affectedSplitIds: [])
-        } else {
-            change = computeFlatChange(oldIds: previousItemIds,
-                                       newIds: newIds,
-                                       affectedGroupTokens: affectedTokens,
-                                       affectedSplitIds: affectedSplits)
-        }
-
         self.tabItems = items
-        self.previousItemIds = newIds
         self.previousGroupMembers = newGroupMembers
         self.previousSplitMembers = newSplitMembers
 
-        delegate?.tabSectionDidUpdate(with: change)
+        delegate?.tabSectionDidUpdate(with: TabSectionChange(
+            affectedGroupTokens: affectedTokens,
+            affectedSplitIds: affectedSplits
+        ))
     }
 
     /// Snapshot of each group's ordered guid list. Compared frame-over-frame
@@ -394,8 +354,8 @@ class TabSectionController: NSObject {
     }
 
     /// Split ids present in both frames whose pane guids changed. Ids only
-    /// in one frame surface as row insertions/removals in the flat diff and
-    /// rebuild their cell anyway.
+    /// in one frame surface as row insertions/removals in the root snapshot
+    /// and rebuild their cell anyway.
     private static func affectedSplitIds(old: [String: [Int]],
                                          new: [String: [Int]]) -> Set<String> {
         var ids: Set<String> = []
@@ -405,83 +365,6 @@ class TabSectionController: NSObject {
         return ids
     }
 
-    private func computeFlatChange(oldIds: [AnyHashable],
-                                   newIds: [AnyHashable],
-                                   affectedGroupTokens: Set<String>,
-                                   affectedSplitIds: Set<String>) -> TabSectionChange {
-        let oldSet = Set(oldIds)
-        let newSet = Set(newIds)
-
-        let insertedIds = newSet.subtracting(oldSet)
-        let removedIds = oldSet.subtracting(newSet)
-
-        let commonIds = oldSet.intersection(newSet)
-        let oldCommonOrder = oldIds.filter { commonIds.contains($0) }
-        let newCommonOrder = newIds.filter { commonIds.contains($0) }
-
-        if oldCommonOrder != newCommonOrder {
-            if insertedIds.isEmpty && removedIds.isEmpty {
-                if let moveOp = detectSingleMove(oldIds: oldIds, newIds: newIds) {
-                    return TabSectionChange(
-                        insertedIndices: [],
-                        removedIndices: [],
-                        moveOperation: (from: moveOp.from, to: moveOp.to),
-                        needsFullReload: false,
-                        affectedGroupTokens: affectedGroupTokens,
-                        affectedSplitIds: affectedSplitIds
-                    )
-                }
-            }
-            return TabSectionChange(insertedIndices: [],
-                                    removedIndices: [],
-                                    moveOperation: nil,
-                                    needsFullReload: true,
-                                    affectedGroupTokens: affectedGroupTokens,
-                                    affectedSplitIds: affectedSplitIds)
-        }
-
-        var insertedIndices = IndexSet()
-        for (index, id) in newIds.enumerated() where insertedIds.contains(id) {
-            insertedIndices.insert(index)
-        }
-
-        var removedIndices = IndexSet()
-        for (index, id) in oldIds.enumerated() where removedIds.contains(id) {
-            removedIndices.insert(index)
-        }
-
-        return TabSectionChange(
-            insertedIndices: insertedIndices,
-            removedIndices: removedIndices,
-            moveOperation: nil,
-            needsFullReload: false,
-            affectedGroupTokens: affectedGroupTokens,
-            affectedSplitIds: affectedSplitIds
-        )
-    }
-    
-    /// Detect whether the change can be represented as a single move.
-    /// - Parameters:
-    ///   - oldIds: Item ids before the move.
-    ///   - newIds: Item ids after the move.
-    /// - Returns: The `(from, to)` indices when a single move is detected.
-    private func detectSingleMove(oldIds: [AnyHashable], newIds: [AnyHashable]) -> (from: Int, to: Int)? {
-        guard oldIds.count == newIds.count else { return nil }
-
-        for from in 0..<oldIds.count {
-            for to in 0..<oldIds.count where from != to {
-                var simulated = oldIds
-                let item = simulated.remove(at: from)
-                simulated.insert(item, at: to)
-                if simulated == newIds {
-                    return (from: from, to: to)
-                }
-            }
-        }
-
-        return nil
-    }
-    
     func activateTab(_ tab: Tab) {
         tab.makeSelfActive()
     }

--- a/Sources/UserInterface/Sidebar/TabList/Views/SideBarOutlineView.swift
+++ b/Sources/UserInterface/Sidebar/TabList/Views/SideBarOutlineView.swift
@@ -225,7 +225,7 @@ protocol SideBarOutlineViewDelegate: AnyObject {
     func outlineView(_ outlineView: NSOutlineView, draggingEnded sender: any NSDraggingInfo)
 }
 
-class SideBarOutlineView: NSOutlineView {
+class SideBarOutlineView: DiffableOutlineView {
     static let indentation = 10
     private static let dragThreshold: CGFloat = 5
     private static let dragAutoscrollHotZoneHeight: CGFloat = 92

--- a/Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Phi
+
+private final class PlannerItem: NSObject {
+    let name: String
+
+    init(_ name: String) {
+        self.name = name
+        super.init()
+    }
+}
+
+private func item(_ id: String) -> PlannerItem {
+    PlannerItem(id)
+}
+
+private func snapshot(_ roots: [String], _ nodes: [String: (String?, [String])]) -> DiffableOutlineSnapshot<String> {
+    var snapshotNodes: [String: DiffableOutlineSnapshot<String>.Node] = [:]
+    for (id, value) in nodes {
+        snapshotNodes[id] = .init(id: id, item: item(id), parentID: value.0, childIDs: value.1)
+    }
+    return DiffableOutlineSnapshot(rootIDs: roots, nodes: snapshotNodes)
+}
+
+final class DiffableOutlineDiffPlannerTests: XCTestCase {
+    func testRootInsertProducesInsertOperation() {
+        let old = snapshot(["a"], ["a": (nil, [])])
+        let new = snapshot(["a", "b"], ["a": (nil, []), "b": (nil, [])])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.insert(id: "b", parentID: nil, index: 1)])
+        XCTAssertTrue(plan.isSafe)
+    }
+
+    func testChildDeleteProducesRemoveOperationAtOldIndex() {
+        let old = snapshot(["folder"], [
+            "folder": (nil, ["a", "b"]),
+            "a": ("folder", []),
+            "b": ("folder", []),
+        ])
+        let new = snapshot(["folder"], [
+            "folder": (nil, ["a"]),
+            "a": ("folder", []),
+        ])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.remove(id: "b", parentID: "folder", index: 1)])
+    }
+
+    func testSubtreeDeleteOnlyRemovesHighestDeletedNode() {
+        let old = snapshot(["folder"], [
+            "folder": (nil, ["child"]),
+            "child": ("folder", ["grandchild"]),
+            "grandchild": ("child", []),
+        ])
+        let new = DiffableOutlineSnapshot<String>(rootIDs: [], nodes: [:])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.remove(id: "folder", parentID: nil, index: 0)])
+    }
+
+    func testSubtreeInsertOnlyInsertsHighestInsertedNode() {
+        let old = DiffableOutlineSnapshot<String>(rootIDs: [], nodes: [:])
+        let new = snapshot(["folder"], [
+            "folder": (nil, ["child"]),
+            "child": ("folder", ["grandchild"]),
+            "grandchild": ("child", []),
+        ])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.insert(id: "folder", parentID: nil, index: 0)])
+    }
+}

--- a/Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
@@ -95,6 +95,26 @@ final class DiffableOutlineDiffPlannerTests: XCTestCase {
         XCTAssertEqual(plan.operations, [.move(id: "b", parentID: nil, from: 1, to: 0)])
     }
 
+    func testStableParentChildReorderProducesMove() {
+        let folder = item("folder")
+        let a = item("a")
+        let b = item("b")
+        let old = snapshot(["folder"], [
+            "folder": (nil, ["a", "b"]),
+            "a": ("folder", []),
+            "b": ("folder", []),
+        ], items: ["folder": folder, "a": a, "b": b])
+        let new = snapshot(["folder"], [
+            "folder": (nil, ["b", "a"]),
+            "a": ("folder", []),
+            "b": ("folder", []),
+        ], items: ["folder": folder, "a": a, "b": b])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.move(id: "b", parentID: "folder", from: 1, to: 0)])
+    }
+
     func testCrossParentMoveUsesRemoveAndInsert() {
         let left = item("left")
         let right = item("right")
@@ -142,6 +162,44 @@ final class DiffableOutlineDiffPlannerTests: XCTestCase {
         let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
 
         XCTAssertEqual(plan.operations, [.replace(id: "root", parentID: nil, index: 0)])
+    }
+
+    func testParentReplacementSuppressesChildReorderMove() {
+        let oldFolder = item("old-folder")
+        let newFolder = item("new-folder")
+        let a = item("a")
+        let b = item("b")
+        let old = snapshot(["folder"], [
+            "folder": (nil, ["a", "b"]),
+            "a": ("folder", []),
+            "b": ("folder", []),
+        ], items: ["folder": oldFolder, "a": a, "b": b])
+        let new = snapshot(["folder"], [
+            "folder": (nil, ["b", "a"]),
+            "a": ("folder", []),
+            "b": ("folder", []),
+        ], items: ["folder": newFolder, "a": a, "b": b])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.replace(id: "folder", parentID: nil, index: 0)])
+    }
+
+    func testParentReplacementSuppressesChildInsert() {
+        let oldFolder = item("old-folder")
+        let newFolder = item("new-folder")
+        let child = item("child")
+        let old = snapshot(["folder"], [
+            "folder": (nil, []),
+        ], items: ["folder": oldFolder])
+        let new = snapshot(["folder"], [
+            "folder": (nil, ["child"]),
+            "child": ("folder", []),
+        ], items: ["folder": newFolder, "child": child])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.replace(id: "folder", parentID: nil, index: 0)])
     }
 
     func testExplicitReloadMarkerProducesReload() {

--- a/Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
@@ -185,6 +185,28 @@ final class DiffableOutlineDiffPlannerTests: XCTestCase {
         XCTAssertEqual(plan.operations, [.replace(id: "folder", parentID: nil, index: 0)])
     }
 
+    func testReplacementSiblingWithSameParentMoveIsUnsafe() {
+        let oldProxy = item("old-proxy")
+        let newProxy = item("new-proxy")
+        let a = item("a")
+        let b = item("b")
+        let old = snapshot(["proxy", "a", "b"], [
+            "proxy": (nil, []),
+            "a": (nil, []),
+            "b": (nil, []),
+        ], items: ["proxy": oldProxy, "a": a, "b": b])
+        let new = snapshot(["proxy", "b", "a"], [
+            "proxy": (nil, []),
+            "a": (nil, []),
+            "b": (nil, []),
+        ], items: ["proxy": newProxy, "a": a, "b": b])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertFalse(plan.isSafe)
+        XCTAssertTrue(plan.operations.isEmpty)
+    }
+
     func testParentReplacementSuppressesChildInsert() {
         let oldFolder = item("old-folder")
         let newFolder = item("new-folder")

--- a/Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
@@ -14,18 +14,23 @@ private func item(_ id: String) -> PlannerItem {
     PlannerItem(id)
 }
 
-private func snapshot(_ roots: [String], _ nodes: [String: (String?, [String])]) -> DiffableOutlineSnapshot<String> {
+private func snapshot(
+    _ roots: [String],
+    _ nodes: [String: (String?, [String])],
+    items: [String: PlannerItem] = [:]
+) -> DiffableOutlineSnapshot<String> {
     var snapshotNodes: [String: DiffableOutlineSnapshot<String>.Node] = [:]
     for (id, value) in nodes {
-        snapshotNodes[id] = .init(id: id, item: item(id), parentID: value.0, childIDs: value.1)
+        snapshotNodes[id] = .init(id: id, item: items[id] ?? item(id), parentID: value.0, childIDs: value.1)
     }
     return DiffableOutlineSnapshot(rootIDs: roots, nodes: snapshotNodes)
 }
 
 final class DiffableOutlineDiffPlannerTests: XCTestCase {
     func testRootInsertProducesInsertOperation() {
-        let old = snapshot(["a"], ["a": (nil, [])])
-        let new = snapshot(["a", "b"], ["a": (nil, []), "b": (nil, [])])
+        let a = item("a")
+        let old = snapshot(["a"], ["a": (nil, [])], items: ["a": a])
+        let new = snapshot(["a", "b"], ["a": (nil, []), "b": (nil, [])], items: ["a": a])
 
         let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
 
@@ -34,15 +39,17 @@ final class DiffableOutlineDiffPlannerTests: XCTestCase {
     }
 
     func testChildDeleteProducesRemoveOperationAtOldIndex() {
+        let folder = item("folder")
+        let a = item("a")
         let old = snapshot(["folder"], [
             "folder": (nil, ["a", "b"]),
             "a": ("folder", []),
             "b": ("folder", []),
-        ])
+        ], items: ["folder": folder, "a": a])
         let new = snapshot(["folder"], [
             "folder": (nil, ["a"]),
             "a": ("folder", []),
-        ])
+        ], items: ["folder": folder, "a": a])
 
         let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
 
@@ -73,5 +80,94 @@ final class DiffableOutlineDiffPlannerTests: XCTestCase {
         let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
 
         XCTAssertEqual(plan.operations, [.insert(id: "folder", parentID: nil, index: 0)])
+    }
+
+    func testSameParentReorderProducesMoveUsingCollectionDifference() {
+        let a = item("a")
+        let b = item("b")
+        let c = item("c")
+        let items = ["a": a, "b": b, "c": c]
+        let old = snapshot(["a", "b", "c"], ["a": (nil, []), "b": (nil, []), "c": (nil, [])], items: items)
+        let new = snapshot(["b", "a", "c"], ["a": (nil, []), "b": (nil, []), "c": (nil, [])], items: items)
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.move(id: "b", parentID: nil, from: 1, to: 0)])
+    }
+
+    func testCrossParentMoveUsesRemoveAndInsert() {
+        let left = item("left")
+        let right = item("right")
+        let movingItem = item("item")
+        let items = ["left": left, "right": right, "item": movingItem]
+        let old = snapshot(["left", "right"], [
+            "left": (nil, ["item"]),
+            "right": (nil, []),
+            "item": ("left", []),
+        ], items: items)
+        let new = snapshot(["left", "right"], [
+            "left": (nil, []),
+            "right": (nil, ["item"]),
+            "item": ("right", []),
+        ], items: items)
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [
+            .remove(id: "item", parentID: "left", index: 0),
+            .insert(id: "item", parentID: "right", index: 0),
+        ])
+    }
+
+    func testIdentityReplacementUsesHighestChangedNode() {
+        let oldRoot = item("old-root")
+        let oldChild = item("old-child")
+        let newRoot = item("new-root")
+        let newChild = item("new-child")
+        let old = DiffableOutlineSnapshot(
+            rootIDs: ["root"],
+            nodes: [
+                "root": .init(id: "root", item: oldRoot, parentID: nil, childIDs: ["child"]),
+                "child": .init(id: "child", item: oldChild, parentID: "root", childIDs: []),
+            ]
+        )
+        let new = DiffableOutlineSnapshot(
+            rootIDs: ["root"],
+            nodes: [
+                "root": .init(id: "root", item: newRoot, parentID: nil, childIDs: ["child"]),
+                "child": .init(id: "child", item: newChild, parentID: "root", childIDs: []),
+            ]
+        )
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.replace(id: "root", parentID: nil, index: 0)])
+    }
+
+    func testExplicitReloadMarkerProducesReload() {
+        let base = ["a": (Optional<String>.none, [String]())]
+        let old = snapshot(["a"], base)
+        let new = DiffableOutlineSnapshot(
+            rootIDs: ["a"],
+            nodes: ["a": .init(id: "a", item: item("a"), parentID: nil, childIDs: [])],
+            reloadIDs: ["a"]
+        )
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.replace(id: "a", parentID: nil, index: 0), .reload(id: "a")])
+    }
+
+    func testInvalidSnapshotProducesUnsafePlan() {
+        let old = DiffableOutlineSnapshot<String>(rootIDs: [], nodes: [:])
+        let invalid = DiffableOutlineSnapshot(
+            rootIDs: ["missing"],
+            nodes: [:]
+        )
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: invalid)
+
+        XCTAssertFalse(plan.isSafe)
+        XCTAssertTrue(plan.operations.isEmpty)
     }
 }

--- a/Tests/PhiBrowserTests/DiffableOutlineSnapshotTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineSnapshotTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import Phi
+
+private final class DiffableOutlineTestItem: NSObject {
+    let name: String
+
+    init(_ name: String) {
+        self.name = name
+        super.init()
+    }
+}
+
+final class DiffableOutlineSnapshotTests: XCTestCase {
+    func testValidSnapshotPreservesRootAndChildOrder() {
+        let folder = DiffableOutlineTestItem("folder")
+        let childA = DiffableOutlineTestItem("child-a")
+        let childB = DiffableOutlineTestItem("child-b")
+
+        let snapshot = DiffableOutlineSnapshot(
+            rootIDs: ["folder"],
+            nodes: [
+                "folder": .init(id: "folder", item: folder, parentID: nil, childIDs: ["child-a", "child-b"]),
+                "child-a": .init(id: "child-a", item: childA, parentID: "folder", childIDs: []),
+                "child-b": .init(id: "child-b", item: childB, parentID: "folder", childIDs: []),
+            ]
+        )
+
+        XCTAssertNil(snapshot.validationError)
+        XCTAssertEqual(snapshot.rootIDs, ["folder"])
+        XCTAssertEqual(snapshot.childIDs(of: "folder"), ["child-a", "child-b"])
+        XCTAssertEqual(snapshot.parentID(of: "child-a"), "folder")
+        XCTAssertEqual(snapshot.index(of: "child-b"), 1)
+        XCTAssertTrue(snapshot.item(for: "folder") === folder)
+    }
+
+    func testDuplicateChildReferenceFailsValidation() {
+        let parent = DiffableOutlineTestItem("parent")
+        let child = DiffableOutlineTestItem("child")
+
+        let snapshot = DiffableOutlineSnapshot(
+            rootIDs: ["parent"],
+            nodes: [
+                "parent": .init(id: "parent", item: parent, parentID: nil, childIDs: ["child", "child"]),
+                "child": .init(id: "child", item: child, parentID: "parent", childIDs: []),
+            ]
+        )
+
+        XCTAssertEqual(snapshot.validationError, .duplicateChildID("child"))
+    }
+
+    func testMissingParentFailsValidation() {
+        let child = DiffableOutlineTestItem("child")
+
+        let snapshot = DiffableOutlineSnapshot(
+            rootIDs: [],
+            nodes: [
+                "child": .init(id: "child", item: child, parentID: "missing", childIDs: []),
+            ]
+        )
+
+        XCTAssertEqual(snapshot.validationError, .missingParent(id: "child", parentID: "missing"))
+    }
+
+    func testCycleFailsValidation() {
+        let a = DiffableOutlineTestItem("a")
+        let b = DiffableOutlineTestItem("b")
+
+        let snapshot = DiffableOutlineSnapshot(
+            rootIDs: [],
+            nodes: [
+                "a": .init(id: "a", item: a, parentID: "b", childIDs: ["b"]),
+                "b": .init(id: "b", item: b, parentID: "a", childIDs: ["a"]),
+            ]
+        )
+
+        XCTAssertEqual(snapshot.validationError, .cycleDetected("a"))
+    }
+
+    func testSameIDCanUseDifferentItemInstanceAcrossSnapshots() {
+        let first = DiffableOutlineTestItem("first")
+        let second = DiffableOutlineTestItem("second")
+
+        let old = DiffableOutlineSnapshot(
+            rootIDs: ["item"],
+            nodes: ["item": .init(id: "item", item: first, parentID: nil, childIDs: [])]
+        )
+        let new = DiffableOutlineSnapshot(
+            rootIDs: ["item"],
+            nodes: ["item": .init(id: "item", item: second, parentID: nil, childIDs: [])]
+        )
+
+        XCTAssertNil(old.validationError)
+        XCTAssertNil(new.validationError)
+        XCTAssertFalse(old.item(for: "item") === new.item(for: "item"))
+    }
+}

--- a/Tests/PhiBrowserTests/DiffableOutlineViewAnimationTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineViewAnimationTests.swift
@@ -1,0 +1,327 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import AppKit
+import XCTest
+@testable import Phi
+
+private final class OutlineAnimationItem: NSObject {
+    let id: String
+    let title: String
+
+    init(id: String, title: String) {
+        self.id = id
+        self.title = title
+        super.init()
+    }
+}
+
+private struct OutlineAnimationModel {
+    let roots: [OutlineAnimationItem]
+    let childrenByID: [String: [OutlineAnimationItem]]
+
+    func children(of item: Any?) -> [OutlineAnimationItem] {
+        guard let item = item as? OutlineAnimationItem else { return roots }
+        return childrenByID[item.id] ?? []
+    }
+
+    func snapshot() -> DiffableOutlineSnapshot<AnyHashable> {
+        var nodes: [AnyHashable: DiffableOutlineSnapshot<AnyHashable>.Node] = [:]
+
+        func append(_ item: OutlineAnimationItem, parentID: String?) {
+            let children = childrenByID[item.id] ?? []
+            nodes[AnyHashable(item.id)] = .init(
+                id: AnyHashable(item.id),
+                item: item,
+                parentID: parentID.map(AnyHashable.init),
+                childIDs: children.map { AnyHashable($0.id) }
+            )
+
+            for child in children {
+                append(child, parentID: item.id)
+            }
+        }
+
+        for root in roots {
+            append(root, parentID: nil)
+        }
+
+        return DiffableOutlineSnapshot(
+            rootIDs: roots.map { AnyHashable($0.id) },
+            nodes: nodes
+        )
+    }
+}
+
+private final class AnimatingDiffableOutlineView: DiffableOutlineView {
+    enum Mutation: Equatable {
+        case insert(parentID: String?, indexes: [Int], animated: Bool)
+        case remove(parentID: String?, indexes: [Int], animated: Bool)
+        case move(parentID: String?, from: Int, to: Int)
+        case reloadData
+    }
+
+    private(set) var mutations: [Mutation] = []
+
+    func clearMutations() {
+        mutations.removeAll()
+    }
+
+    override func reloadData() {
+        mutations.append(.reloadData)
+        super.reloadData()
+    }
+
+    override func applyInsert(
+        at indexes: IndexSet,
+        inParent parent: Any?,
+        animation: NSOutlineView.AnimationOptions
+    ) {
+        mutations.append(
+            .insert(parentID: parentID(parent), indexes: Array(indexes), animated: !animation.isEmpty)
+        )
+        super.applyInsert(at: indexes, inParent: parent, animation: animation)
+    }
+
+    override func applyRemove(
+        at indexes: IndexSet,
+        inParent parent: Any?,
+        animation: NSOutlineView.AnimationOptions
+    ) {
+        mutations.append(
+            .remove(parentID: parentID(parent), indexes: Array(indexes), animated: !animation.isEmpty)
+        )
+        super.applyRemove(at: indexes, inParent: parent, animation: animation)
+    }
+
+    override func applyMove(
+        from fromIndex: Int,
+        inParent oldParent: Any?,
+        to toIndex: Int,
+        inParent newParent: Any?
+    ) {
+        mutations.append(.move(parentID: parentID(oldParent), from: fromIndex, to: toIndex))
+        super.applyMove(from: fromIndex, inParent: oldParent, to: toIndex, inParent: newParent)
+    }
+
+    private func parentID(_ parent: Any?) -> String? {
+        (parent as? OutlineAnimationItem)?.id
+    }
+}
+
+private final class DiffableOutlineAnimationFixture: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate {
+    private enum Identifier {
+        static let column = NSUserInterfaceItemIdentifier("diffable-outline-animation-column")
+        static let cell = NSUserInterfaceItemIdentifier("diffable-outline-animation-cell")
+    }
+
+    let outlineView = AnimatingDiffableOutlineView()
+
+    private let window: NSWindow
+    private var model = OutlineAnimationModel(roots: [], childrenByID: [:])
+
+    override init() {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 320, height: 240))
+        window = NSWindow(
+            contentRect: scrollView.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+
+        super.init()
+
+        let column = NSTableColumn(identifier: Identifier.column)
+        column.width = scrollView.bounds.width
+
+        outlineView.frame = scrollView.bounds
+        outlineView.headerView = nil
+        outlineView.rowHeight = 24
+        outlineView.addTableColumn(column)
+        outlineView.outlineTableColumn = column
+        outlineView.dataSource = self
+        outlineView.delegate = self
+
+        scrollView.documentView = outlineView
+        window.contentView = scrollView
+        layout()
+    }
+
+    deinit {
+        outlineView.dataSource = nil
+        outlineView.delegate = nil
+        window.close()
+    }
+
+    func apply(_ nextModel: OutlineAnimationModel, animated: Bool) -> Bool {
+        let snapshot = nextModel.snapshot()
+        var completed = false
+
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0
+            outlineView.reloadWith(
+                snapshot,
+                animated: animated,
+                updateDataSource: {
+                    self.model = nextModel
+                },
+                completion: {
+                    completed = true
+                }
+            )
+        }
+
+        drainMainQueue(until: { completed })
+        layout()
+        return completed
+    }
+
+    func expand(_ item: OutlineAnimationItem) {
+        outlineView.expandItem(item)
+        drainMainQueue()
+        layout()
+    }
+
+    func visibleTitles() -> [String] {
+        layout()
+        return (0..<outlineView.numberOfRows).compactMap { row in
+            (outlineView.item(atRow: row) as? OutlineAnimationItem)?.title
+        }
+    }
+
+    func visibleCellTitles() -> [String] {
+        layout()
+        return (0..<outlineView.numberOfRows).compactMap { row in
+            let cell = outlineView.view(atColumn: 0, row: row, makeIfNecessary: true) as? NSTableCellView
+            return cell?.textField?.stringValue
+        }
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, numberOfChildrenOfItem item: Any?) -> Int {
+        model.children(of: item).count
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, child index: Int, ofItem item: Any?) -> Any {
+        model.children(of: item)[index]
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, isItemExpandable item: Any) -> Bool {
+        !model.children(of: item).isEmpty
+    }
+
+    func outlineView(_ outlineView: NSOutlineView, viewFor tableColumn: NSTableColumn?, item: Any) -> NSView? {
+        let cell = outlineView.makeView(withIdentifier: Identifier.cell, owner: self) as? NSTableCellView
+            ?? makeCell()
+        cell.textField?.stringValue = (item as? OutlineAnimationItem)?.title ?? ""
+        return cell
+    }
+
+    private func makeCell() -> NSTableCellView {
+        let cell = NSTableCellView(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        cell.identifier = Identifier.cell
+
+        let textField = NSTextField(labelWithString: "")
+        textField.frame = cell.bounds.insetBy(dx: 4, dy: 2)
+        textField.autoresizingMask = [.width, .height]
+        cell.addSubview(textField)
+        cell.textField = textField
+
+        return cell
+    }
+
+    private func layout() {
+        window.contentView?.layoutSubtreeIfNeeded()
+        outlineView.layoutSubtreeIfNeeded()
+    }
+
+    private func drainMainQueue(until isDone: (() -> Bool)? = nil) {
+        let deadline = Date().addingTimeInterval(0.5)
+        while Date() < deadline {
+            if isDone?() == true { break }
+            RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.01))
+        }
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.01))
+    }
+}
+
+final class DiffableOutlineViewAnimationTests: XCTestCase {
+    func testAppliesCRUDSnapshotsWithRealOutlineViewAnimations() {
+        runOnMain {
+            let fixture = DiffableOutlineAnimationFixture()
+            let folder = OutlineAnimationItem(id: "folder", title: "Folder")
+            let alpha = OutlineAnimationItem(id: "alpha", title: "Alpha")
+            let beta = OutlineAnimationItem(id: "beta", title: "Beta")
+            let gamma = OutlineAnimationItem(id: "gamma", title: "Gamma")
+
+            let initial = OutlineAnimationModel(
+                roots: [folder, gamma],
+                childrenByID: ["folder": [alpha, beta]]
+            )
+            XCTAssertTrue(fixture.apply(initial, animated: false))
+            fixture.expand(folder)
+            XCTAssertEqual(fixture.visibleTitles(), ["Folder", "Alpha", "Beta", "Gamma"])
+            XCTAssertEqual(fixture.visibleCellTitles(), ["Folder", "Alpha", "Beta", "Gamma"])
+            XCTAssertEqual(fixture.outlineView.mutations, [.reloadData])
+
+            let delta = OutlineAnimationItem(id: "delta", title: "Delta")
+            let inserted = OutlineAnimationModel(
+                roots: [folder, gamma],
+                childrenByID: ["folder": [alpha, delta, beta]]
+            )
+            fixture.outlineView.clearMutations()
+            XCTAssertTrue(fixture.apply(inserted, animated: true))
+            XCTAssertEqual(fixture.visibleTitles(), ["Folder", "Alpha", "Delta", "Beta", "Gamma"])
+            XCTAssertEqual(
+                fixture.outlineView.mutations,
+                [.insert(parentID: "folder", indexes: [1], animated: true)]
+            )
+
+            let updatedAlpha = OutlineAnimationItem(id: "alpha", title: "Alpha Updated")
+            let updated = OutlineAnimationModel(
+                roots: [folder, gamma],
+                childrenByID: ["folder": [updatedAlpha, delta, beta]]
+            )
+            fixture.outlineView.clearMutations()
+            XCTAssertTrue(fixture.apply(updated, animated: true))
+            XCTAssertEqual(fixture.visibleCellTitles(), ["Folder", "Alpha Updated", "Delta", "Beta", "Gamma"])
+            XCTAssertEqual(
+                fixture.outlineView.mutations,
+                [
+                    .remove(parentID: "folder", indexes: [0], animated: true),
+                    .insert(parentID: "folder", indexes: [0], animated: true),
+                ]
+            )
+
+            let moved = OutlineAnimationModel(
+                roots: [folder, gamma],
+                childrenByID: ["folder": [beta, updatedAlpha, delta]]
+            )
+            fixture.outlineView.clearMutations()
+            XCTAssertTrue(fixture.apply(moved, animated: true))
+            XCTAssertEqual(fixture.visibleTitles(), ["Folder", "Beta", "Alpha Updated", "Delta", "Gamma"])
+            XCTAssertEqual(fixture.outlineView.mutations, [.move(parentID: "folder", from: 2, to: 0)])
+
+            let deleted = OutlineAnimationModel(
+                roots: [folder, gamma],
+                childrenByID: ["folder": [beta, updatedAlpha]]
+            )
+            fixture.outlineView.clearMutations()
+            XCTAssertTrue(fixture.apply(deleted, animated: true))
+            XCTAssertEqual(fixture.visibleTitles(), ["Folder", "Beta", "Alpha Updated", "Gamma"])
+            XCTAssertEqual(
+                fixture.outlineView.mutations,
+                [.remove(parentID: "folder", indexes: [2], animated: true)]
+            )
+        }
+    }
+
+    private func runOnMain(_ body: @escaping () -> Void) {
+        if Thread.isMainThread {
+            body()
+        } else {
+            DispatchQueue.main.sync(execute: body)
+        }
+    }
+}

--- a/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
@@ -182,4 +182,10 @@ final class DiffableOutlineViewTests: XCTestCase {
 
         XCTAssertTrue(view.events.isEmpty)
     }
+
+    func testSideBarOutlineViewIsDiffableOutlineView() {
+        let view = SideBarOutlineView()
+
+        XCTAssertTrue(view is DiffableOutlineView)
+    }
 }

--- a/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
@@ -19,6 +19,7 @@ private final class OutlineApplyItem: NSObject {
 private final class RecordingDiffableOutlineView: DiffableOutlineView {
     private(set) var events: [String] = []
     private(set) var invalidSnapshotErrors: [DiffableOutlineSnapshotValidationError<AnyHashable>] = []
+    var onApplyInsert: (() -> Void)?
 
     func record(_ event: String) {
         events.append(event)
@@ -50,6 +51,7 @@ private final class RecordingDiffableOutlineView: DiffableOutlineView {
 
     override func applyInsert(at indexes: IndexSet, inParent parent: Any?, animation: NSOutlineView.AnimationOptions) {
         events.append("insert:\(Array(indexes)):\(parentID(parent)):\(animationDescription(animation))")
+        onApplyInsert?()
     }
 
     override func applyMove(from fromIndex: Int, inParent oldParent: Any?, to toIndex: Int, inParent newParent: Any?) {
@@ -153,6 +155,59 @@ final class DiffableOutlineViewTests: XCTestCase {
         }
 
         XCTAssertEqual(view.events, ["updateDataSource", "beginUpdates", "insert:[1]:root:none", "endUpdates"])
+    }
+
+    func testReentrantReloadAppliesOnlyLatestPendingSnapshot() {
+        let view = RecordingDiffableOutlineView()
+        let item0 = OutlineApplyItem("item0")
+        let item1 = OutlineApplyItem("item1")
+        let item2 = OutlineApplyItem("item2")
+        let item3 = OutlineApplyItem("item3")
+        let old = applySnapshot(["item0"], [
+            "item0": (item0, nil, []),
+        ])
+        let first = applySnapshot(["item0", "item1"], [
+            "item0": (item0, nil, []),
+            "item1": (item1, nil, []),
+        ])
+        let stale = applySnapshot(["item0", "item1", "item2"], [
+            "item0": (item0, nil, []),
+            "item1": (item1, nil, []),
+            "item2": (item2, nil, []),
+        ])
+        let latest = applySnapshot(["item0", "item1", "item3"], [
+            "item0": (item0, nil, []),
+            "item1": (item1, nil, []),
+            "item3": (item3, nil, []),
+        ])
+        view.reloadWith(old, animated: false) {}
+        view.clearEvents()
+
+        view.onApplyInsert = { [weak view] in
+            guard let view else { return }
+            view.onApplyInsert = nil
+            view.reloadWith(stale, animated: false) {
+                view.record("staleData")
+            }
+            view.reloadWith(latest, animated: false) {
+                view.record("latestData")
+            }
+        }
+
+        view.reloadWith(first, animated: false) {
+            view.record("firstData")
+        }
+
+        XCTAssertEqual(view.events, [
+            "firstData",
+            "beginUpdates",
+            "insert:[1]:root:none",
+            "endUpdates",
+            "latestData",
+            "beginUpdates",
+            "insert:[2]:root:none",
+            "endUpdates",
+        ])
     }
 
     func testReplaceUsesOldParentForRemoveAndNewParentForInsert() {

--- a/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
@@ -18,6 +18,7 @@ private final class OutlineApplyItem: NSObject {
 
 private final class RecordingDiffableOutlineView: DiffableOutlineView {
     private(set) var events: [String] = []
+    private(set) var invalidSnapshotErrors: [DiffableOutlineSnapshotValidationError<AnyHashable>] = []
 
     func record(_ event: String) {
         events.append(event)
@@ -29,6 +30,10 @@ private final class RecordingDiffableOutlineView: DiffableOutlineView {
 
     override func reloadData() {
         events.append("reloadData")
+    }
+
+    override func reportInvalidSnapshot(_ error: DiffableOutlineSnapshotValidationError<AnyHashable>) {
+        invalidSnapshotErrors.append(error)
     }
 
     override func beginUpdates() {
@@ -292,7 +297,7 @@ final class DiffableOutlineViewTests: XCTestCase {
         ])
     }
 
-    func testInvalidSnapshotDoesNotUpdateDataSource() {
+    func testInvalidSnapshotReportsErrorWithoutUpdatingDataSource() {
         let view = RecordingDiffableOutlineView()
         let invalid = DiffableOutlineSnapshot<AnyHashable>(rootIDs: [AnyHashable("missing")], nodes: [:])
 
@@ -301,6 +306,10 @@ final class DiffableOutlineViewTests: XCTestCase {
         }
 
         XCTAssertTrue(view.events.isEmpty)
+        XCTAssertEqual(
+            view.invalidSnapshotErrors,
+            [.missingRoot(AnyHashable("missing"))]
+        )
     }
 
     func testSideBarOutlineViewIsDiffableOutlineView() {

--- a/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
@@ -180,6 +180,68 @@ final class DiffableOutlineViewTests: XCTestCase {
         ])
     }
 
+    func testStableParentChildReorderAppliesMove() {
+        let view = RecordingDiffableOutlineView()
+        let folder = OutlineApplyItem("folder")
+        let childA = OutlineApplyItem("item1")
+        let childB = OutlineApplyItem("item2")
+        let old = applySnapshot(["folder"], [
+            "folder": (folder, nil, ["item1", "item2"]),
+            "item1": (childA, "folder", []),
+            "item2": (childB, "folder", []),
+        ])
+        let new = applySnapshot(["folder"], [
+            "folder": (folder, nil, ["item2", "item1"]),
+            "item1": (childA, "folder", []),
+            "item2": (childB, "folder", []),
+        ])
+        view.reloadWith(old, animated: false) {}
+        view.clearEvents()
+
+        view.reloadWith(new, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, [
+            "updateDataSource",
+            "beginUpdates",
+            "move:1:folder->0:folder",
+            "endUpdates",
+        ])
+    }
+
+    func testParentReplacementDoesNotApplyChildMove() {
+        let view = RecordingDiffableOutlineView()
+        let oldFolder = OutlineApplyItem("folder")
+        let newFolder = OutlineApplyItem("folder")
+        let childA = OutlineApplyItem("item1")
+        let childB = OutlineApplyItem("item2")
+        let old = applySnapshot(["folder"], [
+            "folder": (oldFolder, nil, ["item1", "item2"]),
+            "item1": (childA, "folder", []),
+            "item2": (childB, "folder", []),
+        ])
+        let new = applySnapshot(["folder"], [
+            "folder": (newFolder, nil, ["item2", "item1"]),
+            "item1": (childA, "folder", []),
+            "item2": (childB, "folder", []),
+        ])
+        view.reloadWith(old, animated: false) {}
+        view.clearEvents()
+
+        view.reloadWith(new, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, [
+            "updateDataSource",
+            "beginUpdates",
+            "remove:[0]:root:none",
+            "insert:[0]:root:none",
+            "endUpdates",
+        ])
+    }
+
     func testReloadOperationResolvesRowsAfterDataSourceUpdate() {
         let view = RecordingDiffableOutlineView()
         let item1 = OutlineApplyItem("item1")

--- a/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
@@ -242,6 +242,32 @@ final class DiffableOutlineViewTests: XCTestCase {
         ])
     }
 
+    func testReplacementSiblingMoveFallsBackToReloadData() {
+        let view = RecordingDiffableOutlineView()
+        let oldProxy = OutlineApplyItem("proxy")
+        let newProxy = OutlineApplyItem("proxy")
+        let item1 = OutlineApplyItem("item1")
+        let item2 = OutlineApplyItem("item2")
+        let old = applySnapshot(["proxy", "item1", "item2"], [
+            "proxy": (oldProxy, nil, []),
+            "item1": (item1, nil, []),
+            "item2": (item2, nil, []),
+        ])
+        let new = applySnapshot(["proxy", "item2", "item1"], [
+            "proxy": (newProxy, nil, []),
+            "item1": (item1, nil, []),
+            "item2": (item2, nil, []),
+        ])
+        view.reloadWith(old, animated: false) {}
+        view.clearEvents()
+
+        view.reloadWith(new, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, ["updateDataSource", "reloadData"])
+    }
+
     func testReloadOperationResolvesRowsAfterDataSourceUpdate() {
         let view = RecordingDiffableOutlineView()
         let item1 = OutlineApplyItem("item1")

--- a/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
@@ -1,0 +1,185 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import AppKit
+import XCTest
+@testable import Phi
+
+private final class OutlineApplyItem: NSObject {
+    let id: String
+
+    init(_ id: String) {
+        self.id = id
+        super.init()
+    }
+}
+
+private final class RecordingDiffableOutlineView: DiffableOutlineView {
+    private(set) var events: [String] = []
+
+    func record(_ event: String) {
+        events.append(event)
+    }
+
+    func clearEvents() {
+        events.removeAll()
+    }
+
+    override func reloadData() {
+        events.append("reloadData")
+    }
+
+    override func beginUpdates() {
+        events.append("beginUpdates")
+    }
+
+    override func endUpdates() {
+        events.append("endUpdates")
+    }
+
+    override func applyRemove(at indexes: IndexSet, inParent parent: Any?, animation: NSOutlineView.AnimationOptions) {
+        events.append("remove:\(Array(indexes)):\(parentID(parent)):\(animationDescription(animation))")
+    }
+
+    override func applyInsert(at indexes: IndexSet, inParent parent: Any?, animation: NSOutlineView.AnimationOptions) {
+        events.append("insert:\(Array(indexes)):\(parentID(parent)):\(animationDescription(animation))")
+    }
+
+    override func applyMove(from fromIndex: Int, inParent oldParent: Any?, to toIndex: Int, inParent newParent: Any?) {
+        events.append("move:\(fromIndex):\(parentID(oldParent))->\(toIndex):\(parentID(newParent))")
+    }
+
+    override func applyReload(rowIndexes: IndexSet) {
+        events.append("reloadRows:\(Array(rowIndexes))")
+    }
+
+    override func row(forItem item: Any?) -> Int {
+        guard let item = item as? OutlineApplyItem else { return -1 }
+        return Int(item.id.filter(\.isNumber)) ?? 0
+    }
+
+    private func parentID(_ parent: Any?) -> String {
+        guard let parent = parent as? OutlineApplyItem else { return "root" }
+        return parent.id
+    }
+
+    private func animationDescription(_ animation: NSOutlineView.AnimationOptions) -> String {
+        animation.isEmpty ? "none" : "animated"
+    }
+}
+
+private func applySnapshot(
+    _ roots: [String],
+    _ nodes: [String: (OutlineApplyItem, String?, [String])]
+) -> DiffableOutlineSnapshot<AnyHashable> {
+    var snapshotNodes: [AnyHashable: DiffableOutlineSnapshot<AnyHashable>.Node] = [:]
+    for (id, value) in nodes {
+        snapshotNodes[AnyHashable(id)] = .init(
+            id: AnyHashable(id),
+            item: value.0,
+            parentID: value.1.map(AnyHashable.init),
+            childIDs: value.2.map(AnyHashable.init)
+        )
+    }
+    return DiffableOutlineSnapshot(rootIDs: roots.map(AnyHashable.init), nodes: snapshotNodes)
+}
+
+final class DiffableOutlineViewTests: XCTestCase {
+    func testFirstSnapshotUpdatesDataSourceBeforeReloadData() {
+        let view = RecordingDiffableOutlineView()
+        let snapshot = applySnapshot(["item0"], ["item0": (OutlineApplyItem("item0"), nil, [])])
+
+        view.reloadWith(snapshot, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, ["updateDataSource", "reloadData"])
+    }
+
+    func testInsertUpdatesDataSourceBeforeMutation() {
+        let view = RecordingDiffableOutlineView()
+        let item0 = OutlineApplyItem("item0")
+        let old = applySnapshot(["item0"], ["item0": (item0, nil, [])])
+        let new = applySnapshot(["item0", "item1"], [
+            "item0": (item0, nil, []),
+            "item1": (OutlineApplyItem("item1"), nil, []),
+        ])
+        view.reloadWith(old, animated: false) {
+            view.record("initialData")
+        }
+        view.clearEvents()
+
+        view.reloadWith(new, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, ["updateDataSource", "beginUpdates", "insert:[1]:root:none", "endUpdates"])
+    }
+
+    func testReplaceUsesOldParentForRemoveAndNewParentForInsert() {
+        let view = RecordingDiffableOutlineView()
+        let oldFolder = OutlineApplyItem("oldFolder")
+        let newFolder = OutlineApplyItem("newFolder")
+        let oldChild = OutlineApplyItem("item1")
+        let newChild = OutlineApplyItem("item1")
+        let old = applySnapshot(["folder"], [
+            "folder": (oldFolder, nil, ["item1"]),
+            "item1": (oldChild, "folder", []),
+        ])
+        let new = applySnapshot(["folder"], [
+            "folder": (newFolder, nil, ["item1"]),
+            "item1": (newChild, "folder", []),
+        ])
+        view.reloadWith(old, animated: false) {}
+        view.clearEvents()
+
+        view.reloadWith(new, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, [
+            "updateDataSource",
+            "beginUpdates",
+            "remove:[0]:root:none",
+            "insert:[0]:root:none",
+            "endUpdates",
+        ])
+    }
+
+    func testReloadOperationResolvesRowsAfterDataSourceUpdate() {
+        let view = RecordingDiffableOutlineView()
+        let item1 = OutlineApplyItem("item1")
+        let old = applySnapshot(["item1"], ["item1": (item1, nil, [])])
+        let new = DiffableOutlineSnapshot(
+            rootIDs: [AnyHashable("item1")],
+            nodes: [AnyHashable("item1"): .init(id: AnyHashable("item1"), item: item1, parentID: nil, childIDs: [])],
+            reloadIDs: [AnyHashable("item1")]
+        )
+        view.reloadWith(old, animated: false) {}
+        view.clearEvents()
+
+        view.reloadWith(new, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, [
+            "updateDataSource",
+            "beginUpdates",
+            "reloadRows:[1]",
+            "endUpdates",
+        ])
+    }
+
+    func testInvalidSnapshotDoesNotUpdateDataSource() {
+        let view = RecordingDiffableOutlineView()
+        let invalid = DiffableOutlineSnapshot<AnyHashable>(rootIDs: [AnyHashable("missing")], nodes: [:])
+
+        view.reloadWith(invalid, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertTrue(view.events.isEmpty)
+    }
+}

--- a/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
+++ b/Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
@@ -98,6 +98,38 @@ final class DiffableOutlineViewTests: XCTestCase {
         XCTAssertEqual(view.events, ["updateDataSource", "reloadData"])
     }
 
+    func testPrepareReloadDataRunsBeforeReloadData() {
+        let view = RecordingDiffableOutlineView()
+        let snapshot = applySnapshot(["item0"], ["item0": (OutlineApplyItem("item0"), nil, [])])
+
+        view.reloadWith(snapshot, animated: false) {
+            view.record("updateDataSource")
+        } prepareReloadData: {
+            view.record("prepareReloadData")
+        }
+
+        XCTAssertEqual(view.events, ["updateDataSource", "prepareReloadData", "reloadData"])
+    }
+
+    func testResetDiffableSnapshotForcesNextApplyToReloadData() {
+        let view = RecordingDiffableOutlineView()
+        let item0 = OutlineApplyItem("item0")
+        let old = applySnapshot(["item0"], ["item0": (item0, nil, [])])
+        let new = applySnapshot(["item0", "item1"], [
+            "item0": (item0, nil, []),
+            "item1": (OutlineApplyItem("item1"), nil, []),
+        ])
+        view.reloadWith(old, animated: false) {}
+        view.resetDiffableSnapshot()
+        view.clearEvents()
+
+        view.reloadWith(new, animated: false) {
+            view.record("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, ["updateDataSource", "reloadData"])
+    }
+
     func testInsertUpdatesDataSourceBeforeMutation() {
         let view = RecordingDiffableOutlineView()
         let item0 = OutlineApplyItem("item0")

--- a/Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift
+++ b/Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift
@@ -10,20 +10,30 @@ private final class SnapshotSidebarItem: SidebarItem {
     let id: AnyHashable
     let title: String
     let childrenItems: [SidebarItem]
+    private let isExpandableOverride: Bool?
+    private let itemTypeOverride: SidebarItemType?
 
-    init(id: String, title: String? = nil, children: [SidebarItem] = []) {
+    init(
+        id: String,
+        title: String? = nil,
+        children: [SidebarItem] = [],
+        isExpandable: Bool? = nil,
+        itemType: SidebarItemType? = nil
+    ) {
         self.id = AnyHashable(id)
         self.title = title ?? id
         self.childrenItems = children
+        self.isExpandableOverride = isExpandable
+        self.itemTypeOverride = itemType
     }
 
     var url: String? { nil }
     var iconName: String? { nil }
     var faviconUrl: String? { nil }
-    var isExpandable: Bool { !childrenItems.isEmpty }
-    var hasChildren: Bool { !childrenItems.isEmpty }
+    var isExpandable: Bool { isExpandableOverride ?? !childrenItems.isEmpty }
+    var hasChildren: Bool { isExpandable }
     var depth: Int { 0 }
-    var itemType: SidebarItemType { isExpandable ? .bookmarkFolder : .bookmark }
+    var itemType: SidebarItemType { itemTypeOverride ?? (isExpandable ? .bookmarkFolder : .bookmark) }
     var isActive: Bool { false }
     var isSelectable: Bool { true }
     var isBookmark: Bool { true }
@@ -87,5 +97,22 @@ final class SidebarDiffableSnapshotTests: XCTestCase {
             snapshot.childIDs(of: AnyHashable("parent")),
             [AnyHashable("first"), AnyHashable("virtual"), AnyHashable("second")]
         )
+    }
+
+    func testSidebarSnapshotTreatsNonExpandableItemsAsLeaves() {
+        let member = SnapshotSidebarItem(id: "member")
+        let group = SnapshotSidebarItem(
+            id: "group",
+            children: [member],
+            isExpandable: false,
+            itemType: .tabGroup
+        )
+
+        let snapshot = SidebarDiffableSnapshotBuilder(rootItems: [group]).makeSnapshot()
+
+        XCTAssertEqual(snapshot.rootIDs, [AnyHashable("group")])
+        XCTAssertEqual(snapshot.childIDs(of: AnyHashable("group")), [])
+        XCTAssertTrue(snapshot.item(for: AnyHashable("group")) === group)
+        XCTAssertNil(snapshot.item(for: AnyHashable("member")))
     }
 }

--- a/Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift
+++ b/Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift
@@ -99,6 +99,26 @@ final class SidebarDiffableSnapshotTests: XCTestCase {
         )
     }
 
+    func testSidebarSnapshotHidesRealItemAndInsertsVirtualReplacement() {
+        let real = SnapshotSidebarItem(id: "real")
+        let sibling = SnapshotSidebarItem(id: "sibling")
+        let virtual = SnapshotSidebarItem(id: "virtual")
+        let parent = SnapshotSidebarItem(id: "parent", children: [real, sibling])
+
+        let snapshot = SidebarDiffableSnapshotBuilder(
+            rootItems: [parent],
+            virtualInsertion: .init(item: virtual, parentID: AnyHashable("parent"), index: 0),
+            hiddenItemID: AnyHashable("real")
+        ).makeSnapshot()
+
+        XCTAssertEqual(
+            snapshot.childIDs(of: AnyHashable("parent")),
+            [AnyHashable("virtual"), AnyHashable("sibling")]
+        )
+        XCTAssertNil(snapshot.item(for: AnyHashable("real")))
+        XCTAssertTrue(snapshot.item(for: AnyHashable("virtual")) === virtual)
+    }
+
     func testSidebarSnapshotTreatsNonExpandableItemsAsLeaves() {
         let member = SnapshotSidebarItem(id: "member")
         let group = SnapshotSidebarItem(

--- a/Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift
+++ b/Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift
@@ -1,0 +1,91 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import XCTest
+@testable import Phi
+
+private final class SnapshotSidebarItem: SidebarItem {
+    let id: AnyHashable
+    let title: String
+    let childrenItems: [SidebarItem]
+
+    init(id: String, title: String? = nil, children: [SidebarItem] = []) {
+        self.id = AnyHashable(id)
+        self.title = title ?? id
+        self.childrenItems = children
+    }
+
+    var url: String? { nil }
+    var iconName: String? { nil }
+    var faviconUrl: String? { nil }
+    var isExpandable: Bool { !childrenItems.isEmpty }
+    var hasChildren: Bool { !childrenItems.isEmpty }
+    var depth: Int { 0 }
+    var itemType: SidebarItemType { isExpandable ? .bookmarkFolder : .bookmark }
+    var isActive: Bool { false }
+    var isSelectable: Bool { true }
+    var isBookmark: Bool { true }
+
+    func performAction(with owner: SidebarTabListItemOwner?) {}
+}
+
+final class SidebarDiffableSnapshotTests: XCTestCase {
+    func testSidebarSnapshotUsesStableItemIDs() {
+        let child = SnapshotSidebarItem(id: "child")
+        let parent = SnapshotSidebarItem(id: "parent", children: [child])
+
+        let snapshot = SidebarDiffableSnapshotBuilder(rootItems: [parent]).makeSnapshot()
+
+        XCTAssertEqual(snapshot.rootIDs, [AnyHashable("parent")])
+        XCTAssertEqual(snapshot.childIDs(of: AnyHashable("parent")), [AnyHashable("child")])
+        XCTAssertTrue(snapshot.item(for: AnyHashable("parent")) === parent)
+        XCTAssertTrue(snapshot.item(for: AnyHashable("child")) === child)
+    }
+
+    func testSidebarSnapshotFiltersHiddenItem() {
+        let hidden = SnapshotSidebarItem(id: "hidden")
+        let visible = SnapshotSidebarItem(id: "visible")
+        let parent = SnapshotSidebarItem(id: "parent", children: [hidden, visible])
+
+        let snapshot = SidebarDiffableSnapshotBuilder(
+            rootItems: [parent],
+            hiddenItemID: AnyHashable("hidden")
+        ).makeSnapshot()
+
+        XCTAssertEqual(snapshot.childIDs(of: AnyHashable("parent")), [AnyHashable("visible")])
+        XCTAssertNil(snapshot.item(for: AnyHashable("hidden")))
+    }
+
+    func testSidebarSnapshotInsertsVirtualItemAtRoot() {
+        let first = SnapshotSidebarItem(id: "first")
+        let second = SnapshotSidebarItem(id: "second")
+        let virtual = SnapshotSidebarItem(id: "virtual")
+
+        let snapshot = SidebarDiffableSnapshotBuilder(
+            rootItems: [first, second],
+            virtualInsertion: .init(item: virtual, parentID: nil, index: 1)
+        ).makeSnapshot()
+
+        XCTAssertEqual(snapshot.rootIDs, [AnyHashable("first"), AnyHashable("virtual"), AnyHashable("second")])
+        XCTAssertTrue(snapshot.item(for: AnyHashable("virtual")) === virtual)
+    }
+
+    func testSidebarSnapshotInsertsVirtualItemInParent() {
+        let first = SnapshotSidebarItem(id: "first")
+        let second = SnapshotSidebarItem(id: "second")
+        let virtual = SnapshotSidebarItem(id: "virtual")
+        let parent = SnapshotSidebarItem(id: "parent", children: [first, second])
+
+        let snapshot = SidebarDiffableSnapshotBuilder(
+            rootItems: [parent],
+            virtualInsertion: .init(item: virtual, parentID: AnyHashable("parent"), index: 1)
+        ).makeSnapshot()
+
+        XCTAssertEqual(
+            snapshot.childIDs(of: AnyHashable("parent")),
+            [AnyHashable("first"), AnyHashable("virtual"), AnyHashable("second")]
+        )
+    }
+}

--- a/docs/superpowers/plans/2026-06-16-diffable-outline-view.md
+++ b/docs/superpowers/plans/2026-06-16-diffable-outline-view.md
@@ -1,0 +1,1626 @@
+# Diffable Outline View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a reusable `DiffableOutlineView` that applies stable-ID tree snapshots with safe incremental `NSOutlineView` mutations, then use it for sidebar tab/bookmark refreshes.
+
+**Architecture:** Keep the existing sidebar controller as the data source and delegate. Add a small Common-layer snapshot model, tree-aware planner backed by `CollectionDifference`, and an `NSOutlineView` subclass that owns the current snapshot and mutation timing. Sidebar integration builds snapshots from the same tree used by `dataSourceChildren(of:)` and applies all structural refreshes through `reloadWith` so the view snapshot never drifts from the actual outline state.
+
+**Tech Stack:** Swift, AppKit `NSOutlineView`, `CollectionDifference`, XCTest, `PhiBrowser-canary` Xcode scheme.
+
+---
+
+## File Structure
+
+- Create `Sources/UserInterface/Common/DiffableOutlineSnapshot.swift`
+  - Pure Swift tree snapshot, validation, lookup, subtree helpers, and explicit reload markers.
+- Create `Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift`
+  - Pure Swift planner that uses `CollectionDifference` per sibling list and emits safe outline operations.
+- Create `Sources/UserInterface/Common/DiffableOutlineView.swift`
+  - `NSOutlineView` subclass that stores the current snapshot, enforces apply timing, and calls AppKit mutation APIs through overridable hooks for tests.
+- Modify `Sources/UserInterface/Sidebar/TabList/Views/SideBarOutlineView.swift`
+  - Change inheritance from `NSOutlineView` to `DiffableOutlineView`.
+- Create `Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift`
+  - Pure sidebar snapshot builder that accepts root `SidebarItem` values plus optional virtual insertion and hidden item state.
+- Modify `Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift`
+  - Build sidebar snapshots, route structural refreshes through `reloadWith`, and keep existing delegate/data-source ownership.
+- Modify `Phi.xcodeproj/project.pbxproj`
+  - Register the three new Common Swift files and the sidebar snapshot builder in the app target.
+- Create `Tests/PhiBrowserTests/DiffableOutlineSnapshotTests.swift`
+  - Snapshot validation and lookup tests.
+- Create `Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift`
+  - Planner tests for insert/delete/move/replace/order/fallback behavior.
+- Create `Tests/PhiBrowserTests/DiffableOutlineViewTests.swift`
+  - Apply timing and mutation sequencing tests using a recording subclass.
+- Create `Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift`
+  - Focused tests for sidebar snapshot IDs, child ordering, hidden item filtering, and virtual focused-item insertion.
+
+---
+
+### Task 1: Add Snapshot Model
+
+**Files:**
+- Create: `Sources/UserInterface/Common/DiffableOutlineSnapshot.swift`
+- Create: `Tests/PhiBrowserTests/DiffableOutlineSnapshotTests.swift`
+- Modify: `Phi.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing snapshot tests**
+
+Create `Tests/PhiBrowserTests/DiffableOutlineSnapshotTests.swift`:
+
+```swift
+import XCTest
+@testable import Phi
+
+private final class DiffableOutlineTestItem: NSObject {
+    let name: String
+
+    init(_ name: String) {
+        self.name = name
+        super.init()
+    }
+}
+
+final class DiffableOutlineSnapshotTests: XCTestCase {
+    func testValidSnapshotPreservesRootAndChildOrder() {
+        let folder = DiffableOutlineTestItem("folder")
+        let childA = DiffableOutlineTestItem("child-a")
+        let childB = DiffableOutlineTestItem("child-b")
+
+        let snapshot = DiffableOutlineSnapshot(
+            rootIDs: ["folder"],
+            nodes: [
+                "folder": .init(id: "folder", item: folder, parentID: nil, childIDs: ["child-a", "child-b"]),
+                "child-a": .init(id: "child-a", item: childA, parentID: "folder", childIDs: []),
+                "child-b": .init(id: "child-b", item: childB, parentID: "folder", childIDs: []),
+            ]
+        )
+
+        XCTAssertNil(snapshot.validationError)
+        XCTAssertEqual(snapshot.rootIDs, ["folder"])
+        XCTAssertEqual(snapshot.childIDs(of: "folder"), ["child-a", "child-b"])
+        XCTAssertEqual(snapshot.parentID(of: "child-a"), "folder")
+        XCTAssertEqual(snapshot.index(of: "child-b"), 1)
+        XCTAssertTrue(snapshot.item(for: "folder") === folder)
+    }
+
+    func testDuplicateChildReferenceFailsValidation() {
+        let parent = DiffableOutlineTestItem("parent")
+        let child = DiffableOutlineTestItem("child")
+
+        let snapshot = DiffableOutlineSnapshot(
+            rootIDs: ["parent"],
+            nodes: [
+                "parent": .init(id: "parent", item: parent, parentID: nil, childIDs: ["child", "child"]),
+                "child": .init(id: "child", item: child, parentID: "parent", childIDs: []),
+            ]
+        )
+
+        XCTAssertEqual(snapshot.validationError, .duplicateChildID("child"))
+    }
+
+    func testMissingParentFailsValidation() {
+        let child = DiffableOutlineTestItem("child")
+
+        let snapshot = DiffableOutlineSnapshot(
+            rootIDs: [],
+            nodes: [
+                "child": .init(id: "child", item: child, parentID: "missing", childIDs: []),
+            ]
+        )
+
+        XCTAssertEqual(snapshot.validationError, .missingParent(id: "child", parentID: "missing"))
+    }
+
+    func testCycleFailsValidation() {
+        let a = DiffableOutlineTestItem("a")
+        let b = DiffableOutlineTestItem("b")
+
+        let snapshot = DiffableOutlineSnapshot(
+            rootIDs: [],
+            nodes: [
+                "a": .init(id: "a", item: a, parentID: "b", childIDs: ["b"]),
+                "b": .init(id: "b", item: b, parentID: "a", childIDs: ["a"]),
+            ]
+        )
+
+        XCTAssertEqual(snapshot.validationError, .cycleDetected("a"))
+    }
+
+    func testSameIDCanUseDifferentItemInstanceAcrossSnapshots() {
+        let first = DiffableOutlineTestItem("first")
+        let second = DiffableOutlineTestItem("second")
+
+        let old = DiffableOutlineSnapshot(
+            rootIDs: ["item"],
+            nodes: ["item": .init(id: "item", item: first, parentID: nil, childIDs: [])]
+        )
+        let new = DiffableOutlineSnapshot(
+            rootIDs: ["item"],
+            nodes: ["item": .init(id: "item", item: second, parentID: nil, childIDs: [])]
+        )
+
+        XCTAssertNil(old.validationError)
+        XCTAssertNil(new.validationError)
+        XCTAssertFalse(old.item(for: "item") === new.item(for: "item"))
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineSnapshotTests
+```
+
+Expected: FAIL to compile with `Cannot find 'DiffableOutlineSnapshot' in scope`.
+
+- [ ] **Step 3: Create snapshot implementation**
+
+Create `Sources/UserInterface/Common/DiffableOutlineSnapshot.swift`:
+
+```swift
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+
+struct DiffableOutlineSnapshot<ItemID: Hashable> {
+    struct Node {
+        let id: ItemID
+        let item: AnyObject
+        let parentID: ItemID?
+        let childIDs: [ItemID]
+    }
+
+    let rootIDs: [ItemID]
+    let nodes: [ItemID: Node]
+    let reloadIDs: Set<ItemID>
+
+    init(rootIDs: [ItemID], nodes: [ItemID: Node], reloadIDs: Set<ItemID> = []) {
+        self.rootIDs = rootIDs
+        self.nodes = nodes
+        self.reloadIDs = reloadIDs
+    }
+
+    var validationError: DiffableOutlineSnapshotValidationError<ItemID>? {
+        validate()
+    }
+
+    func item(for id: ItemID) -> AnyObject? {
+        nodes[id]?.item
+    }
+
+    func parentID(of id: ItemID) -> ItemID? {
+        nodes[id]?.parentID
+    }
+
+    func childIDs(of parentID: ItemID?) -> [ItemID] {
+        guard let parentID else { return rootIDs }
+        return nodes[parentID]?.childIDs ?? []
+    }
+
+    func index(of id: ItemID) -> Int? {
+        childIDs(of: parentID(of: id)).firstIndex(of: id)
+    }
+
+    func contains(_ id: ItemID) -> Bool {
+        nodes[id] != nil
+    }
+
+    func depth(of id: ItemID) -> Int {
+        var depth = 0
+        var current = parentID(of: id)
+        while let parent = current {
+            depth += 1
+            current = parentID(of: parent)
+        }
+        return depth
+    }
+
+    func descendants(of id: ItemID) -> [ItemID] {
+        var result: [ItemID] = []
+        func walk(_ current: ItemID) {
+            for child in childIDs(of: current) {
+                result.append(child)
+                walk(child)
+            }
+        }
+        walk(id)
+        return result
+    }
+
+    func hasAncestor(of id: ItemID, in ids: Set<ItemID>) -> Bool {
+        var current = parentID(of: id)
+        while let parent = current {
+            if ids.contains(parent) { return true }
+            current = parentID(of: parent)
+        }
+        return false
+    }
+
+    private func validate() -> DiffableOutlineSnapshotValidationError<ItemID>? {
+        var referencedIDs = Set<ItemID>()
+
+        for rootID in rootIDs {
+            guard nodes[rootID] != nil else { return .missingRoot(rootID) }
+            if !referencedIDs.insert(rootID).inserted { return .duplicateChildID(rootID) }
+            if nodes[rootID]?.parentID != nil { return .rootHasParent(rootID) }
+        }
+
+        for (id, node) in nodes {
+            guard node.id == id else { return .nodeKeyMismatch(key: id, nodeID: node.id) }
+            if let parentID = node.parentID, nodes[parentID] == nil {
+                return .missingParent(id: id, parentID: parentID)
+            }
+            for childID in node.childIDs {
+                guard let child = nodes[childID] else { return .missingChild(id: id, childID: childID) }
+                if child.parentID != id { return .parentMismatch(id: childID, expectedParentID: id, actualParentID: child.parentID) }
+                if !referencedIDs.insert(childID).inserted { return .duplicateChildID(childID) }
+            }
+        }
+
+        for id in nodes.keys where !referencedIDs.contains(id) {
+            if detectsCycle(startingAt: id) { return .cycleDetected(id) }
+            if nodes[id]?.parentID == nil { return .unreachableNode(id) }
+        }
+
+        for id in nodes.keys {
+            if detectsCycle(startingAt: id) { return .cycleDetected(id) }
+        }
+
+        if let missingReloadID = reloadIDs.first(where: { nodes[$0] == nil }) {
+            return .missingReloadID(missingReloadID)
+        }
+
+        return nil
+    }
+
+    private func detectsCycle(startingAt id: ItemID) -> Bool {
+        var seen = Set<ItemID>()
+        var current: ItemID? = id
+        while let next = current {
+            if !seen.insert(next).inserted { return true }
+            current = parentID(of: next)
+        }
+        return false
+    }
+}
+
+enum DiffableOutlineSnapshotValidationError<ItemID: Hashable>: Error, Equatable {
+    case missingRoot(ItemID)
+    case rootHasParent(ItemID)
+    case missingParent(id: ItemID, parentID: ItemID)
+    case missingChild(id: ItemID, childID: ItemID)
+    case parentMismatch(id: ItemID, expectedParentID: ItemID, actualParentID: ItemID?)
+    case duplicateChildID(ItemID)
+    case nodeKeyMismatch(key: ItemID, nodeID: ItemID)
+    case unreachableNode(ItemID)
+    case cycleDetected(ItemID)
+    case missingReloadID(ItemID)
+}
+```
+
+- [ ] **Step 4: Register snapshot source file in Xcode project**
+
+Modify `Phi.xcodeproj/project.pbxproj`:
+
+```pbxproj
+D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */; };
+D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineSnapshot.swift; sourceTree = "<group>"; };
+```
+
+Add `D1F600012FD6000000000001 /* DiffableOutlineSnapshot.swift */` to the `Common` group after `TabAreaContextMenuHelper.swift`.
+
+Add `D1F600022FD6000000000002 /* DiffableOutlineSnapshot.swift in Sources */` to the app target `PBXSourcesBuildPhase` near `SideBarOutlineView.swift in Sources`.
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineSnapshotTests
+```
+
+Expected: PASS for `DiffableOutlineSnapshotTests`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/UserInterface/Common/DiffableOutlineSnapshot.swift Tests/PhiBrowserTests/DiffableOutlineSnapshotTests.swift Phi.xcodeproj/project.pbxproj
+git commit -m "feat: add diffable outline snapshot model"
+```
+
+---
+
+### Task 2: Add Planner for Inserts, Deletes, and Subtrees
+
+**Files:**
+- Create: `Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift`
+- Create: `Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift`
+- Modify: `Phi.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing planner tests for structural insert/delete**
+
+Create `Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift`:
+
+```swift
+import XCTest
+@testable import Phi
+
+private final class PlannerItem: NSObject {
+    let name: String
+
+    init(_ name: String) {
+        self.name = name
+        super.init()
+    }
+}
+
+private func item(_ id: String) -> PlannerItem {
+    PlannerItem(id)
+}
+
+private func snapshot(_ roots: [String], _ nodes: [String: (String?, [String])]) -> DiffableOutlineSnapshot<String> {
+    var snapshotNodes: [String: DiffableOutlineSnapshot<String>.Node] = [:]
+    for (id, value) in nodes {
+        snapshotNodes[id] = .init(id: id, item: item(id), parentID: value.0, childIDs: value.1)
+    }
+    return DiffableOutlineSnapshot(rootIDs: roots, nodes: snapshotNodes)
+}
+
+final class DiffableOutlineDiffPlannerTests: XCTestCase {
+    func testRootInsertProducesInsertOperation() {
+        let old = snapshot(["a"], ["a": (nil, [])])
+        let new = snapshot(["a", "b"], ["a": (nil, []), "b": (nil, [])])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.insert(id: "b", parentID: nil, index: 1)])
+        XCTAssertTrue(plan.isSafe)
+    }
+
+    func testChildDeleteProducesRemoveOperationAtOldIndex() {
+        let old = snapshot(["folder"], [
+            "folder": (nil, ["a", "b"]),
+            "a": ("folder", []),
+            "b": ("folder", []),
+        ])
+        let new = snapshot(["folder"], [
+            "folder": (nil, ["a"]),
+            "a": ("folder", []),
+        ])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.remove(id: "b", parentID: "folder", index: 1)])
+    }
+
+    func testSubtreeDeleteOnlyRemovesHighestDeletedNode() {
+        let old = snapshot(["folder"], [
+            "folder": (nil, ["child"]),
+            "child": ("folder", ["grandchild"]),
+            "grandchild": ("child", []),
+        ])
+        let new = DiffableOutlineSnapshot<String>(rootIDs: [], nodes: [:])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.remove(id: "folder", parentID: nil, index: 0)])
+    }
+
+    func testSubtreeInsertOnlyInsertsHighestInsertedNode() {
+        let old = DiffableOutlineSnapshot<String>(rootIDs: [], nodes: [:])
+        let new = snapshot(["folder"], [
+            "folder": (nil, ["child"]),
+            "child": ("folder", ["grandchild"]),
+            "grandchild": ("child", []),
+        ])
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+        XCTAssertEqual(plan.operations, [.insert(id: "folder", parentID: nil, index: 0)])
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineDiffPlannerTests
+```
+
+Expected: FAIL to compile with `Cannot find 'DiffableOutlineDiffPlanner' in scope`.
+
+- [ ] **Step 3: Create minimal planner implementation**
+
+Create `Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift`:
+
+```swift
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+
+enum DiffableOutlineOperation<ItemID: Hashable>: Equatable {
+    case remove(id: ItemID, parentID: ItemID?, index: Int)
+    case move(id: ItemID, parentID: ItemID?, from: Int, to: Int)
+    case insert(id: ItemID, parentID: ItemID?, index: Int)
+    case replace(id: ItemID, parentID: ItemID?, index: Int)
+    case reload(id: ItemID)
+}
+
+struct DiffableOutlinePlan<ItemID: Hashable> {
+    let operations: [DiffableOutlineOperation<ItemID>]
+    let isSafe: Bool
+
+    static var unsafe: DiffableOutlinePlan {
+        DiffableOutlinePlan(operations: [], isSafe: false)
+    }
+}
+
+enum DiffableOutlineDiffPlanner {
+    static func plan<ItemID: Hashable>(
+        from old: DiffableOutlineSnapshot<ItemID>,
+        to new: DiffableOutlineSnapshot<ItemID>
+    ) -> DiffableOutlinePlan<ItemID> {
+        guard old.validationError == nil, new.validationError == nil else {
+            return .unsafe
+        }
+
+        let oldIDs = Set(old.nodes.keys)
+        let newIDs = Set(new.nodes.keys)
+        let removedIDs = oldIDs.subtracting(newIDs)
+        let insertedIDs = newIDs.subtracting(oldIDs)
+
+        let highestRemoved = removedIDs.filter { !old.hasAncestor(of: $0, in: removedIDs) }
+        let highestInserted = insertedIDs.filter { !new.hasAncestor(of: $0, in: insertedIDs) }
+
+        func removeSortKey(_ operation: DiffableOutlineOperation<ItemID>) -> (depth: Int, parent: String, index: Int) {
+            guard case .remove(let id, let parentID, let index) = operation else {
+                return (0, "", 0)
+            }
+            return (old.depth(of: id), String(describing: parentID), index)
+        }
+
+        func insertSortKey(_ operation: DiffableOutlineOperation<ItemID>) -> (depth: Int, parent: String, index: Int) {
+            guard case .insert(let id, let parentID, let index) = operation else {
+                return (0, "", 0)
+            }
+            return (new.depth(of: id), String(describing: parentID), index)
+        }
+
+        let removes = highestRemoved
+            .compactMap { id -> DiffableOutlineOperation<ItemID>? in
+                guard let index = old.index(of: id) else { return nil }
+                return .remove(id: id, parentID: old.parentID(of: id), index: index)
+            }
+            .sorted { lhs, rhs in
+                let left = removeSortKey(lhs)
+                let right = removeSortKey(rhs)
+                if left.depth != right.depth { return left.depth > right.depth }
+                if left.parent != right.parent { return left.parent < right.parent }
+                return left.index > right.index
+            }
+
+        let inserts = highestInserted
+            .compactMap { id -> DiffableOutlineOperation<ItemID>? in
+                guard let index = new.index(of: id) else { return nil }
+                return .insert(id: id, parentID: new.parentID(of: id), index: index)
+            }
+            .sorted { lhs, rhs in
+                let left = insertSortKey(lhs)
+                let right = insertSortKey(rhs)
+                if left.depth != right.depth { return left.depth < right.depth }
+                if left.parent != right.parent { return left.parent < right.parent }
+                return left.index < right.index
+            }
+
+        return DiffableOutlinePlan(operations: removes + inserts, isSafe: true)
+    }
+}
+```
+
+- [ ] **Step 4: Register planner source file**
+
+Modify `Phi.xcodeproj/project.pbxproj`:
+
+```pbxproj
+D1F600042FD6000000000004 /* DiffableOutlineDiffPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */; };
+D1F600032FD6000000000003 /* DiffableOutlineDiffPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineDiffPlanner.swift; sourceTree = "<group>"; };
+```
+
+Add the file reference to the `Common` group after `DiffableOutlineSnapshot.swift`.
+
+Add the build file to the app target source phase near `DiffableOutlineSnapshot.swift in Sources`.
+
+- [ ] **Step 5: Run tests to verify GREEN**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineDiffPlannerTests
+```
+
+Expected: PASS for the four structural planner tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift Phi.xcodeproj/project.pbxproj
+git commit -m "feat: plan diffable outline structural changes"
+```
+
+---
+
+### Task 3: Add Planner Moves, Replacements, Reloads, and Ordering
+
+**Files:**
+- Modify: `Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift`
+- Modify: `Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift`
+
+- [ ] **Step 1: Add failing tests for move, cross-parent move, replacement, reload, and invalid snapshots**
+
+Append to `DiffableOutlineDiffPlannerTests`:
+
+```swift
+func testSameParentReorderProducesMoveUsingCollectionDifference() {
+    let old = snapshot(["a", "b", "c"], ["a": (nil, []), "b": (nil, []), "c": (nil, [])])
+    let new = snapshot(["b", "a", "c"], ["a": (nil, []), "b": (nil, []), "c": (nil, [])])
+
+    let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+    XCTAssertEqual(plan.operations, [.move(id: "b", parentID: nil, from: 1, to: 0)])
+}
+
+func testCrossParentMoveUsesRemoveAndInsert() {
+    let old = snapshot(["left", "right"], [
+        "left": (nil, ["item"]),
+        "right": (nil, []),
+        "item": ("left", []),
+    ])
+    let new = snapshot(["left", "right"], [
+        "left": (nil, []),
+        "right": (nil, ["item"]),
+        "item": ("right", []),
+    ])
+
+    let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+    XCTAssertEqual(plan.operations, [
+        .remove(id: "item", parentID: "left", index: 0),
+        .insert(id: "item", parentID: "right", index: 0),
+    ])
+}
+
+func testIdentityReplacementUsesHighestChangedNode() {
+    let oldRoot = item("old-root")
+    let oldChild = item("old-child")
+    let newRoot = item("new-root")
+    let newChild = item("new-child")
+    let old = DiffableOutlineSnapshot(
+        rootIDs: ["root"],
+        nodes: [
+            "root": .init(id: "root", item: oldRoot, parentID: nil, childIDs: ["child"]),
+            "child": .init(id: "child", item: oldChild, parentID: "root", childIDs: []),
+        ]
+    )
+    let new = DiffableOutlineSnapshot(
+        rootIDs: ["root"],
+        nodes: [
+            "root": .init(id: "root", item: newRoot, parentID: nil, childIDs: ["child"]),
+            "child": .init(id: "child", item: newChild, parentID: "root", childIDs: []),
+        ]
+    )
+
+    let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+    XCTAssertEqual(plan.operations, [.replace(id: "root", parentID: nil, index: 0)])
+}
+
+func testExplicitReloadMarkerProducesReload() {
+    let base = ["a": (Optional<String>.none, [String]())]
+    let old = snapshot(["a"], base)
+    let new = DiffableOutlineSnapshot(
+        rootIDs: ["a"],
+        nodes: ["a": .init(id: "a", item: item("a"), parentID: nil, childIDs: [])],
+        reloadIDs: ["a"]
+    )
+
+    let plan = DiffableOutlineDiffPlanner.plan(from: old, to: new)
+
+    XCTAssertEqual(plan.operations, [.replace(id: "a", parentID: nil, index: 0), .reload(id: "a")])
+}
+
+func testInvalidSnapshotProducesUnsafePlan() {
+    let old = DiffableOutlineSnapshot<String>(rootIDs: [], nodes: [:])
+    let invalid = DiffableOutlineSnapshot(
+        rootIDs: ["missing"],
+        nodes: [:]
+    )
+
+    let plan = DiffableOutlineDiffPlanner.plan(from: old, to: invalid)
+
+    XCTAssertFalse(plan.isSafe)
+    XCTAssertTrue(plan.operations.isEmpty)
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineDiffPlannerTests
+```
+
+Expected: FAIL because move, replace, reload, and unsafe handling are not implemented.
+
+- [ ] **Step 3: Implement tree-aware move, replace, and reload planning**
+
+Update `DiffableOutlineDiffPlanner.plan(from:to:)` to:
+
+```swift
+let oldIDs = Set(old.nodes.keys)
+let newIDs = Set(new.nodes.keys)
+let removedIDs = oldIDs.subtracting(newIDs)
+let insertedIDs = newIDs.subtracting(oldIDs)
+let commonIDs = oldIDs.intersection(newIDs)
+let crossParentMovedIDs = Set(commonIDs.filter { old.parentID(of: $0) != new.parentID(of: $0) })
+
+let structuralRemovedIDs = removedIDs.union(crossParentMovedIDs)
+let structuralInsertedIDs = insertedIDs.union(crossParentMovedIDs)
+let highestRemoved = structuralRemovedIDs.filter { !old.hasAncestor(of: $0, in: structuralRemovedIDs) }
+let highestInserted = structuralInsertedIDs.filter { !new.hasAncestor(of: $0, in: structuralInsertedIDs) }
+```
+
+Add same-parent move planning using `CollectionDifference` as the sibling diff source:
+
+```swift
+private static func sameParentMoves<ItemID: Hashable>(
+    old: DiffableOutlineSnapshot<ItemID>,
+    new: DiffableOutlineSnapshot<ItemID>,
+    excludedIDs: Set<ItemID>
+) -> [DiffableOutlineOperation<ItemID>] {
+    let parentIDs = Set(old.nodes.keys.map { Optional($0) } + [nil])
+    var operations: [DiffableOutlineOperation<ItemID>] = []
+
+    for parentID in parentIDs {
+        let oldChildren = old.childIDs(of: parentID).filter { !excludedIDs.contains($0) && new.parentID(of: $0) == parentID }
+        let newChildren = new.childIDs(of: parentID).filter { !excludedIDs.contains($0) && old.parentID(of: $0) == parentID }
+        guard oldChildren != newChildren else { continue }
+
+        let difference = newChildren.difference(from: oldChildren).inferringMoves()
+        guard difference.containsAssociatedMove else { continue }
+
+        var working = oldChildren
+        for targetIndex in newChildren.indices {
+            let targetID = newChildren[targetIndex]
+            guard working.indices.contains(targetIndex), working[targetIndex] != targetID else { continue }
+            guard let fromIndex = working.firstIndex(of: targetID) else { continue }
+            working.remove(at: fromIndex)
+            working.insert(targetID, at: targetIndex)
+            operations.append(.move(id: targetID, parentID: parentID, from: fromIndex, to: targetIndex))
+        }
+    }
+
+    return operations
+}
+
+private extension CollectionDifference {
+    var containsAssociatedMove: Bool {
+        contains { change in
+            switch change {
+            case .insert(_, _, let associatedWith), .remove(_, _, let associatedWith):
+                return associatedWith != nil
+            }
+        }
+    }
+}
+```
+
+Add highest identity replacement planning:
+
+```swift
+private static func replacements<ItemID: Hashable>(
+    old: DiffableOutlineSnapshot<ItemID>,
+    new: DiffableOutlineSnapshot<ItemID>,
+    excludedIDs: Set<ItemID>
+) -> [DiffableOutlineOperation<ItemID>] {
+    func replacementSortKey(_ operation: DiffableOutlineOperation<ItemID>) -> (depth: Int, parent: String, index: Int) {
+        guard case .replace(let id, let parentID, let index) = operation else {
+            return (0, "", 0)
+        }
+        return (new.depth(of: id), String(describing: parentID), index)
+    }
+
+    let replacedIDs = Set(old.nodes.keys).intersection(new.nodes.keys).filter { id in
+        guard !excludedIDs.contains(id) else { return false }
+        guard let oldItem = old.item(for: id), let newItem = new.item(for: id) else { return false }
+        return oldItem !== newItem
+    }
+
+    let highestReplaced = replacedIDs.filter { !new.hasAncestor(of: $0, in: replacedIDs) }
+
+    return highestReplaced
+        .compactMap { id -> DiffableOutlineOperation<ItemID>? in
+            guard let index = new.index(of: id) else { return nil }
+            return .replace(id: id, parentID: new.parentID(of: id), index: index)
+        }
+        .sorted { lhs, rhs in
+            let left = replacementSortKey(lhs)
+            let right = replacementSortKey(rhs)
+            if left.depth != right.depth { return left.depth < right.depth }
+            if left.parent != right.parent { return left.parent < right.parent }
+            return left.index < right.index
+        }
+}
+```
+
+Add reload planning:
+
+```swift
+let reloads = new.reloadIDs
+    .filter { new.contains($0) }
+    .sorted { String(describing: $0) < String(describing: $1) }
+    .map { DiffableOutlineOperation.reload(id: $0) }
+```
+
+The final operation order is:
+
+```swift
+return DiffableOutlinePlan(
+    operations: removes + moves + inserts + replacements + reloads,
+    isSafe: true
+)
+```
+
+- [ ] **Step 4: Run planner tests**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineDiffPlannerTests
+```
+
+Expected: PASS for all planner tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift
+git commit -m "feat: plan diffable outline moves and replacements"
+```
+
+---
+
+### Task 4: Add DiffableOutlineView Apply Engine
+
+**Files:**
+- Create: `Sources/UserInterface/Common/DiffableOutlineView.swift`
+- Create: `Tests/PhiBrowserTests/DiffableOutlineViewTests.swift`
+- Modify: `Phi.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing apply-order tests**
+
+Create `Tests/PhiBrowserTests/DiffableOutlineViewTests.swift`:
+
+```swift
+import XCTest
+@testable import Phi
+
+private final class OutlineApplyItem: NSObject {
+    let id: String
+
+    init(_ id: String) {
+        self.id = id
+        super.init()
+    }
+}
+
+private final class RecordingDiffableOutlineView: DiffableOutlineView {
+    private(set) var events: [String] = []
+
+    override func reloadData() {
+        events.append("reloadData")
+    }
+
+    override func beginUpdates() {
+        events.append("beginUpdates")
+    }
+
+    override func endUpdates() {
+        events.append("endUpdates")
+    }
+
+    override func applyRemove(at indexes: IndexSet, inParent parent: Any?, animation: NSOutlineView.AnimationOptions) {
+        events.append("remove:\(Array(indexes)):\(parentID(parent))")
+    }
+
+    override func applyInsert(at indexes: IndexSet, inParent parent: Any?, animation: NSOutlineView.AnimationOptions) {
+        events.append("insert:\(Array(indexes)):\(parentID(parent))")
+    }
+
+    override func applyMove(from fromIndex: Int, inParent oldParent: Any?, to toIndex: Int, inParent newParent: Any?) {
+        events.append("move:\(fromIndex):\(parentID(oldParent))->\(toIndex):\(parentID(newParent))")
+    }
+
+    override func applyReload(rowIndexes: IndexSet) {
+        events.append("reloadRows:\(Array(rowIndexes))")
+    }
+
+    override func row(forItem item: Any) -> Int {
+        guard let item = item as? OutlineApplyItem else { return -1 }
+        return Int(item.id.filter(\.isNumber)) ?? 0
+    }
+
+    private func parentID(_ parent: Any?) -> String {
+        guard let parent = parent as? OutlineApplyItem else { return "root" }
+        return parent.id
+    }
+}
+
+private func applySnapshot(_ roots: [String], _ nodes: [String: (OutlineApplyItem, String?, [String])]) -> DiffableOutlineSnapshot<AnyHashable> {
+    var snapshotNodes: [AnyHashable: DiffableOutlineSnapshot<AnyHashable>.Node] = [:]
+    for (id, value) in nodes {
+        snapshotNodes[AnyHashable(id)] = .init(
+            id: AnyHashable(id),
+            item: value.0,
+            parentID: value.1.map(AnyHashable.init),
+            childIDs: value.2.map(AnyHashable.init)
+        )
+    }
+    return DiffableOutlineSnapshot(rootIDs: roots.map(AnyHashable.init), nodes: snapshotNodes)
+}
+
+final class DiffableOutlineViewTests: XCTestCase {
+    func testFirstSnapshotUpdatesDataSourceBeforeReloadData() {
+        let view = RecordingDiffableOutlineView()
+        let snapshot = applySnapshot(["item0"], ["item0": (OutlineApplyItem("item0"), nil, [])])
+
+        view.reloadWith(snapshot, animated: false) {
+            view.events.append("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, ["updateDataSource", "reloadData"])
+    }
+
+    func testInsertUpdatesDataSourceBeforeMutation() {
+        let view = RecordingDiffableOutlineView()
+        let old = applySnapshot(["item0"], ["item0": (OutlineApplyItem("item0"), nil, [])])
+        let new = applySnapshot(["item0", "item1"], [
+            "item0": (OutlineApplyItem("item0"), nil, []),
+            "item1": (OutlineApplyItem("item1"), nil, []),
+        ])
+        view.reloadWith(old, animated: false) { view.events.append("initialData") }
+        view.events.removeAll()
+
+        view.reloadWith(new, animated: false) {
+            view.events.append("updateDataSource")
+        }
+
+        XCTAssertEqual(view.events, ["updateDataSource", "beginUpdates", "insert:[1]:root", "endUpdates"])
+    }
+
+    func testInvalidSnapshotDoesNotUpdateDataSource() {
+        let view = RecordingDiffableOutlineView()
+        let invalid = DiffableOutlineSnapshot<AnyHashable>(rootIDs: [AnyHashable("missing")], nodes: [:])
+
+        view.reloadWith(invalid, animated: false) {
+            view.events.append("updateDataSource")
+        }
+
+        XCTAssertTrue(view.events.isEmpty)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify RED**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineViewTests
+```
+
+Expected: FAIL to compile with `Cannot find type 'DiffableOutlineView' in scope`.
+
+- [ ] **Step 3: Implement DiffableOutlineView**
+
+Create `Sources/UserInterface/Common/DiffableOutlineView.swift`:
+
+```swift
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import AppKit
+
+class DiffableOutlineView: NSOutlineView {
+    private var currentSnapshot: DiffableOutlineSnapshot<AnyHashable>?
+    private var isApplyingSnapshot = false
+
+    func reloadWith(
+        _ snapshot: DiffableOutlineSnapshot<AnyHashable>,
+        animated: Bool = true,
+        updateDataSource: @escaping () -> Void,
+        completion: (() -> Void)? = nil
+    ) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.reloadWith(snapshot, animated: animated, updateDataSource: updateDataSource, completion: completion)
+            }
+            return
+        }
+
+        guard !isApplyingSnapshot else {
+            DispatchQueue.main.async { [weak self] in
+                self?.reloadWith(snapshot, animated: animated, updateDataSource: updateDataSource, completion: completion)
+            }
+            return
+        }
+
+        guard snapshot.validationError == nil else {
+            completion?()
+            return
+        }
+
+        guard let oldSnapshot = currentSnapshot else {
+            updateDataSource()
+            reloadData()
+            currentSnapshot = snapshot
+            completion?()
+            return
+        }
+
+        let plan = DiffableOutlineDiffPlanner.plan(from: oldSnapshot, to: snapshot)
+        guard plan.isSafe else {
+            updateDataSource()
+            reloadData()
+            currentSnapshot = snapshot
+            completion?()
+            return
+        }
+
+        isApplyingSnapshot = true
+        updateDataSource()
+        beginUpdates()
+        apply(plan.operations, oldSnapshot: oldSnapshot, newSnapshot: snapshot, animated: animated)
+        endUpdates()
+        currentSnapshot = snapshot
+        isApplyingSnapshot = false
+
+        DispatchQueue.main.async {
+            completion?()
+        }
+    }
+
+    func applyRemove(at indexes: IndexSet, inParent parent: Any?, animation: NSOutlineView.AnimationOptions) {
+        removeItems(at: indexes, inParent: parent, withAnimation: animation)
+    }
+
+    func applyInsert(at indexes: IndexSet, inParent parent: Any?, animation: NSOutlineView.AnimationOptions) {
+        insertItems(at: indexes, inParent: parent, withAnimation: animation)
+    }
+
+    func applyMove(from fromIndex: Int, inParent oldParent: Any?, to toIndex: Int, inParent newParent: Any?) {
+        moveItem(at: fromIndex, inParent: oldParent, to: toIndex, inParent: newParent)
+    }
+
+    func applyReload(rowIndexes: IndexSet) {
+        guard rowIndexes.isEmpty == false else { return }
+        reloadData(forRowIndexes: rowIndexes, columnIndexes: IndexSet(integersIn: 0..<numberOfColumns))
+    }
+
+    private func apply(
+        _ operations: [DiffableOutlineOperation<AnyHashable>],
+        oldSnapshot: DiffableOutlineSnapshot<AnyHashable>,
+        newSnapshot: DiffableOutlineSnapshot<AnyHashable>,
+        animated: Bool
+    ) {
+        let animation: NSOutlineView.AnimationOptions = animated ? [.effectFade, .effectGap] : []
+
+        for operation in operations {
+            switch operation {
+            case .remove(let id, let parentID, let index):
+                applyRemove(at: IndexSet(integer: index), inParent: oldSnapshot.item(for: parentID), animation: animation)
+            case .move(_, let parentID, let from, let to):
+                let parent = oldSnapshot.item(for: parentID)
+                applyMove(from: from, inParent: parent, to: to, inParent: parent)
+            case .insert(_, let parentID, let index):
+                applyInsert(at: IndexSet(integer: index), inParent: newSnapshot.item(for: parentID), animation: animation)
+            case .replace(let id, let parentID, let index):
+                applyRemove(at: IndexSet(integer: index), inParent: oldSnapshot.item(for: parentID), animation: animation)
+                applyInsert(at: IndexSet(integer: index), inParent: newSnapshot.item(for: parentID), animation: animation)
+            case .reload(let id):
+                guard let item = newSnapshot.item(for: id) else { continue }
+                let row = row(forItem: item)
+                guard row >= 0 else { continue }
+                applyReload(rowIndexes: IndexSet(integer: row))
+            }
+        }
+    }
+}
+
+private extension DiffableOutlineSnapshot where ItemID == AnyHashable {
+    func item(for id: ItemID?) -> AnyObject? {
+        guard let id else { return nil }
+        return item(for: id)
+    }
+}
+```
+
+- [ ] **Step 4: Register view source file**
+
+Modify `Phi.xcodeproj/project.pbxproj`:
+
+```pbxproj
+D1F600062FD6000000000006 /* DiffableOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600052FD6000000000005 /* DiffableOutlineView.swift */; };
+D1F600052FD6000000000005 /* DiffableOutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiffableOutlineView.swift; sourceTree = "<group>"; };
+```
+
+Add the file reference to the `Common` group after `DiffableOutlineDiffPlanner.swift`.
+
+Add the build file to the app target source phase near `DiffableOutlineDiffPlanner.swift in Sources`.
+
+- [ ] **Step 5: Run view tests**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineViewTests
+```
+
+Expected: PASS for initial apply tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/UserInterface/Common/DiffableOutlineView.swift Tests/PhiBrowserTests/DiffableOutlineViewTests.swift Phi.xcodeproj/project.pbxproj
+git commit -m "feat: add diffable outline apply engine"
+```
+
+---
+
+### Task 5: Make SideBarOutlineView Inherit DiffableOutlineView
+
+**Files:**
+- Modify: `Sources/UserInterface/Sidebar/TabList/Views/SideBarOutlineView.swift`
+
+- [ ] **Step 1: Write failing inheritance test**
+
+Add to `DiffableOutlineViewTests`:
+
+```swift
+func testSideBarOutlineViewIsDiffableOutlineView() {
+    let outlineView = SideBarOutlineView()
+
+    XCTAssertTrue(outlineView is DiffableOutlineView)
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineViewTests/testSideBarOutlineViewIsDiffableOutlineView
+```
+
+Expected: FAIL because `SideBarOutlineView` still inherits directly from `NSOutlineView`.
+
+- [ ] **Step 3: Change inheritance**
+
+Update `Sources/UserInterface/Sidebar/TabList/Views/SideBarOutlineView.swift`:
+
+```swift
+class SideBarOutlineView: DiffableOutlineView {
+```
+
+Keep every existing override and property unchanged.
+
+- [ ] **Step 4: Run test to verify GREEN**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineViewTests/testSideBarOutlineViewIsDiffableOutlineView
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/UserInterface/Sidebar/TabList/Views/SideBarOutlineView.swift Tests/PhiBrowserTests/DiffableOutlineViewTests.swift
+git commit -m "feat: make sidebar outline view diffable"
+```
+
+---
+
+### Task 6: Add Sidebar Snapshot Builder
+
+**Files:**
+- Create: `Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift`
+- Modify: `Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift`
+- Create: `Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift`
+- Modify: `Phi.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Write failing snapshot builder tests**
+
+Create `Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift`:
+
+```swift
+import XCTest
+@testable import Phi
+
+private final class SnapshotSidebarItem: SidebarItem {
+    let id: AnyHashable
+    let title: String
+    let childrenItems: [SidebarItem]
+
+    init(id: String, title: String? = nil, children: [SidebarItem] = []) {
+        self.id = AnyHashable(id)
+        self.title = title ?? id
+        self.childrenItems = children
+    }
+
+    var url: String? { nil }
+    var iconName: String? { nil }
+    var faviconUrl: String? { nil }
+    var isExpandable: Bool { !childrenItems.isEmpty }
+    var hasChildren: Bool { !childrenItems.isEmpty }
+    var depth: Int { 0 }
+    var itemType: SidebarItemType { isExpandable ? .bookmarkFolder : .bookmark }
+    var isActive: Bool { false }
+    var isSelectable: Bool { true }
+    var isBookmark: Bool { true }
+
+    func performAction(with owner: SidebarTabListItemOwner?) {}
+}
+
+final class SidebarDiffableSnapshotTests: XCTestCase {
+    func testSidebarSnapshotUsesStableItemIDs() {
+        let child = SnapshotSidebarItem(id: "child")
+        let parent = SnapshotSidebarItem(id: "parent", children: [child])
+
+        let snapshot = SidebarDiffableSnapshotBuilder(rootItems: [parent]).makeSnapshot()
+
+        XCTAssertEqual(snapshot.rootIDs, [AnyHashable("parent")])
+        XCTAssertEqual(snapshot.childIDs(of: AnyHashable("parent")), [AnyHashable("child")])
+        XCTAssertTrue(snapshot.item(for: AnyHashable("parent")) === parent)
+        XCTAssertTrue(snapshot.item(for: AnyHashable("child")) === child)
+    }
+
+    func testSidebarSnapshotFiltersHiddenItem() {
+        let hidden = SnapshotSidebarItem(id: "hidden")
+        let visible = SnapshotSidebarItem(id: "visible")
+        let parent = SnapshotSidebarItem(id: "parent", children: [hidden, visible])
+
+        let snapshot = SidebarDiffableSnapshotBuilder(
+            rootItems: [parent],
+            hiddenItemID: AnyHashable("hidden")
+        ).makeSnapshot()
+
+        XCTAssertEqual(snapshot.childIDs(of: AnyHashable("parent")), [AnyHashable("visible")])
+        XCTAssertNil(snapshot.item(for: AnyHashable("hidden")))
+    }
+
+    func testSidebarSnapshotInsertsVirtualItemAtRoot() {
+        let first = SnapshotSidebarItem(id: "first")
+        let second = SnapshotSidebarItem(id: "second")
+        let virtual = SnapshotSidebarItem(id: "virtual")
+
+        let snapshot = SidebarDiffableSnapshotBuilder(
+            rootItems: [first, second],
+            virtualInsertion: .init(item: virtual, parentID: nil, index: 1)
+        ).makeSnapshot()
+
+        XCTAssertEqual(snapshot.rootIDs, [AnyHashable("first"), AnyHashable("virtual"), AnyHashable("second")])
+        XCTAssertTrue(snapshot.item(for: AnyHashable("virtual")) === virtual)
+    }
+
+    func testSidebarSnapshotInsertsVirtualItemInParent() {
+        let first = SnapshotSidebarItem(id: "first")
+        let second = SnapshotSidebarItem(id: "second")
+        let virtual = SnapshotSidebarItem(id: "virtual")
+        let parent = SnapshotSidebarItem(id: "parent", children: [first, second])
+
+        let snapshot = SidebarDiffableSnapshotBuilder(
+            rootItems: [parent],
+            virtualInsertion: .init(item: virtual, parentID: AnyHashable("parent"), index: 1)
+        ).makeSnapshot()
+
+        XCTAssertEqual(
+            snapshot.childIDs(of: AnyHashable("parent")),
+            [AnyHashable("first"), AnyHashable("virtual"), AnyHashable("second")]
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify RED**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/SidebarDiffableSnapshotTests
+```
+
+Expected: FAIL because `SidebarDiffableSnapshotBuilder` does not exist.
+
+- [ ] **Step 3: Implement sidebar snapshot builder**
+
+Create `Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift`:
+
+```swift
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+
+struct SidebarDiffableSnapshotBuilder {
+    struct VirtualInsertion {
+        let item: SidebarItem
+        let parentID: AnyHashable?
+        let index: Int
+    }
+
+    let rootItems: [SidebarItem]
+    var virtualInsertion: VirtualInsertion?
+    var hiddenItemID: AnyHashable?
+
+    init(
+        rootItems: [SidebarItem],
+        virtualInsertion: VirtualInsertion? = nil,
+        hiddenItemID: AnyHashable? = nil
+    ) {
+        self.rootItems = rootItems
+        self.virtualInsertion = virtualInsertion
+        self.hiddenItemID = hiddenItemID
+    }
+
+    func makeSnapshot() -> DiffableOutlineSnapshot<AnyHashable> {
+        var nodes: [AnyHashable: DiffableOutlineSnapshot<AnyHashable>.Node] = [:]
+        var visited = Set<AnyHashable>()
+
+        func append(_ item: SidebarItem, parentID: AnyHashable?) {
+            guard visited.insert(item.id).inserted else { return }
+            let children = children(of: item)
+            nodes[item.id] = .init(
+                id: item.id,
+                item: item as AnyObject,
+                parentID: parentID,
+                childIDs: children.map(\.id)
+            )
+            for child in children {
+                append(child, parentID: item.id)
+            }
+        }
+
+        let roots = children(of: nil)
+        for root in roots {
+            append(root, parentID: nil)
+        }
+
+        return DiffableOutlineSnapshot(rootIDs: roots.map(\.id), nodes: nodes)
+    }
+
+    private func children(of parent: SidebarItem?) -> [SidebarItem] {
+        var children = parent?.childrenItems ?? rootItems
+        if let hiddenItemID {
+            children.removeAll { $0.id == hiddenItemID }
+        }
+
+        guard let virtualInsertion,
+              virtualInsertion.parentID == parent?.id else {
+            return children
+        }
+
+        let index = min(max(0, virtualInsertion.index), children.count)
+        children.insert(virtualInsertion.item, at: index)
+        return children
+    }
+}
+```
+
+- [ ] **Step 4: Register sidebar snapshot builder**
+
+Modify `Phi.xcodeproj/project.pbxproj`:
+
+```pbxproj
+D1F600082FD6000000000008 /* SidebarDiffableSnapshotBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F600072FD6000000000007 /* SidebarDiffableSnapshotBuilder.swift */; };
+D1F600072FD6000000000007 /* SidebarDiffableSnapshotBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarDiffableSnapshotBuilder.swift; sourceTree = "<group>"; };
+```
+
+Add the file reference to the `TabList` group after `SidebarItem.swift`.
+
+Add the build file to the app target source phase near `SidebarTabListViewController.swift in Sources`.
+
+- [ ] **Step 5: Run builder tests to verify GREEN**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/SidebarDiffableSnapshotTests
+```
+
+Expected: PASS for `SidebarDiffableSnapshotTests`.
+
+- [ ] **Step 6: Add makeAllItems helper in the controller**
+
+In `SidebarTabListViewController.swift`, extract the item assembly from `refreshAllItems()`:
+
+```swift
+private func makeAllItems() -> [SidebarItem] {
+    var items: [SidebarItem] = []
+
+    if showBookmarks {
+        items.append(contentsOf: bookmarkSectionController.bookmarkItems)
+        if !bookmarkSectionController.bookmarkItems.isEmpty && !tabSectionController.tabItems.isEmpty {
+            items.append(separatorItem)
+        }
+    }
+
+    items.append(contentsOf: tabSectionController.tabItems)
+    return items
+}
+```
+
+- [ ] **Step 7: Add controller snapshot adapter**
+
+Add:
+
+```swift
+private func makeDiffableSnapshot(
+    rootItems: [SidebarItem],
+    focusedPresentation: (
+        proxy: FocusedBookmarkSidebarItem,
+        insertionParent: SidebarItem?,
+        insertionIndex: Int
+    )?
+) -> DiffableOutlineSnapshot<AnyHashable> {
+    let virtualInsertion: SidebarDiffableSnapshotBuilder.VirtualInsertion?
+    if let focusedPresentation {
+        virtualInsertion = .init(
+            item: focusedPresentation.proxy,
+            parentID: focusedPresentation.insertionParent?.id,
+            index: focusedPresentation.insertionIndex
+        )
+    } else {
+        virtualInsertion = nil
+    }
+
+    return SidebarDiffableSnapshotBuilder(
+        rootItems: rootItems,
+        virtualInsertion: virtualInsertion,
+        hiddenItemID: temporarilyHiddenRealBookmarkGuid.map(AnyHashable.init)
+    ).makeSnapshot()
+}
+```
+
+- [ ] **Step 8: Run tests**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/SidebarDiffableSnapshotTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift Phi.xcodeproj/project.pbxproj
+git commit -m "feat: build diffable snapshots for sidebar outline"
+```
+
+---
+
+### Task 7: Route Sidebar Structural Refreshes Through reloadWith
+
+**Files:**
+- Modify: `Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift`
+
+- [ ] **Step 1: Re-run existing diffable tests before wiring**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineSnapshotTests -only-testing:PhiBrowserTests/DiffableOutlineDiffPlannerTests -only-testing:PhiBrowserTests/DiffableOutlineViewTests -only-testing:PhiBrowserTests/SidebarDiffableSnapshotTests
+```
+
+Expected: PASS. This confirms the tested units that the controller wiring will call.
+
+- [ ] **Step 2: Replace refreshAllItems with diffable apply**
+
+Update `refreshAllItems()`:
+
+```swift
+private func refreshAllItems(animated: Bool = true) {
+    guard isActive else { return }
+
+    let items = makeAllItems()
+    let oldPresentation = focusedBookmarkPresentation
+    self.allItems = items
+    rebuildFloatingBookmarkPresentationIfNeeded()
+    let plannedPresentation = focusedBookmarkPresentation
+    focusedBookmarkPresentation = oldPresentation
+
+    let snapshot = makeDiffableSnapshot(rootItems: items, focusedPresentation: plannedPresentation)
+
+    outlineView.reloadWith(snapshot, animated: animated) { [weak self] in
+        guard let self else { return }
+        self.allItems = items
+        self.focusedBookmarkPresentation = plannedPresentation
+        self.invalidateExistingTabCells()
+    } completion: { [weak self] in
+        guard let self else { return }
+        self.selectActiveTab()
+        self.applyFocusingSelection(for: self.browserState.focusingTab)
+        self.updateVisibleBookmarkTabs()
+        self.updateFloatingNewTabVisibility()
+    }
+}
+```
+
+- [ ] **Step 3: Update activation and inactive clearing**
+
+Keep `clearInactiveUIState()` using `outlineView.reloadData()` because it intentionally clears state while inactive. Use `refreshAllItems(animated: false)` for first activation if animations are visually noisy:
+
+```swift
+refreshAllItems(animated: false)
+```
+
+- [ ] **Step 4: Remove or bypass manual tab incremental updater**
+
+Update `tabSectionDidUpdate(with:)`:
+
+```swift
+func tabSectionDidUpdate(with change: TabSectionChange) {
+    guard isActive else { return }
+    refreshAllItems(animated: !change.needsFullReload)
+    clearFloatingProxyIfTabClosed()
+}
+```
+
+Leave `TabSectionChange` in place for now so `TabSectionController` stays small and existing semantics are not mixed into this task. Remove `applyIncrementalTabChange(_:)` only after verifying no callers remain.
+
+- [ ] **Step 5: Keep selection and visible bookmark timing in completion**
+
+Ensure no direct selection/scroll call runs between `updateDataSource` and `endUpdates`. The only post-apply work should live in the `completion` block or existing expansion callbacks.
+
+- [ ] **Step 6: Run targeted tests**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineSnapshotTests -only-testing:PhiBrowserTests/DiffableOutlineDiffPlannerTests -only-testing:PhiBrowserTests/DiffableOutlineViewTests -only-testing:PhiBrowserTests/SidebarDiffableSnapshotTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Build for testing**
+
+Run:
+
+```bash
+xcodebuild build-for-testing -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS'
+```
+
+Expected: build succeeds. If this hits a known runner/bootstrap/codesign issue unrelated to source, retry with a fresh derived data path:
+
+```bash
+xcodebuild build-for-testing -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -derivedDataPath build/DerivedData-DiffableOutline
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
+git commit -m "feat: apply sidebar outline updates with diffable snapshots"
+```
+
+---
+
+### Task 8: Polish Safety Fallbacks and Final Verification
+
+**Files:**
+- Modify only the files touched by Tasks 1-7 when a verified edge case requires it:
+  - `Sources/UserInterface/Common/DiffableOutlineSnapshot.swift`
+  - `Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift`
+  - `Sources/UserInterface/Common/DiffableOutlineView.swift`
+  - `Sources/UserInterface/Sidebar/TabList/SidebarDiffableSnapshotBuilder.swift`
+  - `Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift`
+  - `Tests/PhiBrowserTests/DiffableOutlineSnapshotTests.swift`
+  - `Tests/PhiBrowserTests/DiffableOutlineDiffPlannerTests.swift`
+  - `Tests/PhiBrowserTests/DiffableOutlineViewTests.swift`
+  - `Tests/PhiBrowserTests/SidebarDiffableSnapshotTests.swift`
+
+- [ ] **Step 1: Add any regression test for a discovered edge case**
+
+If implementation uncovered an edge case, write a failing test first. Common examples:
+
+```swift
+func testReentrantReloadSchedulesLatestSnapshot() {
+    let view = RecordingDiffableOutlineView()
+    // Trigger reloadWith while updateDataSource is executing.
+    // Assert the second apply runs after the first apply completes.
+}
+```
+
+or:
+
+```swift
+func testReplacementUnderRemovedAncestorDoesNotEmitChildReplacement() {
+    // Old parent and child removed, child object also changed.
+    // Assert only parent remove is emitted.
+}
+```
+
+- [ ] **Step 2: Implement the minimal safety fix**
+
+Keep fixes inside the files listed for this task. Do not move sidebar ownership into the diffable view.
+
+- [ ] **Step 3: Run all new diffable outline tests**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/DiffableOutlineSnapshotTests -only-testing:PhiBrowserTests/DiffableOutlineDiffPlannerTests -only-testing:PhiBrowserTests/DiffableOutlineViewTests -only-testing:PhiBrowserTests/SidebarDiffableSnapshotTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run nearby sidebar test**
+
+Run:
+
+```bash
+xcodebuild test -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS' -only-testing:PhiBrowserTests/SidebarNewTabStickyResolverTests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Build for testing**
+
+Run:
+
+```bash
+xcodebuild build-for-testing -project Phi.xcodeproj -scheme PhiBrowser-canary -destination 'platform=macOS'
+```
+
+Expected: build succeeds, or a clearly unrelated local test-host/bootstrap issue is documented with the exact failure lines.
+
+- [ ] **Step 6: Final status check**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only intentional files are modified before the final commit.
+
+- [ ] **Step 7: Commit final polish**
+
+If Task 8 changed files:
+
+```bash
+git add Sources/UserInterface/Common/DiffableOutlineSnapshot.swift Sources/UserInterface/Common/DiffableOutlineDiffPlanner.swift Sources/UserInterface/Common/DiffableOutlineView.swift Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift Tests/PhiBrowserTests
+git commit -m "fix: harden diffable outline update sequencing"
+```
+
+If Task 8 only verified existing commits, do not create an empty commit.

--- a/docs/superpowers/specs/2026-06-16-diffable-outline-view-design.md
+++ b/docs/superpowers/specs/2026-06-16-diffable-outline-view-design.md
@@ -97,7 +97,7 @@ The planner wraps `CollectionDifference` with tree semantics:
 - Cross-parent movement of the same ID becomes `remove` from the old parent plus `insert` into the new parent.
 - Deleting a subtree emits only the highest removed node; descendants are removed by AppKit as part of that subtree.
 - Inserting a subtree emits only the highest inserted node; descendants are supplied by the updated data source.
-- Replaced payload objects for an existing ID produce a reload/reconfigure operation after structural mutations.
+- Replaced payload objects for an existing ID produce a local identity replacement unless an ancestor is already being removed or inserted. `NSOutlineView` tracks concrete item objects internally, so a stable ID alone is not enough to make an unchanged row point at a reconstructed model object.
 
 The operation model should be explicit:
 
@@ -106,6 +106,7 @@ enum DiffableOutlineOperation<ItemID: Hashable> {
     case remove(id: ItemID, parentID: ItemID?, index: Int)
     case move(id: ItemID, parentID: ItemID?, from: Int, to: Int)
     case insert(id: ItemID, parentID: ItemID?, index: Int)
+    case replace(id: ItemID, parentID: ItemID?, index: Int)
     case reload(id: ItemID)
 }
 ```
@@ -115,7 +116,8 @@ Operation order must be deterministic:
 1. Remove operations, deepest first, higher indexes before lower indexes within the same parent.
 2. Same-parent move operations.
 3. Insert operations, shallowest first, lower indexes before higher indexes within the same parent.
-4. Reload operations for visible existing IDs whose payload object changed.
+4. Replace operations for visible existing IDs whose payload object changed and whose ancestors are not already structurally replaced.
+5. Reload operations for existing IDs explicitly marked for visual reconfiguration without identity replacement.
 
 If snapshot validation fails, `DiffableOutlineView` must not call `updateDataSource()` and must not mutate the outline view. If both snapshots are valid but the planner cannot produce a safe operation sequence, `DiffableOutlineView` must fall back to `updateDataSource()` plus `reloadData()`.
 
@@ -132,7 +134,7 @@ If snapshot validation fails, `DiffableOutlineView` must not call `updateDataSou
 7. If the plan is unsafe, call `updateDataSource()`, `reloadData()`, store the new snapshot, then call completion.
 8. For a safe plan, call `updateDataSource()` before any outline mutation.
 9. Call `beginUpdates()`.
-10. Apply remove, move, insert, and reload operations.
+10. Apply remove, move, insert, replace, and reload operations.
 11. Call `endUpdates()`.
 12. Store the new snapshot.
 13. Run completion on the next main run loop so selection, scrolling, and visible-item bookkeeping happen after AppKit has processed the structural update.
@@ -148,7 +150,7 @@ The key rule is that the external backing data source switches to the new tree a
 - Same-parent moves can use the old parent object when the parent object is still recognized by the outline view.
 - If the needed parent object cannot be resolved safely, fall back to `reloadData()`.
 
-The first sidebar integration should prefer stable parent objects where possible, but reconstructed bookmark objects are valid as long as the data source and snapshot agree before insert/reload queries happen.
+The first sidebar integration should prefer stable parent objects where possible. Reconstructed bookmark objects are valid only when the plan includes local replacements for the highest changed objects, because unchanged rows otherwise remain associated with the old objects inside `NSOutlineView`.
 
 ## Sidebar Integration
 
@@ -203,6 +205,7 @@ The implementation must prioritize crash resistance:
 - Mutations are wrapped in a single `beginUpdates()` / `endUpdates()` pair.
 - No nested `reloadWith` should run while another apply is active; a reentrant call should queue the latest snapshot or fall back to reload after the current apply finishes.
 - The first version should not animate cross-parent moves as `moveItem`.
+- Existing IDs whose item objects changed should be locally replaced at the highest affected node, not merely reloaded by row.
 - If an item involved in a structural operation is expanded or collapsed mid-apply, the apply should avoid extra expansion mutations and let the existing delegate behavior own expansion state.
 - Fallback reload is acceptable when preserving safety is more important than animation.
 
@@ -235,8 +238,9 @@ Cover:
 - cross-parent move produces `remove` plus `insert`
 - subtree insert emits only the inserted subtree root
 - subtree delete emits only the deleted subtree root
+- object identity replacement emits only the highest replaced node
 - mixed remove/move/insert operations have deterministic order
-- payload replacement produces reload after structural operations
+- explicit reload markers produce reload after structural operations
 - invalid snapshot fails validation before planning
 
 ### View Apply Tests
@@ -249,6 +253,7 @@ Use a test double subclass that records calls to `reloadData`, `beginUpdates`, `
 - insert uses new parent and new index
 - same-parent reorder calls `moveItem`
 - cross-parent move calls remove and insert
+- object identity replacement calls remove and insert at the same parent/index
 - invalid snapshot does not call `updateDataSource`
 - unsafe valid plan falls back to `reloadData`
 - completion runs after apply

--- a/docs/superpowers/specs/2026-06-16-diffable-outline-view-design.md
+++ b/docs/superpowers/specs/2026-06-16-diffable-outline-view-design.md
@@ -1,0 +1,266 @@
+# Diffable Outline View Design
+
+## Context
+
+`SidebarTabListViewController` currently has two refresh paths for the sidebar outline view:
+
+- Normal tab changes can be applied incrementally with root-level `insertItems`, `removeItems`, and `moveItem`.
+- Bookmark changes rebuild `allItems` and call `reloadData()`, which churns visible bookmark cells and can interrupt interaction state such as inline editing, hover state, selection, and focus presentation.
+
+The sidebar is too complex to migrate directly to a standard diffable data source. Cell creation, selection, drag and drop, context menus, expansion behavior, focused bookmark proxy presentation, and visible bookmark bookkeeping should remain owned by the existing controller and delegate/data source methods.
+
+This design adds a reusable `DiffableOutlineView` that applies tree snapshots with minimal structural mutations while leaving business behavior in the current owner.
+
+## Goals
+
+- Add a reusable `DiffableOutlineView: NSOutlineView` that can apply tree snapshots with incremental outline mutations.
+- Keep `NSOutlineViewDataSource` and `NSOutlineViewDelegate` ownership external.
+- Use stable item IDs for diff identity so reconstructed model objects do not become delete/insert churn.
+- Use Swift `CollectionDifference` for sibling-list diffing instead of hand-writing a generic diff algorithm.
+- Prefer stability over animation completeness. Same-parent reorders can use `moveItem`; cross-parent moves use remove plus insert in the first version.
+- Provide strict tests for snapshot validation, tree-aware planning, and AppKit mutation ordering.
+
+## Non-Goals
+
+- Do not replace `SidebarTabListViewController` with `NSDiffableDataSource`.
+- Do not move sidebar cell creation, drag/drop, context menu, click handling, or bookmark business rules into the diffable view.
+- Do not implement a custom LCS or generic collection diff algorithm.
+- Do not try to animate every possible tree transformation in the first version.
+- Do not change bookmark storage, tab ordering, or sidebar interaction semantics.
+
+## Public API
+
+The first version should expose a narrow API:
+
+```swift
+class DiffableOutlineView<ItemID: Hashable>: NSOutlineView {
+    func reloadWith(
+        _ snapshot: DiffableOutlineSnapshot<ItemID>,
+        animated: Bool = true,
+        updateDataSource: () -> Void,
+        completion: (() -> Void)? = nil
+    )
+}
+```
+
+`SideBarOutlineView` should inherit from this class and keep its existing sidebar-specific behavior:
+
+```swift
+class SideBarOutlineView: DiffableOutlineView<AnyHashable> {
+    // Existing sizing, indentation, mouse, and drag forwarding behavior stays here.
+}
+```
+
+If AppKit generic subclassing creates build friction, the implementation may keep the snapshot and planner generic while making the concrete view store `AnyHashable`. The external shape should still be a `DiffableOutlineView: NSOutlineView` with a stable-ID snapshot API.
+
+## Snapshot Model
+
+The snapshot describes the tree the outline view should display. It stores stable IDs for diffing and object payloads for AppKit parent/item calls.
+
+```swift
+struct DiffableOutlineSnapshot<ItemID: Hashable> {
+    struct Node {
+        let id: ItemID
+        let item: AnyObject
+        let parentID: ItemID?
+        let childIDs: [ItemID]
+    }
+
+    let rootIDs: [ItemID]
+}
+```
+
+Required behavior:
+
+- Every ID appears once.
+- Every non-root parent ID exists.
+- Root IDs and child IDs preserve visual sibling order.
+- A child can have only one parent.
+- Cycles are invalid.
+- The same stable ID can point at a different object instance in a later snapshot.
+- Snapshot lookup must provide `item(for:)`, `parentID(of:)`, `childIDs(of:)`, `index(of:)`, and subtree traversal helpers.
+
+The snapshot does not create cells and does not answer `NSOutlineViewDataSource` methods. The existing external data source remains authoritative during normal outline view queries.
+
+## Diff Planning
+
+Diff planning is a pure Swift layer that converts an old snapshot and a new snapshot into outline operations. It must use `CollectionDifference` for sibling-level changes:
+
+```swift
+let difference = newChildIDs.difference(from: oldChildIDs).inferringMoves()
+```
+
+The planner wraps `CollectionDifference` with tree semantics:
+
+- For each parent, compare only direct child ID arrays.
+- Same-parent associated remove/insert changes become a `move` operation.
+- Cross-parent movement of the same ID becomes `remove` from the old parent plus `insert` into the new parent.
+- Deleting a subtree emits only the highest removed node; descendants are removed by AppKit as part of that subtree.
+- Inserting a subtree emits only the highest inserted node; descendants are supplied by the updated data source.
+- Replaced payload objects for an existing ID produce a reload/reconfigure operation after structural mutations.
+
+The operation model should be explicit:
+
+```swift
+enum DiffableOutlineOperation<ItemID: Hashable> {
+    case remove(id: ItemID, parentID: ItemID?, index: Int)
+    case move(id: ItemID, parentID: ItemID?, from: Int, to: Int)
+    case insert(id: ItemID, parentID: ItemID?, index: Int)
+    case reload(id: ItemID)
+}
+```
+
+Operation order must be deterministic:
+
+1. Remove operations, deepest first, higher indexes before lower indexes within the same parent.
+2. Same-parent move operations.
+3. Insert operations, shallowest first, lower indexes before higher indexes within the same parent.
+4. Reload operations for visible existing IDs whose payload object changed.
+
+If snapshot validation fails, `DiffableOutlineView` must not call `updateDataSource()` and must not mutate the outline view. If both snapshots are valid but the planner cannot produce a safe operation sequence, `DiffableOutlineView` must fall back to `updateDataSource()` plus `reloadData()`.
+
+## Apply Timing
+
+`reloadWith(snapshot:updateDataSource:completion:)` must use this timing:
+
+1. Assert or dispatch to the main thread.
+2. Read the current snapshot stored by `DiffableOutlineView`.
+3. Validate the new snapshot.
+4. Build a plan from old snapshot to new snapshot.
+5. If validation fails, leave the current snapshot and backing data source untouched, then call completion.
+6. If this is the first valid snapshot, call `updateDataSource()`, `reloadData()`, store the new snapshot, then call completion.
+7. If the plan is unsafe, call `updateDataSource()`, `reloadData()`, store the new snapshot, then call completion.
+8. For a safe plan, call `updateDataSource()` before any outline mutation.
+9. Call `beginUpdates()`.
+10. Apply remove, move, insert, and reload operations.
+11. Call `endUpdates()`.
+12. Store the new snapshot.
+13. Run completion on the next main run loop so selection, scrolling, and visible-item bookkeeping happen after AppKit has processed the structural update.
+
+The key rule is that the external backing data source switches to the new tree after diff planning but before `NSOutlineView` structural mutations. Remove indexes come from the old snapshot. Insert indexes come from the new snapshot. During the mutation window, AppKit can query the data source for inserted nodes and child counts, so delaying the backing update until after animation would be unsafe.
+
+## AppKit Parent Objects
+
+`NSOutlineView` mutation APIs take parent objects, not IDs. The planner should store parent IDs, and `DiffableOutlineView` should resolve them to parent objects at apply time:
+
+- Remove parent objects come from the old snapshot.
+- Insert parent objects come from the new snapshot.
+- Same-parent moves can use the old parent object when the parent object is still recognized by the outline view.
+- If the needed parent object cannot be resolved safely, fall back to `reloadData()`.
+
+The first sidebar integration should prefer stable parent objects where possible, but reconstructed bookmark objects are valid as long as the data source and snapshot agree before insert/reload queries happen.
+
+## Sidebar Integration
+
+`SidebarTabListViewController` should keep ownership of:
+
+- `allItems`
+- `focusedBookmarkPresentation`
+- `dataSourceChildren(of:)`
+- cell creation
+- row view creation
+- drag/drop validation and acceptance
+- expansion/collapse behavior
+- context menus
+- selection and scroll bookkeeping
+
+The controller should add a helper that builds a snapshot from the same logical tree used by `dataSourceChildren(of:)`. The snapshot must include:
+
+- root bookmark items
+- separator item when present
+- new tab button and normal tabs
+- visible bookmark descendants according to the model tree
+- the focused bookmark proxy when present
+
+Bookmark update handling should move from full `refreshAllItems()` reload to:
+
+```swift
+let newItems = makeAllItems()
+let snapshot = makeSnapshot(from: newItems, focusedPresentation: plannedPresentation)
+outlineView.reloadWith(snapshot, animated: true) {
+    self.allItems = newItems
+    self.focusedBookmarkPresentation = plannedPresentation
+} completion: {
+    self.selectActiveTab()
+    self.applyFocusingSelection(for: self.browserState.focusingTab)
+    self.updateVisibleBookmarkTabs()
+    self.updateFloatingNewTabVisibility()
+}
+```
+
+Exact helper names can follow the surrounding code during implementation. The important ownership boundary is that `DiffableOutlineView` does not know about bookmarks or tabs.
+
+Existing hand-written tab incremental updates can remain initially. After the diffable reload path is proven for bookmarks, tab updates can be routed through the same snapshot method if doing so reduces duplication without changing behavior.
+
+## Safety Rules
+
+The implementation must prioritize crash resistance:
+
+- All public apply work runs on the main thread.
+- Invalid snapshots do not update the external backing data source and do not partially mutate the outline view.
+- Duplicate IDs fail validation before mutation.
+- Parent-child cycles fail validation before mutation.
+- Mutations are wrapped in a single `beginUpdates()` / `endUpdates()` pair.
+- No nested `reloadWith` should run while another apply is active; a reentrant call should queue the latest snapshot or fall back to reload after the current apply finishes.
+- The first version should not animate cross-parent moves as `moveItem`.
+- If an item involved in a structural operation is expanded or collapsed mid-apply, the apply should avoid extra expansion mutations and let the existing delegate behavior own expansion state.
+- Fallback reload is acceptable when preserving safety is more important than animation.
+
+## Testing Strategy
+
+Development must use TDD. New production behavior requires a failing test first.
+
+### Snapshot Validation Tests
+
+Cover:
+
+- empty snapshot
+- root-only snapshot
+- nested tree lookup
+- duplicate IDs rejected
+- missing parent rejected
+- duplicate child ownership rejected
+- cycles rejected
+- payload object replacement for the same ID is allowed
+
+### Planner Tests
+
+Cover:
+
+- root insert
+- root delete
+- child insert
+- child delete
+- same-parent reorder produces `move`
+- cross-parent move produces `remove` plus `insert`
+- subtree insert emits only the inserted subtree root
+- subtree delete emits only the deleted subtree root
+- mixed remove/move/insert operations have deterministic order
+- payload replacement produces reload after structural operations
+- invalid snapshot fails validation before planning
+
+### View Apply Tests
+
+Use a test double subclass that records calls to `reloadData`, `beginUpdates`, `endUpdates`, `insertItems`, `removeItems`, `moveItem`, and row reload/reconfigure calls. The tests should verify:
+
+- first snapshot calls `updateDataSource` before `reloadData`
+- normal update calls `updateDataSource` before structural mutations
+- remove uses old parent and old index
+- insert uses new parent and new index
+- same-parent reorder calls `moveItem`
+- cross-parent move calls remove and insert
+- invalid snapshot does not call `updateDataSource`
+- unsafe valid plan falls back to `reloadData`
+- completion runs after apply
+
+A lightweight real `NSOutlineView` smoke test can be added if it is stable in the local test environment, but the required coverage is the planner and recorded mutation sequence.
+
+## Acceptance Criteria
+
+- `DiffableOutlineView` exists as an `NSOutlineView` subclass.
+- `SideBarOutlineView` can inherit from it without losing existing sidebar behavior.
+- A caller can apply a new snapshot with `reloadWith`.
+- Existing data source and delegate methods remain external and unchanged in responsibility.
+- Bookmark updates can use the new method without full `reloadData()` when the diff plan is safe.
+- Unsafe tree changes fall back to full reload instead of attempting risky partial mutations.
+- Tests cover snapshot validation, planner behavior, and mutation ordering before production code is written.


### PR DESCRIPTION
## Background

The sidebar currently relies heavily on full `reloadData()` calls when bookmark / tab sidebar data changes. This avoids many `NSOutlineView` consistency problems, but it also causes visible flicker and makes reorder animations difficult to preserve.

This change introduces a custom diffable outline reload path so the sidebar can apply safe structural mutations incrementally, while still falling back to full reloads for risky tree states.

## Changes

This change mainly does the following:

* Adds a custom diffable outline model, planner, and apply engine:
  * `DiffableOutlineSnapshot`
  * `DiffableOutlineDiffPlanner`
  * `DiffableOutlineView`

* Wires `SideBarOutlineView` into the diffable reload path without replacing the existing `NSOutlineViewDataSource` / delegate ownership.

* Adds `SidebarDiffableSnapshotBuilder` to convert existing sidebar items into outline snapshots, including separator rows and floating bookmark proxy state.

* Preserves bookmark object identity during sidebar model updates so bookmark reorders can be treated as moves instead of remove/insert replacements.

* Adds safety fallbacks for risky cases:
  * invalid snapshots do not update the data source
  * unsafe diff plans fall back to `reloadData()`
  * same-parent moves mixed with replacement siblings fall back to `reloadData()`
  * sidebar item / floating bookmark state is committed only after `reloadWith` accepts the snapshot

* Adds unit and AppKit-level tests for snapshot validation, diff planning, outline mutation application, sidebar snapshot building, and real `NSOutlineView` animation behavior.

## Scope / Impact

The affected area is mainly the sidebar outline refresh path:

* bookmark section refreshes
* bookmark reorder / folder update behavior
* normal tab rows as root-level sidebar items
* floating bookmark proxy presentation
* sidebar separator rows
* `SideBarOutlineView` reload / mutation behavior

This should not affect Chromium navigation, tab WebContents ownership, networking, or browser window lifecycle logic.

The existing sidebar data source, cell creation, selection handling, context menus, and drag behavior are intended to remain owned by `SidebarTabListViewController`.

## Validation

Validated with targeted tests:

* `DiffableOutlineDiffPlannerTests`
* `DiffableOutlineViewTests`

The targeted run passed:

* 24 selected tests
* 0 failures

The test coverage includes:

* structural inserts/removes
* same-parent moves
* cross-parent moves
* identity replacements
* invalid snapshot fallback
* unsafe replacement-sibling move fallback
* update-data-source timing before outline mutations

## Risks / Review Focus

Please review these areas carefully:

* `DiffableOutlineDiffPlanner`
  * operation ordering
  * child index correctness
  * replacement vs move interaction
  * unsafe fallback conditions

* `DiffableOutlineView`
  * when `updateDataSource` is called
  * whether fallback reloads keep `currentSnapshot` and data source aligned
  * whether AppKit mutations are applied only in safe states

* Sidebar integration
  * `refreshAllItems()` state commit timing
  * floating bookmark proxy snapshot handling
  * `resetDiffableSnapshot()` calls after manual outline mutations
  * whether existing sidebar selection / drag / cell lifecycle behavior is preserved

* Bookmark identity preservation
  * whether bookmark updates correctly reuse existing objects
  * whether metadata-only updates avoid unnecessary replacement animations

The highest-risk area is tree mutation timing around `NSOutlineView`, especially mixed reorder / replacement cases and floating bookmark proxy transitions.