### PR TITLE
fix: confirm Sentinel version convergence with bounded retries instead of fire-and-forget

### DIFF
--- a/Sources/Application/SentinelVersionGuard.swift
+++ b/Sources/Application/SentinelVersionGuard.swift
@@ -52,6 +52,9 @@ final class SentinelVersionGuard {
     /// Seconds to wait between confirming whether Sentinel adopted the expected version.
     private let confirmInterval: TimeInterval
     /// Maximum number of confirm-and-re-post cycles before giving up on convergence.
+    /// The total budget (interval × retries) must cover Sentinel's worst-case relaunch:
+    /// its runner stop allows a 45s SIGTERM grace before the new instance comes up, so
+    /// a short budget would emit false "did not converge" warnings on healthy relaunches.
     private let maxConfirmationRetries: Int
 
     private let lastMismatchKeyDefaultsKey = "SentinelVersionGuard.lastMismatchKey"
@@ -79,8 +82,8 @@ final class SentinelVersionGuard {
         sleep: @escaping (TimeInterval) async -> Void = { seconds in
             try? await Task.sleep(nanoseconds: UInt64(max(seconds, 0) * 1_000_000_000))
         },
-        confirmInterval: TimeInterval = 3,
-        maxConfirmationRetries: Int = 3
+        confirmInterval: TimeInterval = 5,
+        maxConfirmationRetries: Int = 10
     ) {
         self.userDefaults = userDefaults
         self.cooldown = cooldown
@@ -116,14 +119,29 @@ final class SentinelVersionGuard {
     /// After a restart request, waits for the running Sentinel to report the expected
     /// version. Re-posts the request on each unconverged check, up to
     /// `maxConfirmationRetries` times, then logs a warning if convergence never happened.
+    ///
+    /// Two distinct "no version" states must not be conflated (`SentinelHelper.runningInfo`):
+    /// a `nil` info means the *process is gone* — nothing will bring Sentinel back until
+    /// the next browser launch, so launch it (mirroring `evaluateCurrentState`'s
+    /// `.launchSentinel`); an info with a `nil`/empty version means the process is up but
+    /// has not (re)written its runtime-info file yet — the expected transient window in
+    /// the middle of a self-relaunch, so keep waiting.
     private func confirmConvergence(_ snapshot: SentinelVersionGuardSnapshot) async {
         for attempt in 1...maxConfirmationRetries {
             await sleep(confirmInterval)
 
-            guard let info = sentinelInfoProvider(snapshot.sentinelBundleID),
-                  let running = info.version, !running.isEmpty else {
-                logger("convergence check: Sentinel not reporting a version; stopping confirmation")
+            guard let info = sentinelInfoProvider(snapshot.sentinelBundleID) else {
+                // Process gone (relaunch failed, or it exited and nothing respawned it).
+                // Launching a duplicate is safe: Sentinel's single-instance guard makes
+                // the loser abort, and ensureRunning no-ops if it is already back up.
+                logger("convergence check: Sentinel is not running; launching it")
+                sentinelLauncher()
                 return
+            }
+
+            guard let running = info.version, !running.isEmpty else {
+                logger("convergence check: Sentinel running but not reporting a version yet (\(attempt)/\(maxConfirmationRetries))")
+                continue
             }
 
             if running == snapshot.browserVersion {

--- a/Sources/Application/SentinelVersionGuard.swift
+++ b/Sources/Application/SentinelVersionGuard.swift
@@ -48,6 +48,11 @@ final class SentinelVersionGuard {
     private let restartRequestPoster: (SentinelVersionGuardSnapshot, String) -> Void
     private let sentinelLauncher: () -> Void
     private let logger: (String) -> Void
+    private let sleep: (TimeInterval) async -> Void
+    /// Seconds to wait between confirming whether Sentinel adopted the expected version.
+    private let confirmInterval: TimeInterval
+    /// Maximum number of confirm-and-re-post cycles before giving up on convergence.
+    private let maxConfirmationRetries: Int
 
     private let lastMismatchKeyDefaultsKey = "SentinelVersionGuard.lastMismatchKey"
     private let lastAttemptTimestampDefaultsKey = "SentinelVersionGuard.lastAttemptTimestamp"
@@ -70,7 +75,12 @@ final class SentinelVersionGuard {
         sentinelInfoProvider: @escaping (String) -> RunningSentinelInfo? = SentinelVersionGuard.defaultRunningSentinelInfo,
         restartRequestPoster: @escaping (SentinelVersionGuardSnapshot, String) -> Void = SentinelVersionGuard.postRestartRequest,
         sentinelLauncher: @escaping () -> Void = SentinelHelper.launch,
-        logger: @escaping (String) -> Void = { AppLogInfo("[SentinelVersionGuard] \($0)") }
+        logger: @escaping (String) -> Void = { AppLogInfo("[SentinelVersionGuard] \($0)") },
+        sleep: @escaping (TimeInterval) async -> Void = { seconds in
+            try? await Task.sleep(nanoseconds: UInt64(max(seconds, 0) * 1_000_000_000))
+        },
+        confirmInterval: TimeInterval = 3,
+        maxConfirmationRetries: Int = 3
     ) {
         self.userDefaults = userDefaults
         self.cooldown = cooldown
@@ -81,16 +91,51 @@ final class SentinelVersionGuard {
         self.restartRequestPoster = restartRequestPoster
         self.sentinelLauncher = sentinelLauncher
         self.logger = logger
+        self.sleep = sleep
+        self.confirmInterval = confirmInterval
+        self.maxConfirmationRetries = maxConfirmationRetries
     }
 
     func runStartupCheck(delaySeconds: TimeInterval = 3) async {
         if delaySeconds > 0 {
-            let nanoseconds = UInt64(delaySeconds * 1_000_000_000)
-            try? await Task.sleep(nanoseconds: nanoseconds)
+            await sleep(delaySeconds)
         }
 
         let decision = evaluateCurrentState()
         apply(decision)
+
+        // A single restart request is not enough. It can be missed entirely (Sentinel
+        // registers its restart observer late, during its own cold launch) or Sentinel
+        // may simply not have relaunched yet. Confirm the running Sentinel actually
+        // adopts the expected version, re-posting a bounded number of times until it
+        // converges — otherwise the browser and Sentinel can stay on mismatched versions.
+        guard case .requestRestart(let snapshot) = decision else { return }
+        await confirmConvergence(snapshot)
+    }
+
+    /// After a restart request, waits for the running Sentinel to report the expected
+    /// version. Re-posts the request on each unconverged check, up to
+    /// `maxConfirmationRetries` times, then logs a warning if convergence never happened.
+    private func confirmConvergence(_ snapshot: SentinelVersionGuardSnapshot) async {
+        for attempt in 1...maxConfirmationRetries {
+            await sleep(confirmInterval)
+
+            guard let info = sentinelInfoProvider(snapshot.sentinelBundleID),
+                  let running = info.version, !running.isEmpty else {
+                logger("convergence check: Sentinel not reporting a version; stopping confirmation")
+                return
+            }
+
+            if running == snapshot.browserVersion {
+                logger("convergence check: Sentinel converged to \(running) after \(attempt) check(s)")
+                return
+            }
+
+            logger("convergence check: Sentinel still \(running), expected \(snapshot.browserVersion); re-posting restart (\(attempt)/\(maxConfirmationRetries))")
+            restartRequestPoster(snapshot, UUID().uuidString)
+        }
+
+        logger("convergence check: WARNING Sentinel did not converge to \(snapshot.browserVersion) after \(maxConfirmationRetries) retries")
     }
 
     func evaluateCurrentState() -> SentinelVersionGuardDecision {

--- a/Tests/PhiBrowserTests/SentinelVersionGuardTests.swift
+++ b/Tests/PhiBrowserTests/SentinelVersionGuardTests.swift
@@ -131,6 +131,79 @@ final class SentinelVersionGuardTests: XCTestCase {
         XCTAssertEqual(launchCount, 1)
     }
 
+    func testConvergenceStopsOnceSentinelAdoptsExpectedVersion() async {
+        // Sentinel reports the old version at evaluation, then the expected version on
+        // the first confirmation read: only the initial request should be posted.
+        let guarder = makeConvergenceGuard(
+            browserVersion: "1.2.1",
+            sentinelVersions: ["1.2.0", "1.2.1"],
+            maxRetries: 3
+        )
+
+        await guarder.runStartupCheck(delaySeconds: 0)
+
+        XCTAssertEqual(postedSnapshots.count, 1)
+    }
+
+    func testConvergenceRepostsUntilRetriesExhausted() async {
+        // Sentinel never adopts the expected version: initial post + one re-post per retry.
+        let guarder = makeConvergenceGuard(
+            browserVersion: "1.2.1",
+            sentinelVersions: ["1.2.0"],
+            maxRetries: 2
+        )
+
+        await guarder.runStartupCheck(delaySeconds: 0)
+
+        XCTAssertEqual(postedSnapshots.count, 3)
+    }
+
+    func testConvergenceStopsWhenSentinelStopsReporting() async {
+        // If Sentinel is no longer reporting a version, stop confirming (nothing to converge).
+        let guarder = makeConvergenceGuard(
+            browserVersion: "1.2.1",
+            sentinelVersions: ["1.2.0", nil],
+            maxRetries: 3
+        )
+
+        await guarder.runStartupCheck(delaySeconds: 0)
+
+        XCTAssertEqual(postedSnapshots.count, 1)
+    }
+
+    private func makeConvergenceGuard(
+        browserVersion: String,
+        sentinelVersions: [String?],
+        maxRetries: Int
+    ) -> SentinelVersionGuard {
+        var callIndex = 0
+        return SentinelVersionGuard(
+            userDefaults: defaults,
+            now: { self.now },
+            browserBundleIDProvider: { "com.phibrowser.Mac" },
+            browserVersionProvider: { browserVersion },
+            sentinelInfoProvider: { sentinelBundleID in
+                let version = sentinelVersions[min(callIndex, sentinelVersions.count - 1)]
+                callIndex += 1
+                guard let version else { return nil }
+                return SentinelVersionGuard.RunningSentinelInfo(
+                    bundleID: sentinelBundleID,
+                    version: version
+                )
+            },
+            restartRequestPoster: { snapshot, _ in
+                self.postedSnapshots.append(snapshot)
+            },
+            sentinelLauncher: {
+                self.launchCount += 1
+            },
+            logger: { _ in },
+            sleep: { _ in },
+            confirmInterval: 0,
+            maxConfirmationRetries: maxRetries
+        )
+    }
+
     private func makeGuard(
         browserBundleID: String,
         browserVersion: String,

--- a/Tests/PhiBrowserTests/SentinelVersionGuardTests.swift
+++ b/Tests/PhiBrowserTests/SentinelVersionGuardTests.swift
@@ -131,49 +131,96 @@ final class SentinelVersionGuardTests: XCTestCase {
         XCTAssertEqual(launchCount, 1)
     }
 
+    /// What the sentinelInfoProvider reports on one sampling call. Index 0 is consumed
+    /// by evaluateCurrentState; the confirmation loop starts at index 1. The last
+    /// sample repeats for any further calls.
+    private enum SentinelSample {
+        /// Process not running (runningInfo returns nil).
+        case gone
+        /// Process alive but runtime-info file not (re)written yet (version == nil).
+        case noVersion
+        case version(String)
+    }
+
     func testConvergenceStopsOnceSentinelAdoptsExpectedVersion() async {
         // Sentinel reports the old version at evaluation, then the expected version on
         // the first confirmation read: only the initial request should be posted.
         let guarder = makeConvergenceGuard(
             browserVersion: "1.2.1",
-            sentinelVersions: ["1.2.0", "1.2.1"],
+            samples: [.version("1.2.0"), .version("1.2.1")],
             maxRetries: 3
         )
 
         await guarder.runStartupCheck(delaySeconds: 0)
 
         XCTAssertEqual(postedSnapshots.count, 1)
+        XCTAssertEqual(launchCount, 0)
     }
 
     func testConvergenceRepostsUntilRetriesExhausted() async {
         // Sentinel never adopts the expected version: initial post + one re-post per retry.
         let guarder = makeConvergenceGuard(
             browserVersion: "1.2.1",
-            sentinelVersions: ["1.2.0"],
+            samples: [.version("1.2.0")],
             maxRetries: 2
         )
 
         await guarder.runStartupCheck(delaySeconds: 0)
 
         XCTAssertEqual(postedSnapshots.count, 3)
+        XCTAssertEqual(launchCount, 0)
     }
 
-    func testConvergenceStopsWhenSentinelStopsReporting() async {
-        // If Sentinel is no longer reporting a version, stop confirming (nothing to converge).
+    func testConvergenceLaunchesSentinelWhenProcessGone() async {
+        // Sentinel's process disappears during confirmation (relaunch failed or it
+        // exited): the guard must launch it, or nothing brings Sentinel back until
+        // the next browser cold launch.
         let guarder = makeConvergenceGuard(
             browserVersion: "1.2.1",
-            sentinelVersions: ["1.2.0", nil],
+            samples: [.version("1.2.0"), .gone],
             maxRetries: 3
         )
 
         await guarder.runStartupCheck(delaySeconds: 0)
 
         XCTAssertEqual(postedSnapshots.count, 1)
+        XCTAssertEqual(launchCount, 1)
+    }
+
+    func testConvergenceWaitsThroughMissingVersionThenConverges() async {
+        // Mid-relaunch the process is up but the runtime-info file is not rewritten
+        // yet (version == nil): the loop must keep waiting through the transient,
+        // not bail out, and then observe convergence.
+        let guarder = makeConvergenceGuard(
+            browserVersion: "1.2.1",
+            samples: [.version("1.2.0"), .noVersion, .version("1.2.1")],
+            maxRetries: 3
+        )
+
+        await guarder.runStartupCheck(delaySeconds: 0)
+
+        XCTAssertEqual(postedSnapshots.count, 1)
+        XCTAssertEqual(launchCount, 0)
+    }
+
+    func testConvergenceSucceedsOnLastRetry() async {
+        // Convergence lands exactly on the final allowed check — pins the loop bound.
+        let guarder = makeConvergenceGuard(
+            browserVersion: "1.2.1",
+            samples: [.version("1.2.0"), .version("1.2.0"), .version("1.2.0"), .version("1.2.1")],
+            maxRetries: 3
+        )
+
+        await guarder.runStartupCheck(delaySeconds: 0)
+
+        // Initial post + re-posts on the two unconverged checks; converged on the third.
+        XCTAssertEqual(postedSnapshots.count, 3)
+        XCTAssertEqual(launchCount, 0)
     }
 
     private func makeConvergenceGuard(
         browserVersion: String,
-        sentinelVersions: [String?],
+        samples: [SentinelSample],
         maxRetries: Int
     ) -> SentinelVersionGuard {
         var callIndex = 0
@@ -183,13 +230,22 @@ final class SentinelVersionGuardTests: XCTestCase {
             browserBundleIDProvider: { "com.phibrowser.Mac" },
             browserVersionProvider: { browserVersion },
             sentinelInfoProvider: { sentinelBundleID in
-                let version = sentinelVersions[min(callIndex, sentinelVersions.count - 1)]
+                let sample = samples[min(callIndex, samples.count - 1)]
                 callIndex += 1
-                guard let version else { return nil }
-                return SentinelVersionGuard.RunningSentinelInfo(
-                    bundleID: sentinelBundleID,
-                    version: version
-                )
+                switch sample {
+                case .gone:
+                    return nil
+                case .noVersion:
+                    return SentinelVersionGuard.RunningSentinelInfo(
+                        bundleID: sentinelBundleID,
+                        version: nil
+                    )
+                case .version(let version):
+                    return SentinelVersionGuard.RunningSentinelInfo(
+                        bundleID: sentinelBundleID,
+                        version: version
+                    )
+                }
             },
             restartRequestPoster: { snapshot, _ in
                 self.postedSnapshots.append(snapshot)


### PR DESCRIPTION
## Problem

The stable-channel `SentinelVersionGuard` posted a single fire-and-forget `com.phibrowser.sentinel.restart.request` on version mismatch, once per browser launch. The request can be missed entirely (Sentinel registers its restart observer late during its own cold launch) or Sentinel may not have relaunched yet — leaving the browser and Sentinel running mismatched versions with no retry until the next browser cold launch (further suppressed by the 10-min cooldown).

## Fix

`runStartupCheck` now runs a convergence loop after requesting a restart (`confirmConvergence`):

- Re-reads the running Sentinel's version (runtime-info file) and re-posts the restart request until it matches the browser version, bounded by `maxConfirmationRetries`.
- Distinguishes the two "no version" states of `SentinelHelper.runningInfo`:
  - `nil` info ⟹ **process gone** → launch Sentinel (mirrors `evaluateCurrentState`'s `.launchSentinel`; safe against duplicates via Sentinel's single-instance guard). Without this, a Sentinel that dies mid-relaunch stays down until the next browser cold launch.
  - `version == nil` ⟹ **process up, runtime-info not rewritten yet** (the expected mid-relaunch transient) → keep waiting.
- Budget sized to Sentinel's worst-case relaunch: 5s × 10 = 50s, covering the runner's 45s SIGTERM grace, so healthy relaunches don't emit false "did not converge" warnings.

No behavior change for matching versions, non-stable channels, or the cooldown logic. All knobs are injectable; existing call sites unchanged.

## Tests

5 convergence unit tests (sample-sequence driven): converge-and-stop, repost-until-exhausted, process-gone → launch, missing-version transient → keep waiting → converge, converge-exactly-on-last-retry.

## Verification

- `xcodebuild build-for-testing` (scheme PhiBrowser): **TEST BUILD SUCCEEDED** — guard + all tests compile.
- ⚠️ Unit-test assertions were not executed locally: the PhiBrowser test host requires an Apple-provisioned profile (`web-browser.public-key-credential` entitlement) unavailable on the dev machine. Please run `PhiBrowserTests/SentinelVersionGuardTests` in CI / on a provisioned machine.

## Related

Counterpart sentinel-side fix (deterministic `exit(0)` on `prepareForBrowserUpdate`, terminal-path mutual exclusion) is on sentinel branch `release/2.1`. Full analysis: knowledge base `60-knowledge-items/pitfalls/sentinel-browser-update-shutdown-and-version-convergence.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)