### PR TITLE
Add French (fr) localization and in-app language selector

### DIFF
--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -2224,6 +2224,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				fr,
 				Base,
 			);
 			mainGroup = B0C4693F2E3B10E1007F0C7A;

--- a/PhiBrowser-Info.plist
+++ b/PhiBrowser-Info.plist
@@ -54,6 +54,11 @@
 			</array>
 		</dict>
 	</array>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>fr</string>
+	</array>
 	<key>Chromium version</key>
 	<string>144.0.7559.102</string>
 	<key>CrProductDirName</key>

--- a/Resources/DownloadSafety.xcstrings
+++ b/Resources/DownloadSafety.xcstrings
@@ -10,6 +10,12 @@
             "state" : "translated",
             "value" : "This file can harm your personal and social network accounts"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier peut nuire à vos comptes personnels et de réseaux sociaux"
+          }
         }
       }
     },
@@ -21,6 +27,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Your organization blocked this file because it is encrypted"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre organisation a bloqué ce fichier car il est chiffré"
           }
         }
       }
@@ -34,6 +46,12 @@
             "state" : "translated",
             "value" : "Your organization blocked this file because the scan failed"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre organisation a bloqué ce fichier car l'analyse a échoué"
+          }
         }
       }
     },
@@ -45,6 +63,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Your organization blocked this file because it is too big for a security check"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre organisation a bloqué ce fichier car il est trop volumineux pour un contrôle de sécurité"
           }
         }
       }
@@ -58,6 +82,12 @@
             "state" : "translated",
             "value" : "This file is dangerous"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier est dangereux"
+          }
         }
       }
     },
@@ -69,6 +99,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This file type isn't commonly downloaded and it may be dangerous"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce type de fichier est rarement téléchargé et peut être dangereux"
           }
         }
       }
@@ -82,6 +118,12 @@
             "state" : "translated",
             "value" : "This file is deceptive and may make unexpected changes to your device"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier est trompeur et peut apporter des modifications inattendues à votre appareil"
+          }
         }
       }
     },
@@ -93,6 +135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This file is dangerous"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier est dangereux"
           }
         }
       }
@@ -106,6 +154,12 @@
             "state" : "translated",
             "value" : "This site isn't using a secure connection and the file may have been tampered with"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce site n'utilise pas de connexion sécurisée et le fichier a peut-être été altéré"
+          }
         }
       }
     },
@@ -117,6 +171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This file has been blocked by security policy"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier a été bloqué par la politique de sécurité"
           }
         }
       }
@@ -130,6 +190,12 @@
             "state" : "translated",
             "value" : "This file may be dangerous"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier peut être dangereux"
+          }
         }
       }
     },
@@ -141,6 +207,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "This file might be a virus or malware"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier est peut-être un virus ou un logiciel malveillant"
           }
         }
       }
@@ -154,6 +226,12 @@
             "state" : "translated",
             "value" : "This file might be a virus or malware"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier est peut-être un virus ou un logiciel malveillant"
+          }
         }
       }
     },
@@ -165,6 +243,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Your organization recommends deleting this file because it has sensitive content"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre organisation recommande de supprimer ce fichier car il contient du contenu sensible"
           }
         }
       }
@@ -178,6 +262,12 @@
             "state" : "translated",
             "value" : "This file isn't commonly downloaded and it may be dangerous"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce fichier est rarement téléchargé et peut être dangereux"
+          }
         }
       }
     },
@@ -189,6 +279,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Blocked"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bloqué"
           }
         }
       }
@@ -202,6 +298,12 @@
             "state" : "translated",
             "value" : "Dangerous download blocked"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement dangereux bloqué"
+          }
         }
       }
     },
@@ -213,6 +315,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Encrypted"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chiffré"
           }
         }
       }
@@ -226,6 +334,12 @@
             "state" : "translated",
             "value" : "Insecure download blocked"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement non sécurisé bloqué"
+          }
         }
       }
     },
@@ -237,6 +351,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scan failed"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de l'analyse"
           }
         }
       }
@@ -250,6 +370,12 @@
             "state" : "translated",
             "value" : "Scanning…"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Analyse…"
+          }
         }
       }
     },
@@ -262,6 +388,12 @@
             "state" : "translated",
             "value" : "Suspicious download blocked"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement suspect bloqué"
+          }
         }
       }
     },
@@ -273,6 +405,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Too big"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trop volumineux"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -5,13 +5,29 @@
 
     },
     " Telegram bot creation and customization process, follow the on-screen instructions and paste the Bot Token below" : {
-      "comment" : "Phi Link - Custom bot guide suffix"
+      "comment" : "Phi Link - Custom bot guide suffix",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " Processus de création et de personnalisation du bot Telegram, suivez les instructions à l'écran et collez le Bot Token ci-dessous"
+          }
+        }
+      }
     },
     "・" : {
 
     },
     "・Paused" : {
-      "comment" : "Download item row - Status indicator when download is paused"
+      "comment" : "Download item row - Status indicator when download is paused",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "・En pause"
+          }
+        }
+      }
     },
     "·" : {
 
@@ -23,91 +39,323 @@
 
     },
     "/**/Appearance" : {
-      "comment" : "[EXAMPLE] Theme example: appearance picker label"
+      "comment" : "[EXAMPLE] Theme example: appearance picker label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Apparence"
+          }
+        }
+      }
     },
     "/**/Appearance Choice" : {
-      "comment" : "[EXAMPLE] Theme example: appearance picker section title"
+      "comment" : "[EXAMPLE] Theme example: appearance picker section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Choix d'apparence"
+          }
+        }
+      }
     },
     "/**/AppKit Controls Examples" : {
-      "comment" : "[EXAMPLE] Theme example: AppKit controls section title"
+      "comment" : "[EXAMPLE] Theme example: AppKit controls section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Exemples de contrôles AppKit"
+          }
+        }
+      }
     },
     "/**/Basic Usage - <> Operator" : {
-      "comment" : "[EXAMPLE] Theme example: basic usage code title"
+      "comment" : "[EXAMPLE] Theme example: basic usage code title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Utilisation de base - Opérateur <>"
+          }
+        }
+      }
     },
     "/**/Border" : {
-      "comment" : "[EXAMPLE] Theme example: border style label"
+      "comment" : "[EXAMPLE] Theme example: border style label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Bordure"
+          }
+        }
+      }
     },
     "/**/Border & Separator Examples" : {
-      "comment" : "[EXAMPLE] Theme example: border section title"
+      "comment" : "[EXAMPLE] Theme example: border section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Exemples de bordures et séparateurs"
+          }
+        }
+      }
     },
     "/**/Code Examples" : {
-      "comment" : "[EXAMPLE] Theme example: code examples section title"
+      "comment" : "[EXAMPLE] Theme example: code examples section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Exemples de code"
+          }
+        }
+      }
     },
     "/**/Current Appearance: %@" : {
-      "comment" : "[EXAMPLE] Theme example: current appearance label with format"
+      "comment" : "[EXAMPLE] Theme example: current appearance label with format",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Apparence actuelle : %@"
+          }
+        }
+      }
     },
     "/**/Custom Theme" : {
-      "comment" : "[EXAMPLE] Theme example: custom theme code title"
+      "comment" : "[EXAMPLE] Theme example: custom theme code title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Thème personnalisé"
+          }
+        }
+      }
     },
     "/**/Dark Mode Button" : {
-      "comment" : "[EXAMPLE] Theme example: dark mode button title"
+      "comment" : "[EXAMPLE] Theme example: dark mode button title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Bouton mode sombre"
+          }
+        }
+      }
     },
     "/**/Hovered Tab" : {
-      "comment" : "[EXAMPLE] Theme example: hovered tab label"
+      "comment" : "[EXAMPLE] Theme example: hovered tab label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Onglet survolé"
+          }
+        }
+      }
     },
     "/**/Light Mode Button" : {
-      "comment" : "[EXAMPLE] Theme example: light mode button title"
+      "comment" : "[EXAMPLE] Theme example: light mode button title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Bouton mode clair"
+          }
+        }
+      }
     },
     "/**/Normal Tab" : {
-      "comment" : "[EXAMPLE] Theme example: normal tab label"
+      "comment" : "[EXAMPLE] Theme example: normal tab label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Onglet normal"
+          }
+        }
+      }
     },
     "/**/NSButton with phi.title:" : {
-      "comment" : "[EXAMPLE] Theme example: NSButton description"
+      "comment" : "[EXAMPLE] Theme example: NSButton description",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/NSButton avec phi.title :"
+          }
+        }
+      }
     },
     "/**/NSTextField with phi.textColor:" : {
-      "comment" : "[EXAMPLE] Theme example: NSTextField description"
+      "comment" : "[EXAMPLE] Theme example: NSTextField description",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/NSTextField avec phi.textColor :"
+          }
+        }
+      }
     },
     "/**/NSView with phiLayer.backgroundColor:" : {
-      "comment" : "[EXAMPLE] Theme example: NSView layer description"
+      "comment" : "[EXAMPLE] Theme example: NSView layer description",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/NSView avec phiLayer.backgroundColor :"
+          }
+        }
+      }
     },
     "/**/Overlay Background" : {
-      "comment" : "[EXAMPLE] Theme example: overlay background label"
+      "comment" : "[EXAMPLE] Theme example: overlay background label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Arrière-plan de superposition"
+          }
+        }
+      }
     },
     "/**/Primary Text - Main content text" : {
-      "comment" : "[EXAMPLE] Theme example: primary text sample"
+      "comment" : "[EXAMPLE] Theme example: primary text sample",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Texte principal - Texte du contenu principal"
+          }
+        }
+      }
     },
     "/**/Secondary Text - Supporting text" : {
-      "comment" : "[EXAMPLE] Theme example: secondary text sample"
+      "comment" : "[EXAMPLE] Theme example: secondary text sample",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Texte secondaire - Texte d'accompagnement"
+          }
+        }
+      }
     },
     "/**/Selected Tab" : {
-      "comment" : "[EXAMPLE] Theme example: selected tab label"
+      "comment" : "[EXAMPLE] Theme example: selected tab label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Onglet sélectionné"
+          }
+        }
+      }
     },
     "/**/Separator" : {
-      "comment" : "[EXAMPLE] Theme example: separator style label"
+      "comment" : "[EXAMPLE] Theme example: separator style label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Séparateur"
+          }
+        }
+      }
     },
     "/**/Sidebar Style Examples" : {
-      "comment" : "[EXAMPLE] Theme example: sidebar section title"
+      "comment" : "[EXAMPLE] Theme example: sidebar section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Exemples de style de barre latérale"
+          }
+        }
+      }
     },
     "/**/SwiftUI Modifiers" : {
-      "comment" : "[EXAMPLE] Theme example: SwiftUI modifiers code title"
+      "comment" : "[EXAMPLE] Theme example: SwiftUI modifiers code title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Modificateurs SwiftUI"
+          }
+        }
+      }
     },
     "/**/Tertiary Text - Tertiary level text" : {
-      "comment" : "[EXAMPLE] Theme example: tertiary text sample"
+      "comment" : "[EXAMPLE] Theme example: tertiary text sample",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Texte tertiaire - Texte de niveau tertiaire"
+          }
+        }
+      }
     },
     "/**/Text Color Examples" : {
-      "comment" : "[EXAMPLE] Theme example: text color section title"
+      "comment" : "[EXAMPLE] Theme example: text color section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Exemples de couleur de texte"
+          }
+        }
+      }
     },
     "/**/This is an NSTextField, color changes with appearance" : {
-      "comment" : "[EXAMPLE] Theme example: NSTextField sample text"
+      "comment" : "[EXAMPLE] Theme example: NSTextField sample text",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Ceci est un NSTextField, la couleur change selon l'apparence"
+          }
+        }
+      }
     },
     "/**/User Appearance Choice" : {
-      "comment" : "[EXAMPLE] Theme example: user appearance code title"
+      "comment" : "[EXAMPLE] Theme example: user appearance code title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Choix d'apparence de l'utilisateur"
+          }
+        }
+      }
     },
     "/**/Window Background" : {
-      "comment" : "[EXAMPLE] Theme example: window background label"
+      "comment" : "[EXAMPLE] Theme example: window background label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "/**/Arrière-plan de la fenêtre"
+          }
+        }
+      }
     },
     "%@ — in use by a Space" : {
-      "comment" : "Spaces menu - Delete Profile row label for a profile bound to a Space"
+      "comment" : "Spaces menu - Delete Profile row label for a profile bound to a Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ — utilisé par un espace"
+          }
+        }
+      }
     },
     "%@ · %d tabs" : {
       "comment" : "Tab Groups - auto-generated group title, e.g. 'Blue · 3 tabs'",
@@ -116,6 +364,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ · %2$d tabs"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ · %2$d onglets"
           }
         }
       }
@@ -128,6 +382,12 @@
             "state" : "new",
             "value" : "%1$@ tab group, %2$d tabs, collapsed"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Groupe d'onglets %1$@, %2$d onglets, réduit"
+          }
         }
       }
     },
@@ -139,26 +399,70 @@
             "state" : "new",
             "value" : "%1$@ tab group, %2$d tabs, expanded"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Groupe d'onglets %1$@, %2$d onglets, développé"
+          }
         }
       }
     },
     "%d days ago" : {
-      "comment" : "Download item row - Relative time showing days since download completed"
+      "comment" : "Download item row - Relative time showing days since download completed",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il y a %d jours"
+          }
+        }
+      }
     },
     "%d hour ago" : {
-      "comment" : "Download item row - Relative time showing hours since download completed"
+      "comment" : "Download item row - Relative time showing hours since download completed",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il y a %d heure"
+          }
+        }
+      }
     },
     "%d min ago" : {
-      "comment" : "Download item row - Relative time showing minutes since download completed"
+      "comment" : "Download item row - Relative time showing minutes since download completed",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Il y a %d min"
+          }
+        }
+      }
     },
     "%d Spaces" : {
-      "comment" : "Profiles settings - Count of Spaces bound to a profile"
+      "comment" : "Profiles settings - Count of Spaces bound to a profile",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%d espaces"
+          }
+        }
+      }
     },
     "%lld/%lld" : {
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "%1$lld/%2$lld"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "%1$lld/%2$lld"
           }
         }
@@ -168,202 +472,727 @@
 
     },
     "© %d Phinomenon. All rights reserved." : {
-      "comment" : "About window - Copyright notice at bottom"
+      "comment" : "About window - Copyright notice at bottom",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "© %d Phinomenon. Tous droits réservés."
+          }
+        }
+      }
     },
     "A profile with this name already exists." : {
-      "comment" : "Validation shown when a new or renamed profile name duplicates an existing profile"
+      "comment" : "Validation shown when a new or renamed profile name duplicates an existing profile",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un profil portant ce nom existe déjà."
+          }
+        }
+      }
     },
     "Active" : {
-      "comment" : "Search Tabs - Trailing label for the active tab result"
+      "comment" : "Search Tabs - Trailing label for the active tab result",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actif"
+          }
+        }
+      }
     },
     "Add Download" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter un téléchargement"
+          }
+        }
+      }
     },
     "Add Left Split" : {
-      "comment" : "Drop-zone hint shown when dragging a tab over the left third of the page"
+      "comment" : "Drop-zone hint shown when dragging a tab over the left third of the page",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter une division à gauche"
+          }
+        }
+      }
     },
     "Add New" : {
-      "comment" : "Shortcuts settings - Placeholder text when no shortcut is assigned"
+      "comment" : "Shortcuts settings - Placeholder text when no shortcut is assigned",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter"
+          }
+        }
+      }
     },
     "Add Right Split" : {
-      "comment" : "Drop-zone hint shown when dragging a tab over the right third of the page"
+      "comment" : "Drop-zone hint shown when dragging a tab over the right third of the page",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter une division à droite"
+          }
+        }
+      }
     },
     "Add Rule" : {
-      "comment" : "Footer button in URL rules editor"
+      "comment" : "Footer button in URL rules editor",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter une règle"
+          }
+        }
+      }
     },
     "Add Split to Bookmark" : {
-      "comment" : "Tab context menu - Save both panes of the split as a bookmark folder"
+      "comment" : "Tab context menu - Save both panes of the split as a bookmark folder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter la division aux favoris"
+          }
+        }
+      }
     },
     "Add Split to Folder" : {
-      "comment" : "Tab context menu - Save both panes of the split into a chosen bookmark folder"
+      "comment" : "Tab context menu - Save both panes of the split into a chosen bookmark folder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter la division au dossier"
+          }
+        }
+      }
     },
     "Add Tabs to New Group" : {
-      "comment" : "Tab multi-selection context menu - create a new tab group from selected tabs"
+      "comment" : "Tab multi-selection context menu - create a new tab group from selected tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter les onglets à un nouveau groupe"
+          }
+        }
+      }
     },
     "Add to Bookmark" : {
-      "comment" : "Tab context menu - Add current tab to root bookmark bar in sidebar\nTab multi-selection context menu - add selected tabs to the root bookmark location"
+      "comment" : "Tab context menu - Add current tab to root bookmark bar in sidebar\nTab multi-selection context menu - add selected tabs to the root bookmark location",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter aux favoris"
+          }
+        }
+      }
     },
     "Add to Bookmark Bar" : {
-      "comment" : "Tab context menu - Add current tab to root bookmark bar"
+      "comment" : "Tab context menu - Add current tab to root bookmark bar",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter à la barre de favoris"
+          }
+        }
+      }
     },
     "Add to Folder" : {
-      "comment" : "Tab context menu - Menu item to add tab to bookmarks\nTab multi-selection context menu - submenu to add selected tabs to a bookmark folder"
+      "comment" : "Tab context menu - Menu item to add tab to bookmarks\nTab multi-selection context menu - submenu to add selected tabs to a bookmark folder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter au dossier"
+          }
+        }
+      }
     },
     "Add to Group" : {
-      "comment" : "Tab context menu - Submenu to add this tab to an existing tab group"
+      "comment" : "Tab context menu - Submenu to add this tab to an existing tab group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter au groupe"
+          }
+        }
+      }
     },
     "Additional browser settings" : {
-      "comment" : "General settings - Title for always more settings"
+      "comment" : "General settings - Title for always more settings",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres supplémentaires du navigateur"
+          }
+        }
+      }
     },
     "Additional info (optional)" : {
-      "comment" : "Feedback form - Section header for optional additional information"
+      "comment" : "Feedback form - Section header for optional additional information",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informations supplémentaires (facultatif)"
+          }
+        }
+      }
     },
     "Adds a built-in Space that browses in a private session. URL rules can route sites into it; everything it browsed is cleared when its windows close or Phi quits." : {
-      "comment" : "Spaces settings - Incognito Space toggle tooltip"
+      "comment" : "Spaces settings - Incognito Space toggle tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajoute un espace intégré qui navigue en session privée. Des règles d'URL peuvent y diriger des sites ; tout ce qui y a été consulté est effacé à la fermeture de ses fenêtres ou à la fermeture de Phi."
+          }
+        }
+      }
     },
     "AI conversations will be closed and all connected Connectors will be disconnected." : {
-      "comment" : "AI settings - Alert message explaining consequences of disabling AI features"
+      "comment" : "AI settings - Alert message explaining consequences of disabling AI features",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les conversations IA seront fermées et tous les connecteurs connectés seront déconnectés."
+          }
+        }
+      }
     },
     "AI Sidebar" : {
-      "comment" : "AI settings - Section title for AI sidebar options"
+      "comment" : "AI settings - Section title for AI sidebar options",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barre latérale IA"
+          }
+        }
+      }
     },
     "All connected Connectors will be disconnected." : {
-      "comment" : "AI settings - Alert message explaining consequences of disabling connectors"
+      "comment" : "AI settings - Alert message explaining consequences of disabling connectors",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les connecteurs connectés seront déconnectés."
+          }
+        }
+      }
     },
     "All cookies, history, extensions, and saved data on this profile will be permanently removed. This cannot be undone." : {
-      "comment" : "Body of the delete-profile confirmation"
+      "comment" : "Body of the delete-profile confirmation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les cookies, l'historique, les extensions et les données enregistrées de ce profil seront définitivement supprimés. Cette action est irréversible."
+          }
+        }
+      }
     },
     "All Downloads" : {
-      "comment" : "Downloads list - Button to open full downloads page"
+      "comment" : "Downloads list - Button to open full downloads page",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tous les téléchargements"
+          }
+        }
+      }
     },
     "Always Show Bookmark Bar" : {
-      "comment" : "View menu - Menu item to always show the bookmark bar"
+      "comment" : "View menu - Menu item to always show the bookmark bar",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours afficher la barre de favoris"
+          }
+        }
+      }
     },
     "Always show full URL" : {
-      "comment" : "General settings - Toggle title for always showing full URL in address bar"
+      "comment" : "General settings - Toggle title for always showing full URL in address bar",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours afficher l'URL complète"
+          }
+        }
+      }
     },
     "Always Show URL Path" : {
-      "comment" : "Address bar menu - Toggle URL path visibility"
+      "comment" : "Address bar menu - Toggle URL path visibility",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toujours afficher le chemin de l'URL"
+          }
+        }
+      }
     },
     "Amber" : {
-      "comment" : "Amber theme color name"
+      "comment" : "Amber theme color name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ambre"
+          }
+        }
+      }
     },
     "An import is still adding bookmarks to this Space. Wait for it to finish, then try again." : {
-      "comment" : "Body shown when a Space action is blocked by an in-progress import\nBody shown when deleting a Space is blocked by an in-progress import"
+      "comment" : "Body shown when a Space action is blocked by an in-progress import\nBody shown when deleting a Space is blocked by an in-progress import",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une importation ajoute encore des favoris à cet espace. Attendez qu'elle se termine, puis réessayez."
+          }
+        }
+      }
     },
     "Appearance" : {
-      "comment" : "General settings - Appearance section title"
+      "comment" : "General settings - Appearance section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apparence"
+          }
+        }
+      }
     },
     "AppKit" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AppKit"
+          }
+        }
+      }
     },
     "Apply theme to text selection on web pages" : {
-      "comment" : "General settings - Toggle title for tinting ::selection on third-party pages with the window theme accent"
+      "comment" : "General settings - Toggle title for tinting ::selection on third-party pages with the window theme accent",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appliquer le thème à la sélection de texte sur les pages web"
+          }
+        }
+      }
     },
     "Aqua" : {
-      "comment" : "Aqua theme color name"
+      "comment" : "Aqua theme color name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aqua"
+          }
+        }
+      }
     },
     "Are you sure you want to install version %@ and restart Phi?" : {
-      "comment" : "Update alert - Message asking user to confirm update installation with version number"
+      "comment" : "Update alert - Message asking user to confirm update installation with version number",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voulez-vous vraiment installer la version %@ et redémarrer Phi ?"
+          }
+        }
+      }
     },
     "Ask every time" : {
-      "comment" : "Special target in the URL rule Space picker: prompt for a Space on each match"
+      "comment" : "Special target in the URL rule Space picker: prompt for a Space on each match",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Demander à chaque fois"
+          }
+        }
+      }
     },
     "Attach files" : {
-      "comment" : "Feedback form - Label for file attachment section"
+      "comment" : "Feedback form - Label for file attachment section",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Joindre des fichiers"
+          }
+        }
+      }
     },
     "Automatically add current tab as context to new conversation" : {
-      "comment" : "AI settings - Toggle to auto-add current tab as context when starting new AI conversation"
+      "comment" : "AI settings - Toggle to auto-add current tab as context when starting new AI conversation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter automatiquement l'onglet actuel comme contexte à une nouvelle conversation"
+          }
+        }
+      }
     },
     "Automatically add External Data Connectors as context to new conversation" : {
-      "comment" : "AI settings - Toggle to auto-add connector data as context to new AI conversation"
+      "comment" : "AI settings - Toggle to auto-add connector data as context to new AI conversation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter automatiquement les connecteurs de données externes comme contexte à une nouvelle conversation"
+          }
+        }
+      }
     },
     "Back" : {
-      "comment" : "Web content header - Accessibility description for back navigation button"
+      "comment" : "Web content header - Accessibility description for back navigation button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retour"
+          }
+        }
+      }
     },
     "Back Up Phi User Data" : {
-      "comment" : "Debug clear data - NSSavePanel title for saving Phi user data directory as zip"
+      "comment" : "Debug clear data - NSSavePanel title for saving Phi user data directory as zip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauvegarder les données utilisateur de Phi"
+          }
+        }
+      }
     },
     "Back Up User Data First?" : {
-      "comment" : "Debug clear data - Alert title asking whether to export Phi user data before clearing"
+      "comment" : "Debug clear data - Alert title asking whether to export Phi user data before clearing",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauvegarder d'abord les données utilisateur ?"
+          }
+        }
+      }
     },
     "Backup Failed" : {
-      "comment" : "Debug clear data - Alert title when exporting Phi user data zip fails"
+      "comment" : "Debug clear data - Alert title when exporting Phi user data zip fails",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la sauvegarde"
+          }
+        }
+      }
     },
     "Backup..." : {
-      "comment" : "Debug clear data - Alert button to open the save panel for a Phi user data zip"
+      "comment" : "Debug clear data - Alert button to open the save panel for a Phi user data zip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauvegarder…"
+          }
+        }
+      }
     },
     "Backups Unavailable" : {
-      "comment" : "Help menu - Time Machine submenu placeholder when the backup catalog cannot be read"
+      "comment" : "Help menu - Time Machine submenu placeholder when the backup catalog cannot be read",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauvegardes indisponibles"
+          }
+        }
+      }
     },
     "Balanced" : {
-      "comment" : "Layout option - Vertical tabs with address bar at the top of webcontent\nOnboarding layout selection - Balanced option"
+      "comment" : "Layout option - Vertical tabs with address bar at the top of webcontent\nOnboarding layout selection - Balanced option",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Équilibré"
+          }
+        }
+      }
     },
     "Blue" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bleu"
+          }
+        }
+      }
     },
     "Bookmark All Tabs" : {
-      "comment" : "Tab area context menu - Bookmark all open tabs"
+      "comment" : "Tab area context menu - Bookmark all open tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter tous les onglets aux favoris"
+          }
+        }
+      }
     },
     "Bookmark All Tabs..." : {
-      "comment" : "Bookmarks menu - Menu item to add bookmarks for all currently open tabs in the active window"
+      "comment" : "Bookmarks menu - Menu item to add bookmarks for all currently open tabs in the active window",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter tous les onglets aux favoris…"
+          }
+        }
+      }
     },
     "Bookmark Name" : {
-      "comment" : "Bookmark editor - Placeholder for bookmark name input"
+      "comment" : "Bookmark editor - Placeholder for bookmark name input",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom du favori"
+          }
+        }
+      }
     },
     "Bookmark This Tab..." : {
-      "comment" : "Bookmarks menu - Menu item to add or edit a bookmark for the currently focused tab"
+      "comment" : "Bookmarks menu - Menu item to add or edit a bookmark for the currently focused tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajouter cet onglet aux favoris…"
+          }
+        }
+      }
     },
     "Bookmarks" : {
-      "comment" : "Default root bookmarks folder title\nImport data type - Bookmarks toggle label\nMain menu - Top-level Bookmarks menu title in the application menu bar\nSearch Tabs - Bookmark root menu title\nSearch Tabs - Bookmarks section title"
+      "comment" : "Default root bookmarks folder title\nImport data type - Bookmarks toggle label\nMain menu - Top-level Bookmarks menu title in the application menu bar\nSearch Tabs - Bookmark root menu title\nSearch Tabs - Bookmarks section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Favoris"
+          }
+        }
+      }
     },
     "Bookmarks Bar" : {
-      "comment" : "Bookmark editor - Root bookmark folder display name in folder picker"
+      "comment" : "Bookmark editor - Root bookmark folder display name in folder picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Barre de favoris"
+          }
+        }
+      }
     },
     "Bookmarks belonging to this Space will also be removed. This action cannot be undone." : {
-      "comment" : "Body of the delete-Space confirmation"
+      "comment" : "Body of the delete-Space confirmation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les favoris appartenant à cet espace seront également supprimés. Cette action est irréversible."
+          }
+        }
+      }
     },
     "Bot Token" : {
-      "comment" : "Phi Link - Custom bot token label"
+      "comment" : "Phi Link - Custom bot token label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bot Token"
+          }
+        }
+      }
     },
     "Browser data" : {
-      "comment" : "Import browser data page - Page title"
+      "comment" : "Import browser data page - Page title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Données du navigateur"
+          }
+        }
+      }
     },
     "Browser data can't be imported into Incognito. Switch to a regular Space or window, then try again." : {
-      "comment" : "Import browser data - Alert body explaining import is unavailable off-the-record"
+      "comment" : "Import browser data - Alert body explaining import is unavailable off-the-record",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les données du navigateur ne peuvent pas être importées en navigation privée. Passez à un espace ou une fenêtre normale, puis réessayez."
+          }
+        }
+      }
     },
     "Browser memory" : {
-      "comment" : "AI settings - Section title for browser memory management"
+      "comment" : "AI settings - Section title for browser memory management",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mémoire du navigateur"
+          }
+        }
+      }
     },
     "Browser Memory" : {
-      "comment" : "Header more menu - AI memory\nMemory button - Tooltip & Accessibility label for the AI memory entry button shown in the sidebar bottom bar and the web content header trailing area"
+      "comment" : "Header more menu - AI memory\nMemory button - Tooltip & Accessibility label for the AI memory entry button shown in the sidebar bottom bar and the web content header trailing area",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mémoire du navigateur"
+          }
+        }
+      }
     },
     "Browsing" : {
-      "comment" : "General settings - Browsing section title"
+      "comment" : "General settings - Browsing section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigation"
+          }
+        }
+      }
     },
     "Browsing history" : {
-      "comment" : "Import data type - Browsing history toggle label"
+      "comment" : "Import data type - Browsing history toggle label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Historique de navigation"
+          }
+        }
+      }
     },
     "Can’t change this Space’s profile yet" : {
-      "comment" : "Title shown when changing a Space's profile is blocked by an in-progress import"
+      "comment" : "Title shown when changing a Space's profile is blocked by an in-progress import",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de changer le profil de cet espace pour l'instant"
+          }
+        }
+      }
     },
     "Can’t delete this Space yet" : {
-      "comment" : "Title shown when deleting a Space is blocked by an in-progress import"
+      "comment" : "Title shown when deleting a Space is blocked by an in-progress import",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de supprimer cet espace pour l'instant"
+          }
+        }
+      }
     },
     "Can't Import Browser Data" : {
-      "comment" : "Import browser data - Alert title when import is invoked from an incognito window or the Incognito Space"
+      "comment" : "Import browser data - Alert title when import is invoked from an incognito window or the Incognito Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d'importer les données du navigateur"
+          }
+        }
+      }
     },
     "Cancel" : {
-      "comment" : "AI settings - Cancel button in disable-AI confirmation alert\nAI settings - Cancel button in disable-connectors confirmation alert\nAccount settings - Cancel button in logout confirmation dialog\nAccount settings - Cancel button in rename dialog\nCancel\nCancel button\nDebug clear data - Alert button to cancel clearing user data\nDebug import user data - Alert button to cancel importing user data\nDownload item row - Tooltip for cancel button during safety scan\nDownload item row - Tooltip for cancel download button\nEditor - Cancel button title\nGeneric - Cancel button to dismiss an alert\nNew folder dialog cancel button title\nTab group rename alert - Cancel button\nTooltip for cancel button during safety scan in living downloads toast\nUpdate alert - Button to cancel update installation"
+      "comment" : "AI settings - Cancel button in disable-AI confirmation alert\nAI settings - Cancel button in disable-connectors confirmation alert\nAccount settings - Cancel button in logout confirmation dialog\nAccount settings - Cancel button in rename dialog\nCancel\nCancel button\nDebug clear data - Alert button to cancel clearing user data\nDebug import user data - Alert button to cancel importing user data\nDownload item row - Tooltip for cancel button during safety scan\nDownload item row - Tooltip for cancel download button\nEditor - Cancel button title\nGeneric - Cancel button to dismiss an alert\nNew folder dialog cancel button title\nTab group rename alert - Cancel button\nTooltip for cancel button during safety scan in living downloads toast\nUpdate alert - Button to cancel update installation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler"
+          }
+        }
+      }
     },
     "Cancel First" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annuler d'abord"
+          }
+        }
+      }
     },
     "Canceled" : {
-      "comment" : "Download item row - Status label when download was cancelled"
+      "comment" : "Download item row - Status label when download was cancelled",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulé"
+          }
+        }
+      }
     },
     "Cancelled" : {
-      "comment" : "Download state"
+      "comment" : "Download state",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Annulé"
+          }
+        }
+      }
     },
     "Card %lld of %lld" : {
       "localizations" : {
@@ -372,1364 +1201,4970 @@
             "state" : "new",
             "value" : "Card %1$lld of %2$lld"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Carte %1$lld sur %2$lld"
+          }
         }
       }
     },
     "Certificate is invalid" : {
-      "comment" : "Address bar menu - Certificate validity status"
+      "comment" : "Address bar menu - Certificate validity status",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le certificat n'est pas valide"
+          }
+        }
+      }
     },
     "Certificate is valid" : {
-      "comment" : "Address bar menu - Certificate validity status"
+      "comment" : "Address bar menu - Certificate validity status",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le certificat est valide"
+          }
+        }
+      }
     },
     "Change Color" : {
-      "comment" : "Tab group context menu - Submenu to change the group color"
+      "comment" : "Tab group context menu - Submenu to change the group color",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer la couleur"
+          }
+        }
+      }
     },
     "Change Icon…" : {
-      "comment" : "Opens the icon/emoji picker for a Space\nSpaces menu - opens the icon/emoji picker below the active Space's icon\nTab-area menu - opens the icon/emoji picker below the active Space's icon"
+      "comment" : "Opens the icon/emoji picker for a Space\nSpaces menu - opens the icon/emoji picker below the active Space's icon\nTab-area menu - opens the icon/emoji picker below the active Space's icon",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer l'icône…"
+          }
+        }
+      }
     },
     "Change Name" : {
-      "comment" : "Account settings - Dialog title for changing user name"
+      "comment" : "Account settings - Dialog title for changing user name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer le nom"
+          }
+        }
+      }
     },
     "Change Profile" : {
-      "comment" : "Confirm button of the change-Space-profile confirmation\nSpaces menu - Submenu to re-bind the active Space to another profile"
+      "comment" : "Confirm button of the change-Space-profile confirmation\nSpaces menu - Submenu to re-bind the active Space to another profile",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer de profil"
+          }
+        }
+      }
     },
     "Change Profile to “%@”?" : {
-      "comment" : "Title of the change-Space-profile confirmation"
+      "comment" : "Title of the change-Space-profile confirmation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer le profil pour « %@ » ?"
+          }
+        }
+      }
     },
     "Change Theme" : {
-      "comment" : "Active-Space menu: change current Space theme"
+      "comment" : "Active-Space menu: change current Space theme",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changer le thème"
+          }
+        }
+      }
     },
     "Chat" : {
-      "comment" : "Sidebar bottom chat button title"
+      "comment" : "Sidebar bottom chat button title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chat"
+          }
+        }
+      }
     },
     "Check for Update..." : {
-      "comment" : "Phi menu - Menu item to check for app updates"
+      "comment" : "Phi menu - Menu item to check for app updates",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher une mise à jour…"
+          }
+        }
+      }
     },
     "Checking for updates..." : {
-      "comment" : "Phi menu - Menu item text while checking for updates"
+      "comment" : "Phi menu - Menu item text while checking for updates",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recherche de mises à jour…"
+          }
+        }
+      }
     },
     "Choose" : {
-      "comment" : "Profiles settings - download folder picker confirm button"
+      "comment" : "Profiles settings - download folder picker confirm button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir"
+          }
+        }
+      }
     },
     "Choose a download location for this profile." : {
-      "comment" : "Profiles settings - download folder picker message"
+      "comment" : "Profiles settings - download folder picker message",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez un emplacement de téléchargement pour ce profil."
+          }
+        }
+      }
     },
     "Choose Files" : {
-      "comment" : "Feedback form - Button to open file picker for attachments"
+      "comment" : "Feedback form - Button to open file picker for attachments",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir des fichiers"
+          }
+        }
+      }
     },
     "Choose…" : {
-      "comment" : "Profiles settings - download location not set"
+      "comment" : "Profiles settings - download location not set",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisir…"
+          }
+        }
+      }
     },
     "Chromium Engine Version %@" : {
-      "comment" : "About window - Chromium engine version label"
+      "comment" : "About window - Chromium engine version label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version du moteur Chromium %@"
+          }
+        }
+      }
     },
     "Clear Browsing Data" : {
-      "comment" : "Profiles settings - data link to clear browsing data"
+      "comment" : "Profiles settings - data link to clear browsing data",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer les données de navigation"
+          }
+        }
+      }
     },
     "Clear Cache" : {
-      "comment" : "Address bar menu - Settings submenu item to clear cache\nExtension list - Website settings item to clear cache"
+      "comment" : "Address bar menu - Settings submenu item to clear cache\nExtension list - Website settings item to clear cache",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vider le cache"
+          }
+        }
+      }
     },
     "Clear Cookie" : {
-      "comment" : "Address bar menu - Settings submenu item to clear cookie\nExtension list - Website settings item to clear cookies"
+      "comment" : "Address bar menu - Settings submenu item to clear cookie\nExtension list - Website settings item to clear cookies",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Effacer les cookies"
+          }
+        }
+      }
     },
     "Click " : {
-      "comment" : "Phi Link - Custom bot guide prefix"
+      "comment" : "Phi Link - Custom bot guide prefix",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cliquez "
+          }
+        }
+      }
     },
     "Click the title for overview. Click the arrow to expand or collapse." : {
-      "comment" : "Tab Groups - tooltip for horizontal-strip group chip interactions"
+      "comment" : "Tab Groups - tooltip for horizontal-strip group chip interactions",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cliquez sur le titre pour la vue d'ensemble. Cliquez sur la flèche pour développer ou réduire."
+          }
+        }
+      }
     },
     "Click to install update" : {
-      "comment" : "Phi menu - Menu item text when update is ready to install"
+      "comment" : "Phi menu - Menu item text when update is ready to install",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cliquez pour installer la mise à jour"
+          }
+        }
+      }
     },
     "Close" : {
-      "comment" : "Sidebar update reminder - Accessibility description for close button\nTab context menu - Menu item to close the selected tab"
+      "comment" : "Sidebar update reminder - Accessibility description for close button\nTab context menu - Menu item to close the selected tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer"
+          }
+        }
+      }
     },
     "Close Group" : {
-      "comment" : "Tab group context menu - Close the group and all its tabs"
+      "comment" : "Tab group context menu - Close the group and all its tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer le groupe"
+          }
+        }
+      }
     },
     "Close Group Overview" : {
-      "comment" : "Tab group overview - Accessibility label for the button that closes the overview"
+      "comment" : "Tab group overview - Accessibility label for the button that closes the overview",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer la vue d'ensemble du groupe"
+          }
+        }
+      }
     },
     "Close Other Tabs" : {
-      "comment" : "Tab context menu - Menu item to close all tabs except the selected one\nTab multi-selection context menu - close all tabs except the selected ones"
+      "comment" : "Tab context menu - Menu item to close all tabs except the selected one\nTab multi-selection context menu - close all tabs except the selected ones",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer les autres onglets"
+          }
+        }
+      }
     },
     "Close Space" : {
-      "comment" : "Spaces menu - close the Incognito Space's windows and clear the private session"
+      "comment" : "Spaces menu - close the Incognito Space's windows and clear the private session",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer l'espace"
+          }
+        }
+      }
     },
     "Close Tab" : {
-      "comment" : "Search Tabs - Close open tab button tooltip\nTab group overview - Accessibility label for the button that closes one tab card"
+      "comment" : "Search Tabs - Close open tab button tooltip\nTab group overview - Accessibility label for the button that closes one tab card",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer l'onglet"
+          }
+        }
+      }
     },
     "Close Tabs" : {
-      "comment" : "Tab multi-selection context menu - close all selected tabs"
+      "comment" : "Tab multi-selection context menu - close all selected tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer les onglets"
+          }
+        }
+      }
     },
     "Code Examples" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exemples de code"
+          }
+        }
+      }
     },
     "Collapse Group" : {
-      "comment" : "Tab group context menu - Collapse an expanded group"
+      "comment" : "Tab group context menu - Collapse an expanded group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réduire le groupe"
+          }
+        }
+      }
     },
     "Color" : {
-      "comment" : "General settings - Theme color row title\nSpaces settings - theme color row label"
+      "comment" : "General settings - Theme color row title\nSpaces settings - theme color row label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couleur"
+          }
+        }
+      }
     },
     "Color appearance" : {
-      "comment" : "General settings - Color appearance row title"
+      "comment" : "General settings - Color appearance row title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apparence des couleurs"
+          }
+        }
+      }
     },
     "Comfortable" : {
-      "comment" : "Layout option - Horizontal tabs\nOnboarding layout selection - Comfortable option"
+      "comment" : "Layout option - Horizontal tabs\nOnboarding layout selection - Comfortable option",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confortable"
+          }
+        }
+      }
     },
     "Complete First" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminer d'abord"
+          }
+        }
+      }
     },
     "Complete First In-Progress" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminer d'abord l'élément en cours"
+          }
+        }
+      }
     },
     "Completed" : {
-      "comment" : "Download state"
+      "comment" : "Download state",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé"
+          }
+        }
+      }
     },
     "Configured" : {
-      "comment" : "Phi Link - Custom bot configured status"
+      "comment" : "Phi Link - Custom bot configured status",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuré"
+          }
+        }
+      }
     },
     "Confirm" : {
-      "comment" : "New folder dialog confirm button title"
+      "comment" : "New folder dialog confirm button title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmer"
+          }
+        }
+      }
     },
     "Confirm Logout" : {
-      "comment" : "Account settings - Logout confirmation dialog title"
+      "comment" : "Account settings - Logout confirmation dialog title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmer la déconnexion"
+          }
+        }
+      }
     },
     "Confirm logout in the opened browser." : {
-      "comment" : "Account settings - Status shown while waiting for logout to finish"
+      "comment" : "Account settings - Status shown while waiting for logout to finish",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confirmez la déconnexion dans le navigateur ouvert."
+          }
+        }
+      }
     },
     "Conflicts with: %@" : {
-      "comment" : "Shortcuts settings - Warning text showing conflicting shortcuts"
+      "comment" : "Shortcuts settings - Warning text showing conflicting shortcuts",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En conflit avec : %@"
+          }
+        }
+      }
     },
     "Connect" : {
-      "comment" : "AI settings - Button to connect an external data connector"
+      "comment" : "AI settings - Button to connect an external data connector",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecter"
+          }
+        }
+      }
     },
     "Connected" : {
-      "comment" : "AI settings - Badge text when connector is successfully connected"
+      "comment" : "AI settings - Badge text when connector is successfully connected",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecté"
+          }
+        }
+      }
     },
     "Connection is not fully secure" : {
-      "comment" : "Address bar menu - Website security not fully secure\nWebsite security not fully secure"
+      "comment" : "Address bar menu - Website security not fully secure\nWebsite security not fully secure",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La connexion n'est pas entièrement sécurisée"
+          }
+        }
+      }
     },
     "Connection is not secure" : {
-      "comment" : "Address bar menu - Website security not secure\nWebsite security not secure"
+      "comment" : "Address bar menu - Website security not secure\nWebsite security not secure",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La connexion n'est pas sécurisée"
+          }
+        }
+      }
     },
     "Connection is secure" : {
-      "comment" : "Address bar menu - Website security secure\nWebsite security secure"
+      "comment" : "Address bar menu - Website security secure\nWebsite security secure",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La connexion est sécurisée"
+          }
+        }
+      }
     },
     "Connector authorization failed." : {
-      "comment" : "AI settings - OAuth authorization failure"
+      "comment" : "AI settings - OAuth authorization failure",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de l'autorisation du connecteur."
+          }
+        }
+      }
     },
     "Cookies" : {
-      "comment" : "Import data type - Cookies toggle label"
+      "comment" : "Import data type - Cookies toggle label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cookies"
+          }
+        }
+      }
     },
     "Copy Left URL" : {
-      "comment" : "Bookmark context menu - Copy the left (primary) URL of a split-view bookmark\nTab context menu - Copy the left pane's URL for a split"
+      "comment" : "Bookmark context menu - Copy the left (primary) URL of a split-view bookmark\nTab context menu - Copy the left pane's URL for a split",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier l'URL de gauche"
+          }
+        }
+      }
     },
     "Copy Link" : {
-      "comment" : "Address bar menu - Copy link menu item\nBookmark Copy Link menu item\nDownload item row - Tooltip for copy link button\nSidebar address bar - Copy current page URL button tooltip\nTab context menu - Menu item to copy the tab URL to clipboard\nTooltip for button to copy download URL in living downloads toast"
+      "comment" : "Address bar menu - Copy link menu item\nBookmark Copy Link menu item\nDownload item row - Tooltip for copy link button\nSidebar address bar - Copy current page URL button tooltip\nTab context menu - Menu item to copy the tab URL to clipboard\nTooltip for button to copy download URL in living downloads toast",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier le lien"
+          }
+        }
+      }
     },
     "Copy Links" : {
-      "comment" : "Tab multi-selection context menu - copy links of all selected tabs"
+      "comment" : "Tab multi-selection context menu - copy links of all selected tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier les liens"
+          }
+        }
+      }
     },
     "Copy Right URL" : {
-      "comment" : "Bookmark context menu - Copy the right (secondary) URL of a split-view bookmark\nTab context menu - Copy the right pane's URL for a split"
+      "comment" : "Bookmark context menu - Copy the right (secondary) URL of a split-view bookmark\nTab context menu - Copy the right pane's URL for a split",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier l'URL de droite"
+          }
+        }
+      }
     },
     "Copy URL" : {
-      "comment" : "Edit menu - Copy the selected tab URL to the clipboard"
+      "comment" : "Edit menu - Copy the selected tab URL to the clipboard",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier l'URL"
+          }
+        }
+      }
     },
     "Copy URLs" : {
-      "comment" : "Edit menu - Copy the selected tab URLs to the clipboard"
+      "comment" : "Edit menu - Copy the selected tab URLs to the clipboard",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copier les URL"
+          }
+        }
+      }
     },
     "Coral" : {
-      "comment" : "Coral theme color name"
+      "comment" : "Coral theme color name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Corail"
+          }
+        }
+      }
     },
     "Could Not Add Attachment" : {
-      "comment" : "Feedback form - Alert title when selected attachments cannot be added"
+      "comment" : "Feedback form - Alert title when selected attachments cannot be added",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d'ajouter la pièce jointe"
+          }
+        }
+      }
     },
     "Could Not Save Feedback" : {
-      "comment" : "Feedback form - Alert title when local outbox save fails"
+      "comment" : "Feedback form - Alert title when local outbox save fails",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d'enregistrer le commentaire"
+          }
+        }
+      }
     },
     "Couldn't delete profile" : {
-      "comment" : "Title of the profile-delete error"
+      "comment" : "Title of the profile-delete error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de supprimer le profil"
+          }
+        }
+      }
     },
     "Couldn't rename profile" : {
-      "comment" : "Title of the profile-rename error"
+      "comment" : "Title of the profile-rename error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible de renommer le profil"
+          }
+        }
+      }
     },
     "Crash Samples" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échantillons de plantage"
+          }
+        }
+      }
     },
     "Create" : {
-      "comment" : "Create button"
+      "comment" : "Create button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer"
+          }
+        }
+      }
     },
     "Create a new folder to organize your bookmarks." : {
-      "comment" : "Folder creator - Subtitle explaining new folder creation"
+      "comment" : "Folder creator - Subtitle explaining new folder creation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créez un nouveau dossier pour organiser vos favoris."
+          }
+        }
+      }
     },
     "Create a Space" : {
-      "comment" : "Title of the create-Space panel"
+      "comment" : "Title of the create-Space panel",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer un espace"
+          }
+        }
+      }
     },
     "Create Space" : {
-      "comment" : "Confirm button in the create-Space panel"
+      "comment" : "Confirm button in the create-Space panel",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Créer un espace"
+          }
+        }
+      }
     },
     "Credit Cards" : {
-      "comment" : "Profiles settings - data link to payment methods"
+      "comment" : "Profiles settings - data link to payment methods",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cartes bancaires"
+          }
+        }
+      }
     },
     "Current" : {
-      "comment" : "Marks the Space the user is currently in, in the ask-Space list"
+      "comment" : "Marks the Space the user is currently in, in the ask-Space list",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actuel"
+          }
+        }
+      }
     },
     "Current Space" : {
-      "comment" : "Fallback label for the import-target Space when it can't be resolved by id"
+      "comment" : "Fallback label for the import-target Space when it can't be resolved by id",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace actuel"
+          }
+        }
+      }
     },
     "Custom Telegram bot" : {
-      "comment" : "Phi Link - Custom bot title"
+      "comment" : "Phi Link - Custom bot title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bot Telegram personnalisé"
+          }
+        }
+      }
     },
     "Cyan" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cyan"
+          }
+        }
+      }
     },
     "Dark" : {
-      "comment" : "Appearance choice: always dark mode"
+      "comment" : "Appearance choice: always dark mode",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sombre"
+          }
+        }
+      }
     },
     "DEBUG Test Mode" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode test DEBUG"
+          }
+        }
+      }
     },
     "Default" : {
-      "comment" : "Settings - badge marking the default Space or Profile"
+      "comment" : "Settings - badge marking the default Space or Profile",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Par défaut"
+          }
+        }
+      }
     },
     "Delete" : {
-      "comment" : "Delete bookmark menu item\nDestructive button\nDestructive menu item"
+      "comment" : "Delete bookmark menu item\nDestructive button\nDestructive menu item",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer"
+          }
+        }
+      }
     },
     "Delete “%@”?" : {
-      "comment" : "Title of the delete-Space confirmation"
+      "comment" : "Title of the delete-Space confirmation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer « %@ » ?"
+          }
+        }
+      }
     },
     "Delete Profile" : {
-      "comment" : "Spaces menu - Submenu listing deletable browser profiles"
+      "comment" : "Spaces menu - Submenu listing deletable browser profiles",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le profil"
+          }
+        }
+      }
     },
     "Delete profile “%@”?" : {
-      "comment" : "Title of the delete-profile confirmation"
+      "comment" : "Title of the delete-profile confirmation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le profil « %@ » ?"
+          }
+        }
+      }
     },
     "Delete selected profile" : {
-      "comment" : "Profiles settings - delete profile tooltip"
+      "comment" : "Profiles settings - delete profile tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer le profil sélectionné"
+          }
+        }
+      }
     },
     "Delete selected Space" : {
-      "comment" : "Spaces settings - delete Space tooltip"
+      "comment" : "Spaces settings - delete Space tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer l'espace sélectionné"
+          }
+        }
+      }
     },
     "Delete Space…" : {
-      "comment" : "Spaces menu - Delete the active Space"
+      "comment" : "Spaces menu - Delete the active Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer l'espace…"
+          }
+        }
+      }
     },
     "Deleted" : {
-      "comment" : "Download item row - Status label when downloaded file was deleted"
+      "comment" : "Download item row - Status label when downloaded file was deleted",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimé"
+          }
+        }
+      }
     },
     "Describe the issue in detail" : {
-      "comment" : "Feedback form - Section header prompting user to describe the issue"
+      "comment" : "Feedback form - Section header prompting user to describe the issue",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Décrivez le problème en détail"
+          }
+        }
+      }
     },
     "Discard" : {
-      "comment" : "Download item row - Tooltip for discard button on blocked download\nDownload item row - Tooltip for discard button on safety warning\nTooltip for discard button on blocked download in living downloads toast\nTooltip for discard button on safety warning in living downloads toast"
+      "comment" : "Download item row - Tooltip for discard button on blocked download\nDownload item row - Tooltip for discard button on safety warning\nTooltip for discard button on blocked download in living downloads toast\nTooltip for discard button on safety warning in living downloads toast",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abandonner"
+          }
+        }
+      }
     },
     "Disconnect" : {
-      "comment" : "AI settings - Button to disconnect an external data connector"
+      "comment" : "AI settings - Button to disconnect an external data connector",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déconnecter"
+          }
+        }
+      }
     },
     "Dismiss" : {
-      "comment" : "Tooltip for button to dismiss living download item"
+      "comment" : "Tooltip for button to dismiss living download item",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorer"
+          }
+        }
+      }
     },
     "Domain" : {
-      "comment" : "URL rule match type: exact host only"
+      "comment" : "URL rule match type: exact host only",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Domaine"
+          }
+        }
+      }
     },
     "Domain contains" : {
-      "comment" : "URL rule match type: host contains a substring"
+      "comment" : "URL rule match type: host contains a substring",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le domaine contient"
+          }
+        }
+      }
     },
     "Domain suffix" : {
-      "comment" : "URL rule match type: host plus all subdomains"
+      "comment" : "URL rule match type: host plus all subdomains",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suffixe de domaine"
+          }
+        }
+      }
     },
     "Download image" : {
-      "comment" : "Account settings - Button to download profile card as image"
+      "comment" : "Account settings - Button to download profile card as image",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Télécharger l'image"
+          }
+        }
+      }
     },
     "Download location" : {
-      "comment" : "Profiles settings - download location row label"
+      "comment" : "Profiles settings - download location row label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emplacement de téléchargement"
+          }
+        }
+      }
     },
     "Download Test Controls" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Contrôles de test de téléchargement"
+          }
+        }
+      }
     },
     "Downloading" : {
-      "comment" : "Download state"
+      "comment" : "Download state",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement"
+          }
+        }
+      }
     },
     "Downloading rollback package..." : {
-      "comment" : "Time Machine restore progress stage"
+      "comment" : "Time Machine restore progress stage",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement du paquet de restauration…"
+          }
+        }
+      }
     },
     "Downloading update..." : {
-      "comment" : "Phi menu - Menu item text while downloading update"
+      "comment" : "Phi menu - Menu item text while downloading update",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement de la mise à jour…"
+          }
+        }
+      }
     },
     "Downloading..." : {
-      "comment" : "Placeholder text when download filename is not yet available"
+      "comment" : "Placeholder text when download filename is not yet available",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargement…"
+          }
+        }
+      }
     },
     "Downloads" : {
-      "comment" : "Header more menu - Downloads action"
+      "comment" : "Header more menu - Downloads action",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Téléchargements"
+          }
+        }
+      }
     },
     "Drag tabs here or pin them from the tab list" : {
-      "comment" : "Drag tabs here or pin them from the tab list"
+      "comment" : "Drag tabs here or pin them from the tab list",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faites glisser des onglets ici ou épinglez-les depuis la liste des onglets"
+          }
+        }
+      }
     },
     "Duplicate" : {
-      "comment" : "Tab context menu - Menu item to duplicate the selected tab"
+      "comment" : "Tab context menu - Menu item to duplicate the selected tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dupliquer"
+          }
+        }
+      }
     },
     "Duplicate Split" : {
-      "comment" : "Tab context menu - Duplicate both panes of a split as a new split"
+      "comment" : "Tab context menu - Duplicate both panes of a split as a new split",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dupliquer la division"
+          }
+        }
+      }
     },
     "Duplicate Tabs" : {
-      "comment" : "Tab multi-selection context menu - duplicate all selected tabs"
+      "comment" : "Tab multi-selection context menu - duplicate all selected tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dupliquer les onglets"
+          }
+        }
+      }
     },
     "e.g. 123456:ABC-DEF..." : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ex. 123456:ABC-DEF…"
+          }
+        }
+      }
     },
     "Each space has its own independent bookmarks" : {
-      "comment" : "Subtitle of the create-Space panel"
+      "comment" : "Subtitle of the create-Space panel",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chaque espace possède ses propres favoris indépendants"
+          }
+        }
+      }
     },
     "Edit Bookmark" : {
-      "comment" : "Bookmark editor - Title of the sheet to edit a bookmark"
+      "comment" : "Bookmark editor - Title of the sheet to edit a bookmark",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier le favori"
+          }
+        }
+      }
     },
     "Edit Folder" : {
-      "comment" : "Folder editor - Title of the sheet to edit a folder"
+      "comment" : "Folder editor - Title of the sheet to edit a folder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier le dossier"
+          }
+        }
+      }
     },
     "Edit Pinned Split" : {
-      "comment" : "Favorite editor - Title of the sheet to edit a pinned split-view tab"
+      "comment" : "Favorite editor - Title of the sheet to edit a pinned split-view tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier la division épinglée"
+          }
+        }
+      }
     },
     "Edit Pinned Tab" : {
-      "comment" : "Favorite editor - Title of the sheet to edit a pin"
+      "comment" : "Favorite editor - Title of the sheet to edit a pin",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier l'onglet épinglé"
+          }
+        }
+      }
     },
     "Edit Split Bookmark" : {
-      "comment" : "Bookmark editor - Title of the sheet when editing a split-view bookmark"
+      "comment" : "Bookmark editor - Title of the sheet when editing a split-view bookmark",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier le favori de division"
+          }
+        }
+      }
     },
     "Edit the name and address for this bookmark." : {
-      "comment" : "Bookmark editor - Subtitle explaining bookmark editing"
+      "comment" : "Bookmark editor - Subtitle explaining bookmark editing",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifiez le nom et l'adresse de ce favori."
+          }
+        }
+      }
     },
     "Edit the name and address for this pinned tab." : {
-      "comment" : "Pinned tab editor - Subtitle explaining pinned tab editing"
+      "comment" : "Pinned tab editor - Subtitle explaining pinned tab editing",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifiez le nom et l'adresse de cet onglet épinglé."
+          }
+        }
+      }
     },
     "Edit the name and both addresses for this split-view bookmark." : {
-      "comment" : "Bookmark editor - Subtitle explaining split-view bookmark editing"
+      "comment" : "Bookmark editor - Subtitle explaining split-view bookmark editing",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifiez le nom et les deux adresses de ce favori en vue divisée."
+          }
+        }
+      }
     },
     "Edit the names and addresses for both panes of this pinned split." : {
-      "comment" : "Pinned tab editor - Subtitle explaining pinned split editing"
+      "comment" : "Pinned tab editor - Subtitle explaining pinned split editing",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifiez les noms et adresses des deux volets de cette division épinglée."
+          }
+        }
+      }
     },
     "Edit Theme" : {
-      "comment" : "Spaces menu - Submenu to set a theme override for the active Space"
+      "comment" : "Spaces menu - Submenu to set a theme override for the active Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier le thème"
+          }
+        }
+      }
     },
     "Edit..." : {
-      "comment" : "Edit bookmark url menu item title\nPinned tab context menu - Edit pinned tab menu item"
+      "comment" : "Edit bookmark url menu item title\nPinned tab context menu - Edit pinned tab menu item",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modifier…"
+          }
+        }
+      }
     },
     "Emoji" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Emoji"
+          }
+        }
+      }
     },
     "Empty" : {
-      "comment" : "Bookmarks menu - Disabled placeholder item shown when a bookmark folder has no child bookmarks\nSearch Tabs - Empty bookmark folder placeholder\nSearch Tabs - Empty bookmark menu placeholder"
+      "comment" : "Bookmarks menu - Disabled placeholder item shown when a bookmark folder has no child bookmarks\nSearch Tabs - Empty bookmark folder placeholder\nSearch Tabs - Empty bookmark menu placeholder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vide"
+          }
+        }
+      }
     },
     "Enable AI features in Phi Browser" : {
-      "comment" : "AI settings - Master toggle to enable or disable all AI features in Phi Browser"
+      "comment" : "AI settings - Master toggle to enable or disable all AI features in Phi Browser",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer les fonctionnalités IA dans Phi Browser"
+          }
+        }
+      }
     },
     "Enable External Data Connectors" : {
-      "comment" : "AI settings - Toggle to enable external data connectors"
+      "comment" : "AI settings - Toggle to enable external data connectors",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Activer les connecteurs de données externes"
+          }
+        }
+      }
     },
     "Enter a name for the new folder." : {
-      "comment" : "Bookmark editor - Inline new folder creation subtitle"
+      "comment" : "Bookmark editor - Inline new folder creation subtitle",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisissez un nom pour le nouveau dossier."
+          }
+        }
+      }
     },
     "Enter a name for the new profile. Each profile has its own cookies, history, and extensions." : {
-      "comment" : "Body of the create-profile dialog"
+      "comment" : "Body of the create-profile dialog",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisissez un nom pour le nouveau profil. Chaque profil possède ses propres cookies, historique et extensions."
+          }
+        }
+      }
     },
     "Enter a new name for this profile." : {
-      "comment" : "Body of the rename-profile dialog"
+      "comment" : "Body of the rename-profile dialog",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisissez un nouveau nom pour ce profil."
+          }
+        }
+      }
     },
     "Enter a new name for this Space." : {
-      "comment" : "Body of the rename-Space dialog"
+      "comment" : "Body of the rename-Space dialog",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saisissez un nouveau nom pour cet espace."
+          }
+        }
+      }
     },
     "Error" : {
-      "comment" : "Phi Link - Custom bot generic error text"
+      "comment" : "Phi Link - Custom bot generic error text",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur"
+          }
+        }
+      }
     },
     "example" : {
-      "comment" : "URL rule value placeholder for Domain contains match"
+      "comment" : "URL rule value placeholder for Domain contains match",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "exemple"
+          }
+        }
+      }
     },
     "example.com" : {
-      "comment" : "URL rule value placeholder for Domain suffix match"
+      "comment" : "URL rule value placeholder for Domain suffix match",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "example.com"
+          }
+        }
+      }
     },
     "Expand Group" : {
-      "comment" : "Tab group context menu - Expand a collapsed group"
+      "comment" : "Tab group context menu - Expand a collapsed group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Développer le groupe"
+          }
+        }
+      }
     },
     "Expanding rollback package..." : {
-      "comment" : "Time Machine restore progress stage"
+      "comment" : "Time Machine restore progress stage",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extraction du paquet de restauration…"
+          }
+        }
+      }
     },
     "Export" : {
-      "comment" : "Help menu - NSSavePanel primary button title for confirming log export save location"
+      "comment" : "Help menu - NSSavePanel primary button title for confirming log export save location",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporter"
+          }
+        }
+      }
     },
     "Export Failed" : {
-      "comment" : "Help menu - Log export error alert title"
+      "comment" : "Help menu - Log export error alert title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de l'exportation"
+          }
+        }
+      }
     },
     "Export Logs" : {
-      "comment" : "Help menu - Log export alert title when no log folders exist\nHelp menu - NSSavePanel window title for saving the log export zip"
+      "comment" : "Help menu - Log export alert title when no log folders exist\nHelp menu - NSSavePanel window title for saving the log export zip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporter les journaux"
+          }
+        }
+      }
     },
     "Export Logs..." : {
-      "comment" : "Help menu - Menu item to export Phi and Sentinel logs as a zip archive; visible only when holding Option key"
+      "comment" : "Help menu - Menu item to export Phi and Sentinel logs as a zip archive; visible only when holding Option key",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporter les journaux…"
+          }
+        }
+      }
     },
     "Export User Data..." : {
-      "comment" : "Help menu - Submenu item to save Phi user data folder as a zip backup"
+      "comment" : "Help menu - Submenu item to save Phi user data folder as a zip backup",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exporter les données utilisateur…"
+          }
+        }
+      }
     },
     "Extension Info" : {
-      "comment" : "Extension info alert - Title of the alert showing extension version information\nHelp menu - Menu item to show extension version info, only visible when holding Option key"
+      "comment" : "Extension info alert - Title of the alert showing extension version information\nHelp menu - Menu item to show extension version info, only visible when holding Option key",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Infos sur l'extension"
+          }
+        }
+      }
     },
     "Extensions" : {
-      "comment" : "Address bar menu - Extensions submenu title\nExtension list - Section title for browser extensions\nImport data type - Extensions toggle label\nWeb content header - Extensions menu button"
+      "comment" : "Address bar menu - Extensions submenu title\nExtension list - Section title for browser extensions\nImport data type - Extensions toggle label\nWeb content header - Extensions menu button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Extensions"
+          }
+        }
+      }
     },
     "External Data Connectors" : {
-      "comment" : "AI settings - Section title for external data connectors\nAI settings - Sub-section title for connectors list within the container"
+      "comment" : "AI settings - Section title for external data connectors\nAI settings - Sub-section title for connectors list within the container",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecteurs de données externes"
+          }
+        }
+      }
     },
     "External Data Connectors help to provide additional context for better AI experience" : {
-      "comment" : "AI settings - Description explaining external data connectors purpose"
+      "comment" : "AI settings - Description explaining external data connectors purpose",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les connecteurs de données externes aident à fournir un contexte supplémentaire pour une meilleure expérience IA"
+          }
+        }
+      }
     },
     "Fail First In-Progress" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échouer d'abord l'élément en cours"
+          }
+        }
+      }
     },
     "Failed" : {
-      "comment" : "Download item row - Status label when download failed\nDownload state"
+      "comment" : "Download item row - Status label when download failed\nDownload state",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échoué"
+          }
+        }
+      }
     },
     "Failed to decode image" : {
-      "comment" : "Image preview error"
+      "comment" : "Image preview error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec du décodage de l'image"
+          }
+        }
+      }
     },
     "Failed to load remote image" : {
-      "comment" : "Image preview error"
+      "comment" : "Image preview error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec du chargement de l'image distante"
+          }
+        }
+      }
     },
     "Feedback" : {
-      "comment" : "Feedback - Sidebar feedback button title\nFeedback - Tooltip text for icon-only feedback button\nHeader more menu - Feedback action"
+      "comment" : "Feedback - Sidebar feedback button title\nFeedback - Tooltip text for icon-only feedback button\nHeader more menu - Feedback action",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Commentaires"
+          }
+        }
+      }
     },
     "Find shortcut keys" : {
-      "comment" : "Shortcuts settings - Search field placeholder to find shortcuts"
+      "comment" : "Shortcuts settings - Search field placeholder to find shortcuts",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher les touches de raccourci"
+          }
+        }
+      }
     },
     "Finish" : {
-      "comment" : "Onboarding password manager - Finish button"
+      "comment" : "Onboarding password manager - Finish button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminer"
+          }
+        }
+      }
     },
     "Folder" : {
-      "comment" : "Bookmark editor - Label for the folder picker"
+      "comment" : "Bookmark editor - Label for the folder picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dossier"
+          }
+        }
+      }
     },
     "Folder Name" : {
-      "comment" : "Folder editor - Placeholder for folder name input\nNew folder dialog input placeholder"
+      "comment" : "Folder editor - Placeholder for folder name input\nNew folder dialog input placeholder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom du dossier"
+          }
+        }
+      }
     },
     "Follow Global" : {
-      "comment" : "Create-Space panel — toggle so the new Space follows the global theme\nSpaces menu - Theme submenu entry that clears the per-Space override\nSpaces settings - theme entry that clears the per-Space override\nSpaces settings - theme follows global label\nTheme menu: clear per-Space override"
+      "comment" : "Create-Space panel — toggle so the new Space follows the global theme\nSpaces menu - Theme submenu entry that clears the per-Space override\nSpaces settings - theme entry that clears the per-Space override\nSpaces settings - theme follows global label\nTheme menu: clear per-Space override",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suivre les réglages globaux"
+          }
+        }
+      }
     },
     "Forward" : {
-      "comment" : "Web content header - Accessibility description for forward navigation button"
+      "comment" : "Web content header - Accessibility description for forward navigation button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avancer"
+          }
+        }
+      }
     },
     "From %@" : {
-      "comment" : "Download item row - Source host label showing where the file is downloaded from"
+      "comment" : "Download item row - Source host label showing where the file is downloaded from",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "De %@"
+          }
+        }
+      }
     },
     "From Arc" : {
-      "comment" : "Import browser data page - Option label to import data from Arc browser"
+      "comment" : "Import browser data page - Option label to import data from Arc browser",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depuis Arc"
+          }
+        }
+      }
     },
     "From Chrome" : {
-      "comment" : "Import browser data page - Option label to import data from Chrome browser"
+      "comment" : "Import browser data page - Option label to import data from Chrome browser",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depuis Chrome"
+          }
+        }
+      }
     },
     "From Safari" : {
-      "comment" : "Import browser data page - Option label to import data from Safari browser"
+      "comment" : "Import browser data page - Option label to import data from Safari browser",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Depuis Safari"
+          }
+        }
+      }
     },
     "General" : {
-      "comment" : "Settings - Tab title for general settings"
+      "comment" : "Settings - Tab title for general settings",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Général"
+          }
+        }
+      }
     },
     "Give this folder a name to organize your bookmarks." : {
-      "comment" : "Folder editor - Subtitle explaining folder naming"
+      "comment" : "Folder editor - Subtitle explaining folder naming",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Donnez un nom à ce dossier pour organiser vos favoris."
+          }
+        }
+      }
     },
     "Go back and try again" : {
-      "comment" : "Retry link text shown when login fails in onboarding"
+      "comment" : "Retry link text shown when login fails in onboarding",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Revenez en arrière et réessayez"
+          }
+        }
+      }
     },
     "Go to Space \"%@\"" : {
-      "comment" : "Shortcuts settings - Command title to activate the Space at this position"
+      "comment" : "Shortcuts settings - Command title to activate the Space at this position",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aller à l'espace « %@ »"
+          }
+        }
+      }
     },
     "Go to the browser to complete log in" : {
-      "comment" : "Waiting view title shown during login process in onboarding"
+      "comment" : "Waiting view title shown during login process in onboarding",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Accédez au navigateur pour terminer la connexion"
+          }
+        }
+      }
     },
     "Green" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vert"
+          }
+        }
+      }
     },
     "Grey" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gris"
+          }
+        }
+      }
     },
     "here to begin the @BotFather" : {
-      "comment" : "Phi Link - Custom bot guide link text"
+      "comment" : "Phi Link - Custom bot guide link text",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ici pour commencer avec @BotFather"
+          }
+        }
+      }
     },
     "Hide" : {
-      "comment" : "Phi Link - Hide token plaintext button"
+      "comment" : "Phi Link - Hide token plaintext button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Masquer"
+          }
+        }
+      }
     },
     "Hold ⌘ to switch →" : {
-      "comment" : "Omnibox suggestion - Hint shown for suggestions that can switch to an open tab"
+      "comment" : "Omnibox suggestion - Hint shown for suggestions that can switch to an open tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maintenez ⌘ pour changer →"
+          }
+        }
+      }
     },
     "https://example.com" : {
-      "comment" : "Editor - Placeholder example URL in text field"
+      "comment" : "Editor - Placeholder example URL in text field",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com"
+          }
+        }
+      }
     },
     "https://example.com/path" : {
-      "comment" : "URL rule value placeholder for URL (host + path) match"
+      "comment" : "URL rule value placeholder for URL (host + path) match",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "https://example.com/path"
+          }
+        }
+      }
     },
     "I'll setup my own" : {
-      "comment" : "Onboarding password manager - Manual setup option"
+      "comment" : "Onboarding password manager - Manual setup option",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je configurerai le mien"
+          }
+        }
+      }
     },
     "iCloud Passwords" : {
-      "comment" : "Onboarding password manager - iCloud Passwords option"
+      "comment" : "Onboarding password manager - iCloud Passwords option",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mots de passe iCloud"
+          }
+        }
+      }
     },
     "Icon" : {
-      "comment" : "Spaces settings - icon section header"
+      "comment" : "Spaces settings - icon section header",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Icône"
+          }
+        }
+      }
     },
     "Image file not found" : {
-      "comment" : "Image preview error"
+      "comment" : "Image preview error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fichier image introuvable"
+          }
+        }
+      }
     },
     "Import completed successfully" : {
-      "comment" : "Browser data importer - Status message when all imports completed successfully"
+      "comment" : "Browser data importer - Status message when all imports completed successfully",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importation terminée avec succès"
+          }
+        }
+      }
     },
     "Import completed with errors. Failed to import from: %@" : {
-      "comment" : "Browser data importer - Status message when some imports failed, shows list of failed browsers"
+      "comment" : "Browser data importer - Status message when some imports failed, shows list of failed browsers",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importation terminée avec des erreurs. Échec de l'importation depuis : %@"
+          }
+        }
+      }
     },
     "Import Failed" : {
-      "comment" : "Debug import user data - Alert title when extracting or applying backup fails"
+      "comment" : "Debug import user data - Alert title when extracting or applying backup fails",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de l'importation"
+          }
+        }
+      }
     },
     "Import Phi User Data?" : {
-      "comment" : "Debug import user data - Confirmation alert title before replacing Phi user data from zip"
+      "comment" : "Debug import user data - Confirmation alert title before replacing Phi user data from zip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les données utilisateur de Phi ?"
+          }
+        }
+      }
     },
     "Import User Data..." : {
-      "comment" : "Help menu - Submenu item to replace Phi user data from a zip backup and relaunch the app"
+      "comment" : "Help menu - Submenu item to replace Phi user data from a zip backup and relaunch the app",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer les données utilisateur…"
+          }
+        }
+      }
     },
     "Import..." : {
-      "comment" : "Debug import user data - Alert button to open file picker for zip backup"
+      "comment" : "Debug import user data - Alert button to open file picker for zip backup",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importer…"
+          }
+        }
+      }
     },
     "Imported From Arc" : {
-      "comment" : "Arc bookmarks import folder title"
+      "comment" : "Arc bookmarks import folder title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importé depuis Arc"
+          }
+        }
+      }
     },
     "Importing Arc data..." : {
-      "comment" : "Browser data importer - Status message while importing Arc browser data"
+      "comment" : "Browser data importer - Status message while importing Arc browser data",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importation des données Arc…"
+          }
+        }
+      }
     },
     "Importing Chrome data..." : {
-      "comment" : "Browser data importer - Status message while importing Chrome browser data"
+      "comment" : "Browser data importer - Status message while importing Chrome browser data",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importation des données Chrome…"
+          }
+        }
+      }
     },
     "Importing Safari data..." : {
-      "comment" : "Browser data importer - Status message while importing Safari browser data"
+      "comment" : "Browser data importer - Status message while importing Safari browser data",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Importation des données Safari…"
+          }
+        }
+      }
     },
     "Incognito" : {
-      "comment" : "Built-in Incognito Space name\nIncognito label in the native new tab page"
+      "comment" : "Built-in Incognito Space name\nIncognito label in the native new tab page",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navigation privée"
+          }
+        }
+      }
     },
     "Incognito Space" : {
-      "comment" : "Spaces settings - Incognito Space toggle label"
+      "comment" : "Spaces settings - Incognito Space toggle label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace privé"
+          }
+        }
+      }
     },
     "Install and Restart" : {
-      "comment" : "Update alert - Button to install update and restart the app"
+      "comment" : "Update alert - Button to install update and restart the app",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installer et redémarrer"
+          }
+        }
+      }
     },
     "Install Update" : {
-      "comment" : "Update alert - Title for install update confirmation dialog"
+      "comment" : "Update alert - Title for install update confirmation dialog",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installer la mise à jour"
+          }
+        }
+      }
     },
     "Invalid image source" : {
-      "comment" : "Image preview error"
+      "comment" : "Image preview error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Source d'image non valide"
+          }
+        }
+      }
     },
     "Invalid Input" : {
-      "comment" : "Account settings - Alert title for invalid input"
+      "comment" : "Account settings - Alert title for invalid input",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrée non valide"
+          }
+        }
+      }
     },
     "Invitation Code" : {
-      "comment" : "Account settings - Label for invitation code field"
+      "comment" : "Account settings - Label for invitation code field",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Code d'invitation"
+          }
+        }
+      }
     },
     "Invitation Code Details" : {
-      "comment" : "Account settings - Window title for invitation code details"
+      "comment" : "Account settings - Window title for invitation code details",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Détails du code d'invitation"
+          }
+        }
+      }
     },
     "Iris" : {
-      "comment" : "Iris theme color name"
+      "comment" : "Iris theme color name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iris"
+          }
+        }
+      }
     },
     "Item 1" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élément 1"
+          }
+        }
+      }
     },
     "Item 2" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Élément 2"
+          }
+        }
+      }
     },
     "Its open tabs will close and its browsing data will be cleared." : {
-      "comment" : "Body of the confirmation shown when disabling the Incognito Space with open tabs"
+      "comment" : "Body of the confirmation shown when disabling the Incognito Space with open tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ses onglets ouverts se fermeront et ses données de navigation seront effacées."
+          }
+        }
+      }
     },
     "Just now" : {
-      "comment" : "Download item row - Relative time when download completed less than a minute ago"
+      "comment" : "Download item row - Relative time when download completed less than a minute ago",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "À l'instant"
+          }
+        }
+      }
     },
     "Keep" : {
-      "comment" : "Download item row - Tooltip for keep button on safety warning\nTooltip for keep button on safety warning in living downloads toast"
+      "comment" : "Download item row - Tooltip for keep button on safety warning\nTooltip for keep button on safety warning in living downloads toast",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conserver"
+          }
+        }
+      }
     },
     "Launch Phi Sentinel automatically at login" : {
-      "comment" : "AI settings - Toggle to auto-launch Phi Sentinel at system login"
+      "comment" : "AI settings - Toggle to auto-launch Phi Sentinel at system login",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lancer Phi Sentinel automatiquement à l'ouverture de session"
+          }
+        }
+      }
     },
     "Layout mode" : {
-      "comment" : "General settings - Layout mode row title"
+      "comment" : "General settings - Layout mode row title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode de disposition"
+          }
+        }
+      }
     },
     "Layout Mode" : {
-      "comment" : "General settings - Section title for layout configuration\nTab area context menu - Switch layout mode\nView menu - Layout mode section header in View menu"
+      "comment" : "General settings - Section title for layout configuration\nTab area context menu - Switch layout mode\nView menu - Layout mode section header in View menu",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mode de disposition"
+          }
+        }
+      }
     },
     "Layout selection" : {
-      "comment" : "Onboarding layout selection - Page title"
+      "comment" : "Onboarding layout selection - Page title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélection de la disposition"
+          }
+        }
+      }
     },
     "Leave empty to use the auto-generated name." : {
-      "comment" : "Tab group rename alert - Hint that empty title clears to auto-name"
+      "comment" : "Tab group rename alert - Hint that empty title clears to auto-name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laissez vide pour utiliser le nom généré automatiquement."
+          }
+        }
+      }
     },
     "Left Name" : {
-      "comment" : "Bookmark editor - Label for the left (primary) title input field on a split-view bookmark"
+      "comment" : "Bookmark editor - Label for the left (primary) title input field on a split-view bookmark",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom de gauche"
+          }
+        }
+      }
     },
     "Left URL" : {
-      "comment" : "Bookmark editor - Label for the left (primary) URL input field on a split-view bookmark"
+      "comment" : "Bookmark editor - Label for the left (primary) URL input field on a split-view bookmark",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL de gauche"
+          }
+        }
+      }
     },
     "Light" : {
-      "comment" : "Appearance choice: always light mode"
+      "comment" : "Appearance choice: always light mode",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clair"
+          }
+        }
+      }
     },
     "Link" : {
-      "comment" : "Phi Link - Official bot link button"
+      "comment" : "Phi Link - Official bot link button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lien"
+          }
+        }
+      }
     },
     "Link Telegram to chat with %@." : {
-      "comment" : "Phi Link - Official bot link prompt with agent name"
+      "comment" : "Phi Link - Official bot link prompt with agent name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Associez Telegram pour discuter avec %@."
+          }
+        }
+      }
     },
     "Linked" : {
-      "comment" : "Phi Link - Custom bot linked status\nPhi Link - Custom bot linked text\nPhi Link - Official bot linked status"
+      "comment" : "Phi Link - Custom bot linked status\nPhi Link - Custom bot linked text\nPhi Link - Official bot linked status",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Associé"
+          }
+        }
+      }
     },
     "Linking..." : {
-      "comment" : "Phi Link - Custom bot linking text"
+      "comment" : "Phi Link - Custom bot linking text",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Association…"
+          }
+        }
+      }
     },
     "Living Downloads Test" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test de téléchargements en direct"
+          }
+        }
+      }
     },
     "Loading image…" : {
-      "comment" : "Image preview loading"
+      "comment" : "Image preview loading",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement de l'image…"
+          }
+        }
+      }
     },
     "Log in" : {
-      "comment" : "Onboarding Login button title"
+      "comment" : "Onboarding Login button title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter"
+          }
+        }
+      }
     },
     "Logout" : {
-      "comment" : "Account settings - Logout button\nAccount settings - Logout button in logout confirmation dialog"
+      "comment" : "Account settings - Logout button\nAccount settings - Logout button in logout confirmation dialog",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déconnexion"
+          }
+        }
+      }
     },
     "Logout Failed" : {
-      "comment" : "Account settings - Alert title when logout fails"
+      "comment" : "Account settings - Alert title when logout fails",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la déconnexion"
+          }
+        }
+      }
     },
     "Manage Extensions" : {
-      "comment" : "Address bar menu - Extensions submenu item to open extension management\nExtension list - Button to open extensions management page"
+      "comment" : "Address bar menu - Extensions submenu item to open extension management\nExtension list - Button to open extensions management page",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérer les extensions"
+          }
+        }
+      }
     },
     "Manage User Data" : {
-      "comment" : "Help menu - Parent menu item for exporting and importing Phi user data backup"
+      "comment" : "Help menu - Parent menu item for exporting and importing Phi user data backup",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gérer les données utilisateur"
+          }
+        }
+      }
     },
     "Mint" : {
-      "comment" : "Mint theme color name"
+      "comment" : "Mint theme color name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Menthe"
+          }
+        }
+      }
     },
     "Mist" : {
-      "comment" : "Mist theme color name"
+      "comment" : "Mist theme color name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brume"
+          }
+        }
+      }
     },
     "More Settings" : {
-      "comment" : "Address bar menu - Settings submenu item to open settings page\nExtension list - Website settings item to open more settings"
+      "comment" : "Address bar menu - Settings submenu item to open settings page\nExtension list - Website settings item to open more settings",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus de paramètres"
+          }
+        }
+      }
     },
     "More Spaces" : {
-      "comment" : "Tooltip for the overflow button that opens the full Spaces list"
+      "comment" : "Tooltip for the overflow button that opens the full Spaces list",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plus d'espaces"
+          }
+        }
+      }
     },
     "Move Tabs to Group" : {
-      "comment" : "Tab multi-selection context menu - submenu to move selected tabs to an existing tab group"
+      "comment" : "Tab multi-selection context menu - submenu to move selected tabs to an existing tab group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déplacer les onglets vers le groupe"
+          }
+        }
+      }
     },
     "Move to Group" : {
-      "comment" : "Tab context menu - Submenu to move this tab to another tab group"
+      "comment" : "Tab context menu - Submenu to move this tab to another tab group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déplacer vers le groupe"
+          }
+        }
+      }
     },
     "Move to New Group" : {
-      "comment" : "Tab context menu - Move this tab out of its current group into a newly created group"
+      "comment" : "Tab context menu - Move this tab out of its current group into a newly created group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déplacer vers un nouveau groupe"
+          }
+        }
+      }
     },
     "Move to Space" : {
-      "comment" : "Tab context menu - Submenu to move this tab to another Space"
+      "comment" : "Tab context menu - Submenu to move this tab to another Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Déplacer vers l'espace"
+          }
+        }
+      }
     },
     "Mute" : {
-      "comment" : "Notification menu option - Disable auto popup for notification cards\nTab mute button tooltip - mute"
+      "comment" : "Notification menu option - Disable auto popup for notification cards\nTab mute button tooltip - mute",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couper le son"
+          }
+        }
+      }
     },
     "Name" : {
-      "comment" : "Editor - Label for the title/name input field"
+      "comment" : "Editor - Label for the title/name input field",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom"
+          }
+        }
+      }
     },
     "Name cannot be empty" : {
-      "comment" : "Account settings - Error message when user name is empty\nSet name page - Error message when user name is empty or contains only spaces"
+      "comment" : "Account settings - Error message when user name is empty\nSet name page - Error message when user name is empty or contains only spaces",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nom ne peut pas être vide"
+          }
+        }
+      }
     },
     "Name cannot exceed %d characters" : {
-      "comment" : "Account settings - Error message when user name is too long"
+      "comment" : "Account settings - Error message when user name is too long",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nom ne peut pas dépasser %d caractères"
+          }
+        }
+      }
     },
     "Name group" : {
-      "comment" : "Tab group overview editor - Placeholder for the editable group title field"
+      "comment" : "Tab group overview editor - Placeholder for the editable group title field",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nommer le groupe"
+          }
+        }
+      }
     },
     "Name is too long (maximum 100 characters)" : {
-      "comment" : "Set name page - Error message when user name exceeds 100 characters"
+      "comment" : "Set name page - Error message when user name exceeds 100 characters",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le nom est trop long (100 caractères maximum)"
+          }
+        }
+      }
     },
     "New Conversation" : {
-      "comment" : "View menu - Menu item to start a new AI conversation in the sidebar"
+      "comment" : "View menu - Menu item to start a new AI conversation in the sidebar",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvelle conversation"
+          }
+        }
+      }
     },
     "New Folder" : {
-      "comment" : "Bookmark New Folder menu item\nBookmark editor - Inline new folder creation title\nFolder creator - Title of the sheet to create a new folder\nNew folder dialog title\nSidebar context menu title\nTab area context menu - Create a new bookmark folder\nTab multi-selection context menu - bookmark selected tabs into a newly created folder"
+      "comment" : "Bookmark New Folder menu item\nBookmark editor - Inline new folder creation title\nFolder creator - Title of the sheet to create a new folder\nNew folder dialog title\nSidebar context menu title\nTab area context menu - Create a new bookmark folder\nTab multi-selection context menu - bookmark selected tabs into a newly created folder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau dossier"
+          }
+        }
+      }
     },
     "New Folder…" : {
-      "comment" : "Bookmark editor - Create new folder option in folder picker"
+      "comment" : "Bookmark editor - Create new folder option in folder picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau dossier…"
+          }
+        }
+      }
     },
     "New Nested Folder..." : {
-      "comment" : "Bookmark New Folder menu item"
+      "comment" : "Bookmark New Folder menu item",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau sous-dossier…"
+          }
+        }
+      }
     },
     "New profile" : {
-      "comment" : "Profiles settings - new profile tooltip"
+      "comment" : "Profiles settings - new profile tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau profil"
+          }
+        }
+      }
     },
     "New Profile" : {
-      "comment" : "Title of the create-profile dialog"
+      "comment" : "Title of the create-profile dialog",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau profil"
+          }
+        }
+      }
     },
     "New Profile…" : {
-      "comment" : "Profile picker item to create a new profile\nSpaces menu - Create a new browser profile"
+      "comment" : "Profile picker item to create a new profile\nSpaces menu - Create a new browser profile",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau profil…"
+          }
+        }
+      }
     },
     "New Space" : {
-      "comment" : "Spaces picker - create a new Space\nSpaces settings - new Space tooltip\nTooltip for the add-Space button in the sidebar Spaces strip"
+      "comment" : "Spaces picker - create a new Space\nSpaces settings - new Space tooltip\nTooltip for the add-Space button in the sidebar Spaces strip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvel espace"
+          }
+        }
+      }
     },
     "New Space…" : {
-      "comment" : "Spaces menu - Create a new Space"
+      "comment" : "Spaces menu - Create a new Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvel espace…"
+          }
+        }
+      }
     },
     "New Tab" : {
-      "comment" : "Sidebar tab list - Button title to create a new browser tab\nTab area context menu - Open a new browser tab\nTitle for the group overview card that creates a new tab in the selected group\nside bar new tab button text"
+      "comment" : "Sidebar tab list - Button title to create a new browser tab\nTab area context menu - Open a new browser tab\nTitle for the group overview card that creates a new tab in the selected group\nside bar new tab button text",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvel onglet"
+          }
+        }
+      }
     },
     "New tab behavior" : {
-      "comment" : "General settings - Row title for configuring new tab behavior"
+      "comment" : "General settings - Row title for configuring new tab behavior",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comportement des nouveaux onglets"
+          }
+        }
+      }
     },
     "New Tab Group" : {
-      "comment" : "Tab context menu - Add this tab to a newly created tab group"
+      "comment" : "Tab context menu - Add this tab to a newly created tab group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveau groupe d'onglets"
+          }
+        }
+      }
     },
     "New Tab in Group" : {
-      "comment" : "Tab group context menu - Open a new tab inside this group"
+      "comment" : "Tab group context menu - Open a new tab inside this group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvel onglet dans le groupe"
+          }
+        }
+      }
     },
     "New Tab Page" : {
-      "comment" : "AI settings - Section title for new tab page options\nGeneral settings - Option to open New Tab Page when pressing ⌘+T"
+      "comment" : "AI settings - Section title for new tab page options\nGeneral settings - Option to open New Tab Page when pressing ⌘+T",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Page Nouvel onglet"
+          }
+        }
+      }
     },
     "New Tab Page requires Phi AI to be enabled" : {
-      "comment" : "General settings - Hint shown when Phi AI is disabled explaining New Tab Page requires it"
+      "comment" : "General settings - Hint shown when Phi AI is disabled explaining New Tab Page requires it",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La page Nouvel onglet nécessite l'activation de Phi AI"
+          }
+        }
+      }
     },
     "New Version %@ Available" : {
-      "comment" : "Sidebar update reminder - Message showing new version is available"
+      "comment" : "Sidebar update reminder - Message showing new version is available",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvelle version %@ disponible"
+          }
+        }
+      }
     },
     "New version available" : {
-      "comment" : "Phi menu - Menu item text when new version is available"
+      "comment" : "Phi menu - Menu item text when new version is available",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouvelle version disponible"
+          }
+        }
+      }
     },
     "Next" : {
-      "comment" : "Onboarding base - Next button to proceed to next step\nOnboarding welcome page - Next button to proceed to next step"
+      "comment" : "Onboarding base - Next button to proceed to next step\nOnboarding welcome page - Next button to proceed to next step",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suivant"
+          }
+        }
+      }
     },
     "Next image" : {
-      "comment" : "Image preview: accessibility label for next image control"
+      "comment" : "Image preview: accessibility label for next image control",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image suivante"
+          }
+        }
+      }
     },
     "Next Space" : {
-      "comment" : "Spaces menu - Activate the next Space in the strip"
+      "comment" : "Spaces menu - Activate the next Space in the strip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace suivant"
+          }
+        }
+      }
     },
     "Next Test (%lld items)" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test suivant (%lld éléments)"
+          }
+        }
+      }
     },
     "No Backups Available" : {
-      "comment" : "Help menu - Time Machine submenu placeholder when no completed backups exist"
+      "comment" : "Help menu - Time Machine submenu placeholder when no completed backups exist",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune sauvegarde disponible"
+          }
+        }
+      }
     },
     "No certificate available" : {
-      "comment" : "No certificate tooltip"
+      "comment" : "No certificate tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun certificat disponible"
+          }
+        }
+      }
     },
     "No Downloads" : {
-      "comment" : "Downloads list - Empty state text when no downloads exist"
+      "comment" : "Downloads list - Empty state text when no downloads exist",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun téléchargement"
+          }
+        }
+      }
     },
     "No extensions found" : {
-      "comment" : "Address bar menu - Empty extension submenu item\nExtension list - Empty state when no extensions are installed"
+      "comment" : "Address bar menu - Empty extension submenu item\nExtension list - Empty state when no extensions are installed",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune extension trouvée"
+          }
+        }
+      }
     },
     "No extensions found or versions unavailable." : {
-      "comment" : "Extension info alert - Fallback when no extension versions are available"
+      "comment" : "Extension info alert - Fallback when no extension versions are available",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune extension trouvée ou versions indisponibles."
+          }
+        }
+      }
     },
     "No Phi or Sentinel log folders were found." : {
-      "comment" : "Help menu - Log export alert when both PhiLogs and Sentinel log directory are missing"
+      "comment" : "Help menu - Log export alert when both PhiLogs and Sentinel log directory are missing",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun dossier de journaux Phi ou Sentinel n'a été trouvé."
+          }
+        }
+      }
     },
     "No Phi User Data to Back Up" : {
-      "comment" : "Debug clear data - Alert title when the Phi data folder is missing before backup"
+      "comment" : "Debug clear data - Alert title when the Phi data folder is missing before backup",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune donnée utilisateur Phi à sauvegarder"
+          }
+        }
+      }
     },
     "No Profiles to Delete" : {
-      "comment" : "Spaces menu - Delete Profile submenu empty state"
+      "comment" : "Spaces menu - Delete Profile submenu empty state",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun profil à supprimer"
+          }
+        }
+      }
     },
     "No Results" : {
-      "comment" : "Shortcuts settings - Empty state text when no shortcuts match search"
+      "comment" : "Shortcuts settings - Empty state text when no shortcuts match search",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucun résultat"
+          }
+        }
+      }
     },
     "No rules yet." : {
-      "comment" : "Empty state label in the URL rules editor"
+      "comment" : "Empty state label in the URL rules editor",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune règle pour l'instant."
+          }
+        }
+      }
     },
     "No share actions available" : {
-      "comment" : "Address bar menu - Empty share submenu item"
+      "comment" : "Address bar menu - Empty share submenu item",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aucune action de partage disponible"
+          }
+        }
+      }
     },
     "Not configured" : {
-      "comment" : "Phi Link - Custom bot not configured status"
+      "comment" : "Phi Link - Custom bot not configured status",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non configuré"
+          }
+        }
+      }
     },
     "Not connected" : {
-      "comment" : "AI settings - Connector row status text when not connected\nAI settings - Default text when connector is not connected"
+      "comment" : "AI settings - Connector row status text when not connected\nAI settings - Default text when connector is not connected",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non connecté"
+          }
+        }
+      }
     },
     "Not linked" : {
-      "comment" : "Phi Link - Official bot not linked status"
+      "comment" : "Phi Link - Official bot not linked status",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non associé"
+          }
+        }
+      }
     },
     "Not used" : {
-      "comment" : "Profiles settings - tag for a profile with no Spaces"
+      "comment" : "Profiles settings - tag for a profile with no Spaces",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non utilisé"
+          }
+        }
+      }
     },
     "Notifications" : {
-      "comment" : "Profiles settings - data link to notification settings"
+      "comment" : "Profiles settings - data link to notification settings",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        }
+      }
     },
     "Official Phi Link Telegram bot" : {
-      "comment" : "Phi Link - Official Bot title"
+      "comment" : "Phi Link - Official Bot title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bot Telegram officiel de Phi Link"
+          }
+        }
+      }
     },
     "OK" : {
-      "comment" : "Account settings - OK button\nAccount settings - OK button to dismiss logout failed alert\nDismiss button\nExtension info alert - OK button to dismiss the alert\nGeneric - OK button to dismiss an alert"
+      "comment" : "Account settings - OK button\nAccount settings - OK button to dismiss logout failed alert\nDismiss button\nExtension info alert - OK button to dismiss the alert\nGeneric - OK button to dismiss an alert",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        }
+      }
     },
     "Omnibox" : {
-      "comment" : "General settings - Option to open Omnibox search when pressing ⌘+T"
+      "comment" : "General settings - Option to open Omnibox search when pressing ⌘+T",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Omnibox"
+          }
+        }
+      }
     },
     "Opacity" : {
-      "comment" : "General settings - Theme opacity row title for adjusting the selected theme overlay transparency"
+      "comment" : "General settings - Theme opacity row title for adjusting the selected theme overlay transparency",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opacité"
+          }
+        }
+      }
     },
     "Open as Split" : {
-      "comment" : "Bookmark context menu - Open this bookmark as a new tab paired with the current tab in a split\nTab context menu - Open a new tab as the second pane in a split with this tab\nTab multi-selection context menu - split exactly two selected tabs into paired panes"
+      "comment" : "Bookmark context menu - Open this bookmark as a new tab paired with the current tab in a split\nTab context menu - Open a new tab as the second pane in a split with this tab\nTab multi-selection context menu - split exactly two selected tabs into paired panes",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir en division"
+          }
+        }
+      }
     },
     "Open in" : {
-      "comment" : "Leading label for a URL rule's target Space"
+      "comment" : "Leading label for a URL rule's target Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir dans"
+          }
+        }
+      }
     },
     "Open in New Tab" : {
-      "comment" : "Open in New Tab menu item"
+      "comment" : "Open in New Tab menu item",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir dans un nouvel onglet"
+          }
+        }
+      }
     },
     "Open in Telegram" : {
-      "comment" : "Phi Link - Open official bot link in Telegram"
+      "comment" : "Phi Link - Open official bot link in Telegram",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir dans Telegram"
+          }
+        }
+      }
     },
     "Open Settings" : {
-      "comment" : "Import browser data page - Button to open system settings for granting permissions"
+      "comment" : "Import browser data page - Button to open system settings for granting permissions",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir les paramètres"
+          }
+        }
+      }
     },
     "Open Tabs" : {
-      "comment" : "Search Tabs - Open tabs section title"
+      "comment" : "Search Tabs - Open tabs section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onglets ouverts"
+          }
+        }
+      }
     },
     "Open the URL rules editor" : {
-      "comment" : "Spaces settings - tooltip for the URL rules button"
+      "comment" : "Spaces settings - tooltip for the URL rules button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir l'éditeur de règles d'URL"
+          }
+        }
+      }
     },
     "Open User Data Directory" : {
-      "comment" : "Debug menu item to reveal the current user's data storage directory in Finder"
+      "comment" : "Debug menu item to reveal the current user's data storage directory in Finder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ouvrir le dossier des données utilisateur"
+          }
+        }
+      }
     },
     "Or paste an image" : {
-      "comment" : "Feedback form - Hint explaining pasted images can be added as attachments"
+      "comment" : "Feedback form - Hint explaining pasted images can be added as attachments",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ou collez une image"
+          }
+        }
+      }
     },
     "Orange" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Orange"
+          }
+        }
+      }
     },
     "Organize tabs with AI" : {
-      "comment" : "Organize Tabs - Button tooltip and accessibility label\nside bar new tab row - organize tabs button tooltip"
+      "comment" : "Organize Tabs - Button tooltip and accessibility label\nside bar new tab row - organize tabs button tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Organiser les onglets avec l'IA"
+          }
+        }
+      }
     },
     "Passwords Manager" : {
-      "comment" : "Onboarding password manager - Page title"
+      "comment" : "Onboarding password manager - Page title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gestionnaire de mots de passe"
+          }
+        }
+      }
     },
     "Pause" : {
-      "comment" : "Download item row - Tooltip for pause download button"
+      "comment" : "Download item row - Tooltip for pause download button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pause"
+          }
+        }
+      }
     },
     "Performance" : {
-      "comment" : "Layout option - Vertical tabs with address bar at side bar\nOnboarding layout selection - Performance option"
+      "comment" : "Layout option - Vertical tabs with address bar at side bar\nOnboarding layout selection - Performance option",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Performances"
+          }
+        }
+      }
     },
     "Permissions" : {
-      "comment" : "Import browser data page - Page title when showing permission request"
+      "comment" : "Import browser data page - Page title when showing permission request",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Autorisations"
+          }
+        }
+      }
     },
     "Petal" : {
-      "comment" : "Petal theme color name"
+      "comment" : "Petal theme color name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pétale"
+          }
+        }
+      }
     },
     "Phi & AI" : {
-      "comment" : "Settings - Tab title for AI and Phi assistant settings"
+      "comment" : "Settings - Tab title for AI and Phi assistant settings",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi et IA"
+          }
+        }
+      }
     },
     "Phi could not read Time Machine backups: %@" : {
-      "comment" : "Help menu - Time Machine restore catalog read failure body"
+      "comment" : "Help menu - Time Machine restore catalog read failure body",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi n'a pas pu lire les sauvegardes Time Machine : %@"
+          }
+        }
+      }
     },
     "Phi could not start Time Machine restore: %@" : {
-      "comment" : "Help menu - Time Machine restore launch failure body"
+      "comment" : "Help menu - Time Machine restore launch failure body",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi n'a pas pu démarrer la restauration Time Machine : %@"
+          }
+        }
+      }
     },
     "Phi is not your default browser" : {
-      "comment" : "Account settings - Status text when Phi is not the default browser"
+      "comment" : "Account settings - Status text when Phi is not the default browser",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi n'est pas votre navigateur par défaut"
+          }
+        }
+      }
     },
     "Phi is your default browser" : {
-      "comment" : "Account settings - Status text when Phi is the default browser"
+      "comment" : "Account settings - Status text when Phi is the default browser",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi est votre navigateur par défaut"
+          }
+        }
+      }
     },
     "Phi Link" : {
-      "comment" : "Settings - Tab title for Phi Link settings"
+      "comment" : "Settings - Tab title for Phi Link settings",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi Link"
+          }
+        }
+      }
     },
     "Phi needs Full Disk Access to import your data from Safari." : {
-      "comment" : "Import browser data page - Description explaining why Full Disk Access permission is needed"
+      "comment" : "Import browser data page - Description explaining why Full Disk Access permission is needed",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi a besoin de l'accès complet au disque pour importer vos données depuis Safari."
+          }
+        }
+      }
     },
     "Phi Sentinel" : {
-      "comment" : "AI settings - Section title for Phi Sentinel background helper"
+      "comment" : "AI settings - Section title for Phi Sentinel background helper",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi Sentinel"
+          }
+        }
+      }
     },
     "Phi Sentinel is a lightweight background helper that allows Phi to complete scheduled AI tasks" : {
-      "comment" : "AI settings - Description explaining what Phi Sentinel does"
+      "comment" : "AI settings - Description explaining what Phi Sentinel does",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi Sentinel est un assistant léger en arrière-plan qui permet à Phi d'exécuter des tâches IA planifiées"
+          }
+        }
+      }
     },
     "Phi Sentinel service is unavailable. Check whether it started normally." : {
-      "comment" : "IM Channels - Custom bot service unavailable message\nIM Channels - Official bot service unavailable message"
+      "comment" : "IM Channels - Custom bot service unavailable message\nIM Channels - Official bot service unavailable message",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le service Phi Sentinel est indisponible. Vérifiez qu'il a démarré normalement."
+          }
+        }
+      }
     },
     "Phi will quit and restore %@. The current app and selected user data will be replaced." : {
-      "comment" : "Help menu - Time Machine restore confirmation body"
+      "comment" : "Help menu - Time Machine restore confirmation body",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Phi va se fermer et restaurer %@. L'application actuelle et les données utilisateur sélectionnées seront remplacées."
+          }
+        }
+      }
     },
     "Pick a target Space and enter a host like “github.com”." : {
-      "comment" : "Empty state hint in the universal URL rules editor"
+      "comment" : "Empty state hint in the universal URL rules editor",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Choisissez un espace cible et saisissez un hôte comme « github.com »."
+          }
+        }
+      }
     },
     "Pin" : {
-      "comment" : "Tab context menu - Menu item to pin the selected tab"
+      "comment" : "Tab context menu - Menu item to pin the selected tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler"
+          }
+        }
+      }
     },
     "Pin extension" : {
-      "comment" : "Extension list - Tooltip for pinning an extension"
+      "comment" : "Extension list - Tooltip for pinning an extension",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler l'extension"
+          }
+        }
+      }
     },
     "Pin Split" : {
-      "comment" : "Tab context menu - Pin the split that contains this tab"
+      "comment" : "Tab context menu - Pin the split that contains this tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Épingler la division"
+          }
+        }
+      }
     },
     "Pink" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rose"
+          }
+        }
+      }
     },
     "Pinned Tabs" : {
-      "comment" : "Search Tabs - Pinned tabs section title"
+      "comment" : "Search Tabs - Pinned tabs section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Onglets épinglés"
+          }
+        }
+      }
     },
     "Pinned tabs and bookmarks belonging to this Space will also be removed. This action cannot be undone." : {
-      "comment" : "Body of the delete-Space confirmation"
+      "comment" : "Body of the delete-Space confirmation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les onglets épinglés et les favoris appartenant à cet espace seront également supprimés. Cette action est irréversible."
+          }
+        }
+      }
     },
     "Please reauthenticate to restore account features." : {
-      "comment" : "Account settings - Tooltip explaining why reauthentication is needed"
+      "comment" : "Account settings - Tooltip explaining why reauthentication is needed",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veuillez vous réauthentifier pour restaurer les fonctionnalités du compte."
+          }
+        }
+      }
     },
     "Pop up" : {
-      "comment" : "Notification menu option - Enable auto popup for notification cards"
+      "comment" : "Notification menu option - Enable auto popup for notification cards",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fenêtre contextuelle"
+          }
+        }
+      }
     },
     "Preparing installer..." : {
-      "comment" : "Time Machine restore progress stage"
+      "comment" : "Time Machine restore progress stage",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation du programme d'installation…"
+          }
+        }
+      }
     },
     "Preparing restore..." : {
-      "comment" : "Time Machine restore progress stage"
+      "comment" : "Time Machine restore progress stage",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation de la restauration…"
+          }
+        }
+      }
     },
     "Preparing Time Machine Restore" : {
-      "comment" : "Time Machine restore progress title"
+      "comment" : "Time Machine restore progress title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Préparation de la restauration Time Machine"
+          }
+        }
+      }
     },
     "Press shortcut…" : {
-      "comment" : "Shortcuts settings - Prompt text when recording new shortcut"
+      "comment" : "Shortcuts settings - Prompt text when recording new shortcut",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appuyez sur le raccourci…"
+          }
+        }
+      }
     },
     "Preview attachment" : {
-      "comment" : "Feedback form - Tooltip for previewing an attachment"
+      "comment" : "Feedback form - Tooltip for previewing an attachment",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aperçu de la pièce jointe"
+          }
+        }
+      }
     },
     "Previous image" : {
-      "comment" : "Image preview: accessibility label for previous image control"
+      "comment" : "Image preview: accessibility label for previous image control",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Image précédente"
+          }
+        }
+      }
     },
     "Previous Space" : {
-      "comment" : "Spaces menu - Activate the previous Space in the strip"
+      "comment" : "Spaces menu - Activate the previous Space in the strip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace précédent"
+          }
+        }
+      }
     },
     "Privacy and Security" : {
-      "comment" : "Profiles settings - data link to privacy settings"
+      "comment" : "Profiles settings - data link to privacy settings",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Confidentialité et sécurité"
+          }
+        }
+      }
     },
     "Private AI" : {
-      "comment" : "AI settings - Row that opens Phi Sentinel's Private AI page"
+      "comment" : "AI settings - Row that opens Phi Sentinel's Private AI page",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "IA privée"
+          }
+        }
+      }
     },
     "Profile" : {
-      "comment" : "Label for the profile picker in the create-Space panel"
+      "comment" : "Label for the profile picker in the create-Space panel",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profil"
+          }
+        }
+      }
     },
     "Profile name" : {
-      "comment" : "Placeholder for the profile-name field"
+      "comment" : "Placeholder for the profile-name field",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom du profil"
+          }
+        }
+      }
     },
     "Profiles" : {
-      "comment" : "Settings - Tab title for profiles management"
+      "comment" : "Settings - Tab title for profiles management",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profils"
+          }
+        }
+      }
     },
     "Pure" : {
-      "comment" : "Pure theme name"
+      "comment" : "Pure theme name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pur"
+          }
+        }
+      }
     },
     "Purple" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Violet"
+          }
+        }
+      }
     },
     "QR code expired. Generate a fresh one to continue." : {
-      "comment" : "Phi Link - Official bot QR expired hint"
+      "comment" : "Phi Link - Official bot QR expired hint",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le code QR a expiré. Générez-en un nouveau pour continuer."
+          }
+        }
+      }
     },
     "Quit" : {
-      "comment" : "Quit"
+      "comment" : "Quit",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitter"
+          }
+        }
+      }
     },
     "Quit Phi?" : {
-      "comment" : "Quit Phi?"
+      "comment" : "Quit Phi?",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quitter Phi ?"
+          }
+        }
+      }
     },
     "Reauthenticate" : {
-      "comment" : "Auth reauthentication - Primary action to start Auth0 web authentication"
+      "comment" : "Auth reauthentication - Primary action to start Auth0 web authentication",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se réauthentifier"
+          }
+        }
+      }
     },
     "Reauthentication needed." : {
-      "comment" : "Account settings - Warning shown when account tokens require reauthentication"
+      "comment" : "Account settings - Warning shown when account tokens require reauthentication",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réauthentification nécessaire."
+          }
+        }
+      }
     },
     "Recently Closed" : {
-      "comment" : "Search Tabs - Recently closed section title"
+      "comment" : "Search Tabs - Recently closed section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Récemment fermés"
+          }
+        }
+      }
     },
     "Recommended" : {
-      "comment" : "Onboarding password manager - Recommended label for iCloud Passwords"
+      "comment" : "Onboarding password manager - Recommended label for iCloud Passwords",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recommandé"
+          }
+        }
+      }
     },
     "Red" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rouge"
+          }
+        }
+      }
     },
     "Refresh" : {
-      "comment" : "Phi Link - Official bot refresh QR action\nWeb content header - Accessibility description for refresh page button"
+      "comment" : "Phi Link - Official bot refresh QR action\nWeb content header - Accessibility description for refresh page button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualiser"
+          }
+        }
+      }
     },
     "Refresh connector status" : {
-      "comment" : "AI settings - Tooltip for refreshing connector status"
+      "comment" : "AI settings - Tooltip for refreshing connector status",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Actualiser l'état du connecteur"
+          }
+        }
+      }
     },
     "Relink" : {
-      "comment" : "Phi Link - Official bot relink action"
+      "comment" : "Phi Link - Official bot relink action",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réassocier"
+          }
+        }
+      }
     },
     "Remove" : {
-      "comment" : "Bookmark editor - Remove bookmark button title (CMD+D toggle)\nDownload item row - Tooltip for remove download button\nIM Channels - Custom bot remove action"
+      "comment" : "Bookmark editor - Remove bookmark button title (CMD+D toggle)\nDownload item row - Tooltip for remove download button\nIM Channels - Custom bot remove action",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer"
+          }
+        }
+      }
     },
     "Remove attachment" : {
-      "comment" : "Feedback form - Tooltip for removing an attachment"
+      "comment" : "Feedback form - Tooltip for removing an attachment",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer la pièce jointe"
+          }
+        }
+      }
     },
     "Remove from Group" : {
-      "comment" : "Tab context menu - Remove this tab from its tab group"
+      "comment" : "Tab context menu - Remove this tab from its tab group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer du groupe"
+          }
+        }
+      }
     },
     "Remove from list" : {
-      "comment" : "Download item row - Menu option to remove download from list"
+      "comment" : "Download item row - Menu option to remove download from list",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer de la liste"
+          }
+        }
+      }
     },
     "Remove from Split" : {
-      "comment" : "Tab context menu - Dissolve the split that contains this tab"
+      "comment" : "Tab context menu - Dissolve the split that contains this tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retirer de la division"
+          }
+        }
+      }
     },
     "Remove rule" : {
-      "comment" : "Tooltip for remove-rule button"
+      "comment" : "Tooltip for remove-rule button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer la règle"
+          }
+        }
+      }
     },
     "Rename" : {
-      "comment" : "Rename button\nRename folder or bookmark dialog title"
+      "comment" : "Rename button\nRename folder or bookmark dialog title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer"
+          }
+        }
+      }
     },
     "Rename Group" : {
-      "comment" : "Tab group context menu - Rename the group\nTab group rename alert - Title"
+      "comment" : "Tab group context menu - Rename the group\nTab group rename alert - Title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer le groupe"
+          }
+        }
+      }
     },
     "Rename Profile" : {
-      "comment" : "Title of the rename-profile dialog"
+      "comment" : "Title of the rename-profile dialog",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer le profil"
+          }
+        }
+      }
     },
     "Rename selected profile" : {
-      "comment" : "Profiles settings - rename profile tooltip"
+      "comment" : "Profiles settings - rename profile tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer le profil sélectionné"
+          }
+        }
+      }
     },
     "Rename selected Space" : {
-      "comment" : "Spaces settings - rename Space tooltip"
+      "comment" : "Spaces settings - rename Space tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer l'espace sélectionné"
+          }
+        }
+      }
     },
     "Rename Space" : {
-      "comment" : "Title of the rename-Space dialog"
+      "comment" : "Title of the rename-Space dialog",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer l'espace"
+          }
+        }
+      }
     },
     "Rename Space…" : {
-      "comment" : "Spaces menu - Rename the active Space"
+      "comment" : "Spaces menu - Rename the active Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer l'espace…"
+          }
+        }
+      }
     },
     "Rename..." : {
-      "comment" : "Bookmark Rename menu item"
+      "comment" : "Bookmark Rename menu item",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer…"
+          }
+        }
+      }
     },
     "Rename…" : {
-      "comment" : "Active-Space menu: rename current Space"
+      "comment" : "Active-Space menu: rename current Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renommer…"
+          }
+        }
+      }
     },
     "Reopen Closed Tab" : {
-      "comment" : "Tab area context menu - Reopen the last closed tab"
+      "comment" : "Tab area context menu - Reopen the last closed tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rouvrir l'onglet fermé"
+          }
+        }
+      }
     },
     "Replace Bottom" : {
-      "comment" : "Drop-zone hint shown when dragging a tab over the bottom/secondary pane of a horizontal split to replace it"
+      "comment" : "Drop-zone hint shown when dragging a tab over the bottom/secondary pane of a horizontal split to replace it",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplacer en bas"
+          }
+        }
+      }
     },
     "Replace Left" : {
-      "comment" : "Drop-zone hint shown when dragging a tab over the left/primary pane of a vertical split to replace it"
+      "comment" : "Drop-zone hint shown when dragging a tab over the left/primary pane of a vertical split to replace it",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplacer à gauche"
+          }
+        }
+      }
     },
     "Replace Right" : {
-      "comment" : "Drop-zone hint shown when dragging a tab over the right/secondary pane of a vertical split to replace it"
+      "comment" : "Drop-zone hint shown when dragging a tab over the right/secondary pane of a vertical split to replace it",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplacer à droite"
+          }
+        }
+      }
     },
     "Replace Top" : {
-      "comment" : "Drop-zone hint shown when dragging a tab over the top/primary pane of a horizontal split to replace it"
+      "comment" : "Drop-zone hint shown when dragging a tab over the top/primary pane of a horizontal split to replace it",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remplacer en haut"
+          }
+        }
+      }
     },
     "Reset" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réinitialiser"
+          }
+        }
+      }
     },
     "Restarting Phi..." : {
-      "comment" : "Time Machine restore progress stage"
+      "comment" : "Time Machine restore progress stage",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redémarrage de Phi…"
+          }
+        }
+      }
     },
     "Restore" : {
-      "comment" : "Help menu - Time Machine restore confirmation button\nShortcuts settings - Button to restore single shortcut to default"
+      "comment" : "Help menu - Time Machine restore confirmation button\nShortcuts settings - Button to restore single shortcut to default",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurer"
+          }
+        }
+      }
     },
     "Restore all shortcuts" : {
-      "comment" : "Shortcuts settings - Button to reset all shortcuts to default"
+      "comment" : "Shortcuts settings - Button to reset all shortcuts to default",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurer tous les raccourcis"
+          }
+        }
+      }
     },
     "Restore Time Machine Backup?" : {
-      "comment" : "Help menu - Time Machine restore confirmation title"
+      "comment" : "Help menu - Time Machine restore confirmation title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restaurer la sauvegarde Time Machine ?"
+          }
+        }
+      }
     },
     "Resume" : {
-      "comment" : "Download item row - Tooltip for resume download button"
+      "comment" : "Download item row - Tooltip for resume download button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprendre"
+          }
+        }
+      }
     },
     "Retry" : {
-      "comment" : "Download item row - Tooltip for retry download button\nPhi Link - Retry loading official bot\nTooltip for button to retry interrupted download in living downloads toast"
+      "comment" : "Download item row - Tooltip for retry download button\nPhi Link - Retry loading official bot\nTooltip for button to retry interrupted download in living downloads toast",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessayer"
+          }
+        }
+      }
     },
     "Retry after Phi Sentinel is running normally." : {
-      "comment" : "IM Channels - Official bot retry hint when service is unavailable"
+      "comment" : "IM Channels - Official bot retry hint when service is unavailable",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réessayez une fois que Phi Sentinel fonctionne normalement."
+          }
+        }
+      }
     },
     "Reverse Panes" : {
-      "comment" : "Tab context menu - Swap the left/right (or top/bottom) panes of the split this tab belongs to"
+      "comment" : "Tab context menu - Swap the left/right (or top/bottom) panes of the split this tab belongs to",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inverser les volets"
+          }
+        }
+      }
     },
     "Right Name" : {
-      "comment" : "Bookmark editor - Label for the right (secondary) title input field on a split-view bookmark"
+      "comment" : "Bookmark editor - Label for the right (secondary) title input field on a split-view bookmark",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom de droite"
+          }
+        }
+      }
     },
     "Right URL" : {
-      "comment" : "Bookmark editor - Label for the right (secondary) URL input field on a split-view bookmark"
+      "comment" : "Bookmark editor - Label for the right (secondary) URL input field on a split-view bookmark",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL de droite"
+          }
+        }
+      }
     },
     "Routing" : {
-      "comment" : "Spaces settings - routing section header"
+      "comment" : "Spaces settings - routing section header",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Routage"
+          }
+        }
+      }
     },
     "Run" : {
-      "comment" : "Notification card run button - Executes the suggested action"
+      "comment" : "Notification card run button - Executes the suggested action",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Exécuter"
+          }
+        }
+      }
     },
     "Save" : {
-      "comment" : "Account settings - Save button in rename dialog\nDebug clear data - NSSavePanel confirm button title when saving Phi user data backup zip\nEditor - Save button title\nIM Channels - Custom bot save button\nSave button\nTab group rename alert - Confirm button"
+      "comment" : "Account settings - Save button in rename dialog\nDebug clear data - NSSavePanel confirm button title when saving Phi user data backup zip\nEditor - Save button title\nIM Channels - Custom bot save button\nSave button\nTab group rename alert - Confirm button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enregistrer"
+          }
+        }
+      }
     },
     "Scan the QR code with your phone camera or click on the button below to add Phi Link bot to your Telegram" : {
-      "comment" : "Phi Link - Official bot QR hint"
+      "comment" : "Phi Link - Official bot QR hint",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scannez le code QR avec l'appareil photo de votre téléphone ou cliquez sur le bouton ci-dessous pour ajouter le bot Phi Link à votre Telegram"
+          }
+        }
+      }
     },
     "Search" : {
-      "comment" : "Omnibox - Accessibility description for search icon"
+      "comment" : "Omnibox - Accessibility description for search icon",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher"
+          }
+        }
+      }
     },
     "Search engine" : {
-      "comment" : "Profiles settings - search engine row label"
+      "comment" : "Profiles settings - search engine row label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Moteur de recherche"
+          }
+        }
+      }
     },
     "Search or Enter URL" : {
-      "comment" : "Omnibox - Placeholder text prompting user to search or enter URL\nOmnibox suggestion - Placeholder text for search or URL entry\nSidebar address bar - Placeholder text prompting user to enter URL or search query\nWeb content address bar - Placeholder text shown when window has no tab"
+      "comment" : "Omnibox - Placeholder text prompting user to search or enter URL\nOmnibox suggestion - Placeholder text for search or URL entry\nSidebar address bar - Placeholder text prompting user to enter URL or search query\nWeb content address bar - Placeholder text shown when window has no tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher ou saisir une URL"
+          }
+        }
+      }
     },
     "Search Tabs" : {
-      "comment" : "Search Tabs - Button tooltip and accessibility label\nSearch Tabs - Placeholder text for the native tab search field"
+      "comment" : "Search Tabs - Button tooltip and accessibility label\nSearch Tabs - Placeholder text for the native tab search field",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rechercher dans les onglets"
+          }
+        }
+      }
     },
     "Select a profile to view its settings." : {
-      "comment" : "Profiles settings - empty detail placeholder"
+      "comment" : "Profiles settings - empty detail placeholder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionnez un profil pour afficher ses paramètres."
+          }
+        }
+      }
     },
     "Select a Space to view its settings." : {
-      "comment" : "Spaces settings - empty detail placeholder"
+      "comment" : "Spaces settings - empty detail placeholder",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionnez un espace pour afficher ses paramètres."
+          }
+        }
+      }
     },
     "Select Phi User Data Backup" : {
-      "comment" : "Debug import user data - NSOpenPanel title for choosing a Phi user data zip"
+      "comment" : "Debug import user data - NSOpenPanel title for choosing a Phi user data zip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionner une sauvegarde des données utilisateur Phi"
+          }
+        }
+      }
     },
     "Send" : {
-      "comment" : "Feedback form - Send button to submit feedback"
+      "comment" : "Feedback form - Send button to submit feedback",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer"
+          }
+        }
+      }
     },
     "Send Feedback to Phi" : {
-      "comment" : "Feedback window - Window title for feedback submission"
+      "comment" : "Feedback window - Window title for feedback submission",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Envoyer un commentaire à Phi"
+          }
+        }
+      }
     },
     "Service issue" : {
-      "comment" : "Phi Link - Custom bot service issue status\nPhi Link - Official bot service issue status"
+      "comment" : "Phi Link - Custom bot service issue status\nPhi Link - Official bot service issue status",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Problème de service"
+          }
+        }
+      }
     },
     "Set as default" : {
-      "comment" : "Account settings - Button to set Phi as default browser"
+      "comment" : "Account settings - Button to set Phi as default browser",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Définir par défaut"
+          }
+        }
+      }
     },
     "Setting" : {
-      "comment" : "Extension list - Section title for extension settings"
+      "comment" : "Extension list - Section title for extension settings",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réglage"
+          }
+        }
+      }
     },
     "Setting up your own Telegram bot using Telegram's @BotFather" : {
-      "comment" : "Phi Link - Custom bot subtitle"
+      "comment" : "Phi Link - Custom bot subtitle",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuration de votre propre bot Telegram à l'aide du @BotFather de Telegram"
+          }
+        }
+      }
     },
     "Settings" : {
-      "comment" : "Extension list - Website settings entry"
+      "comment" : "Extension list - Website settings entry",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres"
+          }
+        }
+      }
     },
     "Share" : {
-      "comment" : "Account settings - Section title for sharing\nAddress bar menu - Share submenu title"
+      "comment" : "Account settings - Section title for sharing\nAddress bar menu - Share submenu title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partager"
+          }
+        }
+      }
     },
     "Shortcuts" : {
-      "comment" : "Settings - Tab title for keyboard shortcuts settings\nShortcuts settings - Section title for keyboard shortcuts"
+      "comment" : "Settings - Tab title for keyboard shortcuts settings\nShortcuts settings - Section title for keyboard shortcuts",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raccourcis"
+          }
+        }
+      }
     },
     "Show" : {
-      "comment" : "Phi Link - Show token plaintext button"
+      "comment" : "Phi Link - Show token plaintext button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher"
+          }
+        }
+      }
     },
     "Show Bookmark Bar on New Tab" : {
-      "comment" : "View menu - Menu item to show the bookmark bar on new tab pages"
+      "comment" : "View menu - Menu item to show the bookmark bar on new tab pages",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher la barre de favoris sur les nouveaux onglets"
+          }
+        }
+      }
     },
     "Show certificate" : {
-      "comment" : "Show certificate tooltip"
+      "comment" : "Show certificate tooltip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher le certificat"
+          }
+        }
+      }
     },
     "Show in Finder" : {
-      "comment" : "Download item row - Menu option to reveal file in Finder\nDownload item row - Tooltip for show in finder button\nTooltip for button to reveal downloaded file in Finder in living downloads toast"
+      "comment" : "Download item row - Menu option to reveal file in Finder\nDownload item row - Tooltip for show in finder button\nTooltip for button to reveal downloaded file in Finder in living downloads toast",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher dans le Finder"
+          }
+        }
+      }
     },
     "Show proactive suggestions on the new tab page" : {
-      "comment" : "AI settings - Toggle to show proactive suggestions on the new tab page"
+      "comment" : "AI settings - Toggle to show proactive suggestions on the new tab page",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher des suggestions proactives sur la page Nouvel onglet"
+          }
+        }
+      }
     },
     "Sign in again to continue" : {
-      "comment" : "Auth reauthentication - Alert title when the access token can no longer be renewed"
+      "comment" : "Auth reauthentication - Alert title when the access token can no longer be renewed",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reconnectez-vous pour continuer"
+          }
+        }
+      }
     },
     "Site Settings" : {
-      "comment" : "Address bar menu - Settings menu item\nAddress bar menu - Settings submenu title"
+      "comment" : "Address bar menu - Settings menu item\nAddress bar menu - Settings submenu title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paramètres du site"
+          }
+        }
+      }
     },
     "Skip" : {
-      "comment" : "Onboarding base - Skip button to bypass current step"
+      "comment" : "Onboarding base - Skip button to bypass current step",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorer"
+          }
+        }
+      }
     },
     "Skip Backup" : {
-      "comment" : "Debug clear data - Alert button to clear data without creating a backup zip"
+      "comment" : "Debug clear data - Alert button to clear data without creating a backup zip",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorer la sauvegarde"
+          }
+        }
+      }
     },
     "Some account and system information may be sent to Phinomenon. We will use the information you give us to help address technical issues and to improve our services, subject to our Privacy Policy and Terms of Service." : {
-      "comment" : "Feedback form - Legal disclaimer text explaining data usage, contains links to Privacy Policy and Terms of Service"
+      "comment" : "Feedback form - Legal disclaimer text explaining data usage, contains links to Privacy Policy and Terms of Service",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Certaines informations de compte et système peuvent être envoyées à Phinomenon. Nous utiliserons les informations que vous nous fournissez pour aider à résoudre les problèmes techniques et améliorer nos services, conformément à notre Politique de confidentialité et à nos Conditions d'utilisation."
+          }
+        }
+      }
     },
     "Something went wrong when logging out" : {
-      "comment" : "Account settings - Alert message when logout fails"
+      "comment" : "Account settings - Alert message when logout fails",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Une erreur s'est produite lors de la déconnexion"
+          }
+        }
+      }
     },
     "Something went wrong? " : {
-      "comment" : "Retry hint prefix text shown when login fails in onboarding"
+      "comment" : "Retry hint prefix text shown when login fails in onboarding",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Un problème ? "
+          }
+        }
+      }
     },
     "Space %d" : {
-      "comment" : "Default name for a newly created Space"
+      "comment" : "Default name for a newly created Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace %d"
+          }
+        }
+      }
     },
     "Space name" : {
-      "comment" : "Placeholder for the Space-name field"
+      "comment" : "Placeholder for the Space-name field",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom de l'espace"
+          }
+        }
+      }
     },
     "Spaces" : {
-      "comment" : "Accessibility label for the Spaces picker affordance\nMain menu - Top-level Spaces menu title in the application menu bar\nSettings - Tab title for profiles and spaces management"
+      "comment" : "Accessibility label for the Spaces picker affordance\nMain menu - Top-level Spaces menu title in the application menu bar\nSettings - Tab title for profiles and spaces management",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espaces"
+          }
+        }
+      }
     },
     "Split with" : {
-      "comment" : "Search Tabs - Prefix for the split partner shown in a result row"
+      "comment" : "Search Tabs - Prefix for the split partner shown in a result row",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diviser avec"
+          }
+        }
+      }
     },
     "Split with Current" : {
-      "comment" : "Tab context menu - Pair this tab with the currently focused tab in a split"
+      "comment" : "Tab context menu - Pair this tab with the currently focused tab in a split",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diviser avec l'actuel"
+          }
+        }
+      }
     },
     "Start Test" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démarrer le test"
+          }
+        }
+      }
     },
     "Starting restore..." : {
-      "comment" : "Time Machine restore progress stage"
+      "comment" : "Time Machine restore progress stage",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Démarrage de la restauration…"
+          }
+        }
+      }
     },
     "Stop" : {
-      "comment" : "Web content header - Accessibility description for stop loading button"
+      "comment" : "Web content header - Accessibility description for stop loading button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrêter"
+          }
+        }
+      }
     },
     "SwiftUI" : {
-
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SwiftUI"
+          }
+        }
+      }
     },
     "System" : {
-      "comment" : "Appearance choice: follow system setting"
+      "comment" : "Appearance choice: follow system setting",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Système"
+          }
+        }
+      }
     },
     "Tab Group" : {
-      "comment" : "Fallback title shown in the group overview header when group metadata is unavailable\nTab Groups - Fallback bookmark folder title when converting a tab group"
+      "comment" : "Fallback title shown in the group overview header when group metadata is unavailable\nTab Groups - Fallback bookmark folder title when converting a tab group",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Groupe d'onglets"
+          }
+        }
+      }
     },
     "Tab Name" : {
-      "comment" : "Pinned tab editor - Placeholder for pinned tab name input"
+      "comment" : "Pinned tab editor - Placeholder for pinned tab name input",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nom de l'onglet"
+          }
+        }
+      }
     },
     "Target Space unavailable" : {
-      "comment" : "URL rule target whose Space no longer exists"
+      "comment" : "URL rule target whose Space no longer exists",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace cible indisponible"
+          }
+        }
+      }
     },
     "Telegram" : {
-      "comment" : "Phi Link - Section title"
+      "comment" : "Phi Link - Section title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Telegram"
+          }
+        }
+      }
     },
     "Telegram ID" : {
-      "comment" : "Phi Link - Official bot connected label"
+      "comment" : "Phi Link - Official bot connected label",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID Telegram"
+          }
+        }
+      }
     },
     "The archive does not contain a top-level Phi folder." : {
-      "comment" : "Debug import user data - Error message when zip does not include the expected Phi directory at archive root"
+      "comment" : "Debug import user data - Error message when zip does not include the expected Phi directory at archive root",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'archive ne contient pas de dossier Phi de premier niveau."
+          }
+        }
+      }
     },
     "The connector authorization URL is invalid." : {
-      "comment" : "AI settings - OAuth authorization URL error"
+      "comment" : "AI settings - OAuth authorization URL error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'URL d'autorisation du connecteur n'est pas valide."
+          }
+        }
+      }
     },
     "The default Space can't be moved to another profile or deleted." : {
-      "comment" : "Spaces settings - default Space limits note"
+      "comment" : "Spaces settings - default Space limits note",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'espace par défaut ne peut pas être déplacé vers un autre profil ni supprimé."
+          }
+        }
+      }
     },
     "The Incognito Space browses in a private session. Its name and profile are fixed; the toggle above the list turns it off." : {
-      "comment" : "Spaces settings - Incognito Space limits note"
+      "comment" : "Spaces settings - Incognito Space limits note",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L'espace privé navigue en session privée. Son nom et son profil sont fixes ; le commutateur au-dessus de la liste le désactive."
+          }
+        }
+      }
     },
     "The local IM service is unavailable. Check whether Phi Sentinel started normally and the IM service is running." : {
-      "comment" : "IM Channels - Message shown when im-server is not connected"
+      "comment" : "IM Channels - Message shown when im-server is not connected",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le service de messagerie local est indisponible. Vérifiez que Phi Sentinel a démarré normalement et que le service de messagerie fonctionne."
+          }
+        }
+      }
     },
     "The Phi user data folder was not found. Continuing will still remove other local application data and quit." : {
-      "comment" : "Debug clear data - Alert body when Phi folder is missing; clearing will still proceed for other locations"
+      "comment" : "Debug clear data - Alert body when Phi folder is missing; clearing will still proceed for other locations",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le dossier des données utilisateur de Phi est introuvable. Continuer supprimera tout de même les autres données locales de l'application et fermera l'application."
+          }
+        }
+      }
     },
     "The restored Phi user data is not a directory." : {
-      "comment" : "Debug import user data - Error message when extracted Phi item is not a directory"
+      "comment" : "Debug import user data - Error message when extracted Phi item is not a directory",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les données utilisateur Phi restaurées ne sont pas un dossier."
+          }
+        }
+      }
     },
     "The selected Time Machine backup is no longer available." : {
-      "comment" : "Help menu - Time Machine restore error when a selected backup disappears"
+      "comment" : "Help menu - Time Machine restore error when a selected backup disappears",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La sauvegarde Time Machine sélectionnée n'est plus disponible."
+          }
+        }
+      }
     },
     "Theme" : {
-      "comment" : "General settings - Theme section title\nSpaces settings - theme section header"
+      "comment" : "General settings - Theme section title\nSpaces settings - theme section header",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thème"
+          }
+        }
+      }
     },
     "This replaces the Phi user data folder with the archive and restarts Phi. Save your work first." : {
-      "comment" : "Debug import user data - Confirmation alert body warning data replacement and relaunch"
+      "comment" : "Debug import user data - Confirmation alert body warning data replacement and relaunch",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette opération remplace le dossier des données utilisateur de Phi par l'archive et redémarre Phi. Enregistrez d'abord votre travail."
+          }
+        }
+      }
     },
     "This Space's window will be reopened with the new profile and its open tabs will be reloaded there. Site logins won't carry over. Bookmarks stay with the Space; pinned tabs will be the new profile's." : {
-      "comment" : "Body of the change-Space-profile confirmation"
+      "comment" : "Body of the change-Space-profile confirmation",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "La fenêtre de cet espace sera rouverte avec le nouveau profil et ses onglets ouverts y seront rechargés. Les connexions aux sites ne seront pas conservées. Les favoris restent liés à l'espace ; les onglets épinglés seront ceux du nouveau profil."
+          }
+        }
+      }
     },
     "This version of Phi cannot open local browser data that was updated by a newer version. Install the latest Phi version and try again." : {
-      "comment" : "Local store compatibility alert - body when a newer app is required to read local data"
+      "comment" : "Local store compatibility alert - body when a newer app is required to read local data",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette version de Phi ne peut pas ouvrir des données de navigateur locales mises à jour par une version plus récente. Installez la dernière version de Phi et réessayez."
+          }
+        }
+      }
     },
     "Time Machine Backups" : {
-      "comment" : "Help menu - Parent menu item listing completed Phi Time Machine backups"
+      "comment" : "Help menu - Parent menu item listing completed Phi Time Machine backups",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sauvegardes Time Machine"
+          }
+        }
+      }
     },
     "Time Machine Restore" : {
-      "comment" : "Time Machine restore progress window title"
+      "comment" : "Time Machine restore progress window title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Restauration Time Machine"
+          }
+        }
+      }
     },
     "Time Machine Restore Failed" : {
-      "comment" : "Help menu - Time Machine restore failure alert title"
+      "comment" : "Help menu - Time Machine restore failure alert title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la restauration Time Machine"
+          }
+        }
+      }
     },
     "Today" : {
-      "comment" : "Download item row - Relative time when download completed today"
+      "comment" : "Download item row - Relative time when download completed today",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aujourd'hui"
+          }
+        }
+      }
     },
     "Toggle Chatbar" : {
-      "comment" : "View menu - Menu item to show or hide the AI chat bar"
+      "comment" : "View menu - Menu item to show or hide the AI chat bar",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher/masquer la barre de discussion"
+          }
+        }
+      }
     },
     "Toggle Sidebar" : {
-      "comment" : "View menu - Menu item to show or hide the sidebar\nWeb content header - Accessibility description for sidebar toggle button"
+      "comment" : "View menu - Menu item to show or hide the sidebar\nWeb content header - Accessibility description for sidebar toggle button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher/masquer la barre latérale"
+          }
+        }
+      }
     },
     "Token verified successfully" : {
-      "comment" : "IM Channels - Custom bot verify success"
+      "comment" : "IM Channels - Custom bot verify success",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token vérifié avec succès"
+          }
+        }
+      }
     },
     "Turn Off" : {
-      "comment" : "AI settings - Destructive button to confirm turning off AI features\nAI settings - Destructive button to confirm turning off connectors\nConfirm disabling the Incognito Space"
+      "comment" : "AI settings - Destructive button to confirm turning off AI features\nAI settings - Destructive button to confirm turning off connectors\nConfirm disabling the Incognito Space",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver"
+          }
+        }
+      }
     },
     "Turn Off AI Features?" : {
-      "comment" : "AI settings - Confirmation alert title when disabling all AI features"
+      "comment" : "AI settings - Confirmation alert title when disabling all AI features",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver les fonctionnalités IA ?"
+          }
+        }
+      }
     },
     "Turn Off Connectors?" : {
-      "comment" : "AI settings - Confirmation alert title when disabling external data connectors"
+      "comment" : "AI settings - Confirmation alert title when disabling external data connectors",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver les connecteurs ?"
+          }
+        }
+      }
     },
     "Turn off Incognito Space?" : {
-      "comment" : "Title of the confirmation shown when disabling the Incognito Space with open tabs"
+      "comment" : "Title of the confirmation shown when disabling the Incognito Space with open tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désactiver l'espace privé ?"
+          }
+        }
+      }
     },
     "Unable to open connector authorization." : {
-      "comment" : "AI settings - OAuth authorization open error"
+      "comment" : "AI settings - OAuth authorization open error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Impossible d'ouvrir l'autorisation du connecteur."
+          }
+        }
+      }
     },
     "Unavailable" : {
-      "comment" : "Profiles settings - search engine list unavailable"
+      "comment" : "Profiles settings - search engine list unavailable",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indisponible"
+          }
+        }
+      }
     },
     "Ungroup" : {
-      "comment" : "Tab group context menu - Dissolve the group, keeping the tabs"
+      "comment" : "Tab group context menu - Dissolve the group, keeping the tabs",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dégrouper"
+          }
+        }
+      }
     },
     "Unknown" : {
-      "comment" : "Address bar menu - Website security unknown\nWebsite security unknown"
+      "comment" : "Address bar menu - Website security unknown\nWebsite security unknown",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inconnu"
+          }
+        }
+      }
     },
     "Unknown error" : {
-      "comment" : "Fallback profile-delete error reason\nFallback profile-rename error reason"
+      "comment" : "Fallback profile-delete error reason\nFallback profile-rename error reason",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur inconnue"
+          }
+        }
+      }
     },
     "Unlink" : {
-      "comment" : "Phi Link - Official bot unlink button"
+      "comment" : "Phi Link - Official bot unlink button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dissocier"
+          }
+        }
+      }
     },
     "Unmute" : {
-      "comment" : "Tab mute button tooltip - unmute"
+      "comment" : "Tab mute button tooltip - unmute",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Réactiver le son"
+          }
+        }
+      }
     },
     "Unpin" : {
-      "comment" : "Tab context menu - Menu item to unpin the selected tab"
+      "comment" : "Tab context menu - Menu item to unpin the selected tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désépingler"
+          }
+        }
+      }
     },
     "Unpin extension" : {
-      "comment" : "Extension list - Tooltip for unpinning an extension"
+      "comment" : "Extension list - Tooltip for unpinning an extension",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désépingler l'extension"
+          }
+        }
+      }
     },
     "Unpin Split" : {
-      "comment" : "Tab context menu - Remove the pin from the split that contains this tab"
+      "comment" : "Tab context menu - Remove the pin from the split that contains this tab",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Désépingler la division"
+          }
+        }
+      }
     },
     "Unsupported image format" : {
-      "comment" : "Image preview error"
+      "comment" : "Image preview error",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Format d'image non pris en charge"
+          }
+        }
+      }
     },
     "Untitled" : {
-      "comment" : "Default name for new bookmark folder\nDefault name for new bookmark folder in root"
+      "comment" : "Default name for new bookmark folder\nDefault name for new bookmark folder in root",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sans titre"
+          }
+        }
+      }
     },
     "Untitled Space" : {
-      "comment" : "Arc import - fallback name for an Arc Space with no title"
+      "comment" : "Arc import - fallback name for an Arc Space with no title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Espace sans titre"
+          }
+        }
+      }
     },
     "Update" : {
-      "comment" : "Sidebar header upgrade button title"
+      "comment" : "Sidebar header upgrade button title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mettre à jour"
+          }
+        }
+      }
     },
     "Update available" : {
-      "comment" : "Sidebar update reminder - Accessibility description for update icon"
+      "comment" : "Sidebar update reminder - Accessibility description for update icon",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mise à jour disponible"
+          }
+        }
+      }
     },
     "Update Phi to Open Local Data" : {
-      "comment" : "Local store compatibility alert - title when the local database was opened by a newer app version"
+      "comment" : "Local store compatibility alert - title when the local database was opened by a newer app version",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mettez à jour Phi pour ouvrir les données locales"
+          }
+        }
+      }
     },
     "URL" : {
-      "comment" : "Editor - Label for the URL input field\nFeedback form - Label for URL input field\nURL rule match type: exact host plus a path prefix"
+      "comment" : "Editor - Label for the URL input field\nFeedback form - Label for URL input field\nURL rule match type: exact host plus a path prefix",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL"
+          }
+        }
+      }
     },
     "URL Copied" : {
-      "comment" : "Toast shown after copying the selected tab URL to the clipboard"
+      "comment" : "Toast shown after copying the selected tab URL to the clipboard",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL copiée"
+          }
+        }
+      }
     },
     "URL Rules" : {
-      "comment" : "Title of the universal URL rules editor\nWindow title for the universal URL rules editor"
+      "comment" : "Title of the universal URL rules editor\nWindow title for the universal URL rules editor",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Règles d'URL"
+          }
+        }
+      }
     },
     "URL Rules…" : {
-      "comment" : "Spaces menu - Open the universal URL routing rules editor\nSpaces settings - button that opens the URL rules editor"
+      "comment" : "Spaces menu - Open the universal URL routing rules editor\nSpaces settings - button that opens the URL rules editor",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Règles d'URL…"
+          }
+        }
+      }
     },
     "URLs Copied" : {
-      "comment" : "Toast shown after copying selected tab URLs to the clipboard"
+      "comment" : "Toast shown after copying selected tab URLs to the clipboard",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "URL copiées"
+          }
+        }
+      }
     },
     "URLs matching any rule will open in the assigned Space, no matter where you click or type them." : {
-      "comment" : "Subtitle of the universal URL rules editor"
+      "comment" : "Subtitle of the universal URL rules editor",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Les URL correspondant à une règle s'ouvriront dans l'espace attribué, quel que soit l'endroit où vous cliquez ou les saisissez."
+          }
+        }
+      }
     },
     "Using Telegram to send and receive messages with %@" : {
-      "comment" : "Phi Link - Section subtitle with agent name"
+      "comment" : "Phi Link - Section subtitle with agent name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utilise Telegram pour envoyer et recevoir des messages avec %@"
+          }
+        }
+      }
     },
     "Validating rollback app..." : {
-      "comment" : "Time Machine restore progress stage"
+      "comment" : "Time Machine restore progress stage",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Validation de l'application de restauration…"
+          }
+        }
+      }
     },
     "Verification failed. Please check the token and try again." : {
-      "comment" : "IM Channels - Custom bot verify failure"
+      "comment" : "IM Channels - Custom bot verify failure",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Échec de la vérification. Veuillez vérifier le token et réessayer."
+          }
+        }
+      }
     },
     "Verify" : {
-      "comment" : "IM Channels - Custom bot verify action\nIM Channels - Custom bot verify button"
+      "comment" : "IM Channels - Custom bot verify action\nIM Channels - Custom bot verify button",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vérifier"
+          }
+        }
+      }
     },
     "Version %@ (%@)" : {
       "comment" : "About window - App version and build number label",
@@ -1739,71 +6174,267 @@
             "state" : "new",
             "value" : "Version %1$@ (%2$@)"
           }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Version %1$@ (%2$@)"
+          }
         }
       }
     },
     "View and manage your browser memory" : {
-      "comment" : "AI settings - Row title to open browser memory management"
+      "comment" : "AI settings - Row title to open browser memory management",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher et gérer la mémoire de votre navigateur"
+          }
+        }
+      }
     },
     "View Details" : {
-      "comment" : "Account settings - Button to view invitation code details"
+      "comment" : "Account settings - Button to view invitation code details",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les détails"
+          }
+        }
+      }
     },
     "We need to refresh your session before account features can keep working. Please sign in again." : {
-      "comment" : "Auth reauthentication - Alert body explaining required authentication"
+      "comment" : "Auth reauthentication - Alert body explaining required authentication",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nous devons actualiser votre session pour que les fonctionnalités du compte continuent de fonctionner. Veuillez vous reconnecter."
+          }
+        }
+      }
     },
     "We provide a Telegram bot to relay your messages @philink_bot" : {
-      "comment" : "Phi Link - Official Bot subtitle"
+      "comment" : "Phi Link - Official Bot subtitle",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nous fournissons un bot Telegram pour relayer vos messages @philink_bot"
+          }
+        }
+      }
     },
     "Website" : {
-      "comment" : "Extension list - Section title for current website security info\nPinned tab URL editor - Accessibility description for placeholder favicon"
+      "comment" : "Extension list - Section title for current website security info\nPinned tab URL editor - Accessibility description for placeholder favicon",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Site web"
+          }
+        }
+      }
     },
     "Welcome" : {
-      "comment" : "Onboarding welcome page - Main title greeting the user"
+      "comment" : "Onboarding welcome page - Main title greeting the user",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenue"
+          }
+        }
+      }
     },
     "Welcome %@" : {
-      "comment" : "Onboarding welcome page - Personalized welcome title with user name"
+      "comment" : "Onboarding welcome page - Personalized welcome title with user name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bienvenue %@"
+          }
+        }
+      }
     },
     "What should I call you?" : {
-      "comment" : "Set name page - Title asking user for their preferred name"
+      "comment" : "Set name page - Title asking user for their preferred name",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comment dois-je vous appeler ?"
+          }
+        }
+      }
     },
     "What's New" : {
-      "comment" : "Help menu - Menu item that opens the chrome://whats-new page in a new tab, placed right below 'Report an Issue'"
+      "comment" : "Help menu - Menu item that opens the chrome://whats-new page in a new tab, placed right below 'Report an Issue'",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nouveautés"
+          }
+        }
+      }
     },
     "www.example.com" : {
-      "comment" : "URL rule value placeholder for Domain match"
+      "comment" : "URL rule value placeholder for Domain match",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "www.example.com"
+          }
+        }
+      }
     },
     "Yellow" : {
-      "comment" : "Tab Groups - color name shown in auto-named group title and color picker"
+      "comment" : "Tab Groups - color name shown in auto-named group title and color picker",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jaune"
+          }
+        }
+      }
     },
     "Yesterday" : {
-      "comment" : "Download item row - Relative time when download completed yesterday"
+      "comment" : "Download item row - Relative time when download completed yesterday",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hier"
+          }
+        }
+      }
     },
     "You" : {
-      "comment" : "Account settings - Default display name when user name is not available"
+      "comment" : "Account settings - Default display name when user name is not available",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous"
+          }
+        }
+      }
     },
     "You can save a zip of your Phi user data folder before local files are removed and the app quits." : {
-      "comment" : "Debug clear data - Alert body explaining optional zip backup before clearing user data"
+      "comment" : "Debug clear data - Alert body explaining optional zip backup before clearing user data",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous pouvez enregistrer une archive zip de votre dossier de données utilisateur Phi avant que les fichiers locaux ne soient supprimés et que l'application ne se ferme."
+          }
+        }
+      }
     },
     "You will be logged out and returned to the login screen. Are you sure?" : {
-      "comment" : "Account settings - Logout confirmation dialog message"
+      "comment" : "Account settings - Logout confirmation dialog message",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vous serez déconnecté et redirigé vers l'écran de connexion. Êtes-vous sûr ?"
+          }
+        }
+      }
     },
     "Your Data and Settings" : {
-      "comment" : "Profiles settings - data & settings section header"
+      "comment" : "Profiles settings - data & settings section header",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vos données et paramètres"
+          }
+        }
+      }
     },
     "Your Phi session has expired. Please sign in again, then retry Phi Link." : {
-      "comment" : "Phi Link - Message shown when phi-agent returns 401 unauthorized"
+      "comment" : "Phi Link - Message shown when phi-agent returns 401 unauthorized",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Votre session Phi a expiré. Veuillez vous reconnecter, puis réessayer Phi Link."
+          }
+        }
+      }
     },
     "Your Profiles" : {
-      "comment" : "Profiles settings - list header"
+      "comment" : "Profiles settings - list header",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vos profils"
+          }
+        }
+      }
     },
     "Your Spaces" : {
-      "comment" : "Spaces settings - list header"
+      "comment" : "Spaces settings - list header",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vos espaces"
+          }
+        }
+      }
     },
     "Zoom in" : {
-      "comment" : "Image preview: accessibility label for zoom in control"
+      "comment" : "Image preview: accessibility label for zoom in control",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom avant"
+          }
+        }
+      }
     },
     "Zoom out" : {
-      "comment" : "Image preview: accessibility label for zoom out control"
+      "comment" : "Image preview: accessibility label for zoom out control",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zoom arrière"
+          }
+        }
+      }
+    },
+    "Language" : {
+      "comment" : "General settings - Language section title\nGeneral settings - App interface language row title",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Langue"
+          }
+        }
+      }
+    },
+    "Restart Phi to apply the new language." : {
+      "comment" : "General settings - Hint shown after changing the app language, prompting a relaunch",
+      "localizations" : {
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Redémarrez Phi pour appliquer la nouvelle langue."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Sources/Application/AppController.swift
+++ b/Sources/Application/AppController.swift
@@ -59,6 +59,12 @@ import PostHog
         // restored windows come back as normal windows. Set in `init` (before
         // `applicationWillFinishLaunching`) so it lands before AppKit reads it.
         UserDefaults.standard.set(false, forKey: "NSQuitAlwaysKeepsWindows")
+
+        // Re-assert the stored UI-language override (`AppleLanguages`) before
+        // AppKit and Chromium read localized resources. macOS resolves the
+        // bundle localization at process start, so a language change made in
+        // Settings only takes effect on the next launch.
+        PhiPreferences.LanguageSettings.applyStoredChoice()
     }
     
     func applicationDidFinishLaunching(_ notification: Notification) {

--- a/Sources/UserInterface/Preferences/General/GeneralSettingView.swift
+++ b/Sources/UserInterface/Preferences/General/GeneralSettingView.swift
@@ -57,6 +57,7 @@ struct GeneralSettingView: View {
                 }
                 AppearanceSectionView()
                 BrowsingSectionView()
+                LanguageSectionView()
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 36)
@@ -361,6 +362,47 @@ private struct BrowsingSectionView: View {
             .activeWindowController?
             .browserState
             .createTab("chrome://settings")
+    }
+}
+
+private struct LanguageSectionView: View {
+    @State private var selection: AppLanguage = PhiPreferences.LanguageSettings.loadChoice()
+    /// Shown once the user changes the language this session, since the new
+    /// localization only loads on the next launch.
+    @State private var showRelaunchHint: Bool = false
+
+    var body: some View {
+        GeneralSectionView(title: NSLocalizedString("Language", comment: "General settings - Language section title")) {
+            GeneralContainerView {
+                GeneralRowView(title: NSLocalizedString("Language", comment: "General settings - App interface language row title")) {
+                    Picker("", selection: $selection) {
+                        ForEach(AppLanguage.allCases) { language in
+                            Text(language.displayName).tag(language)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.menu)
+                    .fixedSize()
+                    .onChange(of: selection) { _, newValue in
+                        PhiPreferences.LanguageSettings.save(newValue)
+                        showRelaunchHint = true
+                    }
+                }
+
+                if showRelaunchHint {
+                    Divider()
+
+                    HStack(spacing: 12) {
+                        Text(NSLocalizedString("Restart Phi to apply the new language.", comment: "General settings - Hint shown after changing the app language, prompting a relaunch"))
+                            .font(.system(size: 11))
+                            .themedForeground(.textTertiary)
+                        Spacer(minLength: 12)
+                    }
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
     }
 }
 

--- a/Sources/UserInterface/Preferences/PhiPreferences.swift
+++ b/Sources/UserInterface/Preferences/PhiPreferences.swift
@@ -36,6 +36,40 @@ enum LayoutMode: String, CaseIterable, Identifiable {
     var showsNavigationAtTop: Bool { self != .performance }
 }
 
+/// The user-selectable UI language for the app. Applied through an
+/// `AppleLanguages` override written into the app's `UserDefaults` domain;
+/// because macOS resolves the bundle localization at process start, a change
+/// only takes effect after the app relaunches.
+enum AppLanguage: String, CaseIterable, Identifiable {
+    case system   // Follow the system language (no override)
+    case english
+    case french
+
+    var id: String { rawValue }
+
+    /// The `AppleLanguages` locale identifier, or `nil` to follow the system.
+    var localeIdentifier: String? {
+        switch self {
+        case .system:  return nil
+        case .english: return "en"
+        case .french:  return "fr"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .system:
+            // Reuses the existing "System" string; shown as "Follow the system language".
+            return NSLocalizedString("System", comment: "Language setting - Follow the system language")
+        case .english:
+            // Endonyms are conventionally left untranslated in a language picker.
+            return "English"
+        case .french:
+            return "Français"
+        }
+    }
+}
+
 enum PhiPreferences: String {
     case phiMainDebugMenuEnabled
     case phiLoginPhase
@@ -253,6 +287,51 @@ extension PhiPreferences {
 
         func save(_ value: Bool) {
             UserDefaults.standard.set(value, forKey: rawValue)
+        }
+    }
+
+    // MARK: - Language Settings
+
+    /// Persists the user's UI-language choice and mirrors it into the
+    /// `AppleLanguages` override that macOS reads at launch to pick the bundle
+    /// localization. Changing the language requires a relaunch to take effect.
+    enum LanguageSettings {
+        /// Key macOS reads (in the app's `UserDefaults` domain) to override the
+        /// preferred localization order for this app only.
+        static let appleLanguagesKey = "AppleLanguages"
+        /// Key storing the user's explicit `AppLanguage` choice.
+        static let choiceKey = "PhiAppLanguage"
+
+        static func loadChoice() -> AppLanguage {
+            guard let raw = UserDefaults.standard.string(forKey: choiceKey),
+                  let language = AppLanguage(rawValue: raw) else {
+                return .system
+            }
+            return language
+        }
+
+        /// Stores the choice and updates the `AppleLanguages` override. The new
+        /// language is applied the next time the app launches.
+        static func save(_ language: AppLanguage) {
+            UserDefaults.standard.set(language.rawValue, forKey: choiceKey)
+            apply(language)
+        }
+
+        /// Writes (or clears, for `.system`) the `AppleLanguages` override so the
+        /// next launch loads the chosen localization.
+        static func apply(_ language: AppLanguage) {
+            let defaults = UserDefaults.standard
+            if let identifier = language.localeIdentifier {
+                defaults.set([identifier], forKey: appleLanguagesKey)
+            } else {
+                defaults.removeObject(forKey: appleLanguagesKey)
+            }
+        }
+
+        /// Re-asserts the stored choice. Called early in launch (before AppKit /
+        /// Chromium read localized resources) so the override stays consistent.
+        static func applyStoredChoice() {
+            apply(loadChoice())
         }
     }
 }


### PR DESCRIPTION
Closes #63.

## What this does

Adds a complete **French (fr)** localization of the Phi Browser macOS UI.

## Changes

- **Translations** — every UI string in `Resources/Localizable.xcstrings` (580 existing strings + 2 new ones for the selector) and `Resources/DownloadSafety.xcstrings` (23) translated to French. Format specifiers are preserved (positional `%1$@` / `%2$d` where a string carries more than one argument).
- **Locale registration** — `fr` added to `knownRegions` (`Phi.xcodeproj/project.pbxproj`) and to `CFBundleLocalizations` (`PhiBrowser-Info.plist`).
- **In-app language selector** — a *Language* section in **General settings** (System / English / Français). An `AppLanguage` enum plus `PhiPreferences.LanguageSettings` write an `AppleLanguages` override that is re-asserted at `AppController.init()`; a relaunch hint appears after a change. The new language takes effect on the next launch.

## Out of scope

Web page content (the closed `Phi Framework.framework` layer) is unaffected — this is UI-only localization.

## Testing

- Builds cleanly with the `PhiBrowser-OpenSource` scheme (Xcode 26, Debug).
- Both String Catalogs compile with `xcstringstool` without errors.

## Notes

The String Catalog edits are additive (each entry gains an `fr` unit; existing `en`/comments untouched). Happy to tweak any wording, or to split the in-app language selector into a separate PR if you'd rather keep the localization change on its own.
