### PR TITLE
Open sidebar split targets on the right

### DIFF
--- a/Sources/UserInterface/Sidebar/TabList/BookmarkModel+Sidebar.swift
+++ b/Sources/UserInterface/Sidebar/TabList/BookmarkModel+Sidebar.swift
@@ -278,7 +278,7 @@ extension Bookmark: ContextMenuRepresentable {
            state.splitGroup(forTabId: partnerTabId) == nil {
             state.formSplitFromBookmark(bookmarkGuid: guid,
                                         partnerTabId: partnerTabId,
-                                        newTabSlot: .left)
+                                        newTabSlot: .right)
             return
         }
         state.openURLAsSplit(url: url)


### PR DESCRIPTION
## Summary
- Open unopened bookmark/sidebar targets in the right pane when using `Open as Split`.

## Rationale
The tab sidebar sits on the left and tab order follows left-to-right reading and interaction. Keeping the current tab on the left and opening the requested target on the right preserves that direction. It also matches `Split with Current` and the other split actions that open the new or target page on the right, aligning this behavior with common native-app expectations.

## Verification
- Built `PhiBrowser-OpenSource` with `xcodebuild`: 0 errors.
- Reproduced `Open as Split` from a bookmark/sidebar item: the target requested the right slot, the current tab remained primary, and no reverse was issued.