### PR TITLE
Support Option-click tab splits

### DIFF
--- a/Sources/States/BrowserState+Split.swift
+++ b/Sources/States/BrowserState+Split.swift
@@ -1155,16 +1155,17 @@ extension BrowserState {
     /// opens a new tab on the bookmark URL via `openNewTabAsSplit`. Shared
     /// by the drag-onto-page flow, the bookmark "Open as Split" menu, and
     /// any future entry point so all three behave identically.
-    /// - Returns: `true` when a split was attempted, `false` when the
-    ///   bookmark could not be resolved (deleted mid-action, folder, or
-    ///   empty URL). The caller may fall back to other entry points.
+    /// - Returns: `true` when a split command was dispatched, `false` when
+    ///   the bookmark or partner is no longer eligible. The caller may fall
+    ///   back to other entry points.
     @discardableResult
     func formSplitFromBookmark(bookmarkGuid: String,
                                partnerTabId: Int,
                                newTabSlot: SplitSlot) -> Bool {
         guard let bookmark = bookmarkManager.bookmark(withGuid: bookmarkGuid),
               !bookmark.isFolder,
-              let url = bookmark.url, !url.isEmpty else { return false }
+              let url = bookmark.url, !url.isEmpty,
+              splitGroup(forTabId: partnerTabId) == nil else { return false }
         // Resolve the bookmark's attached live tab BEFORE the partner
         // normalization below — `makeTabNormalOpened(partnerTabId)` clears
         // the partner tab's `guidInLocalDB`, so if the attached
@@ -1183,17 +1184,18 @@ extension BrowserState {
            attachedLiveTab.guid != partnerTabId,
            splitGroup(forTabId: attachedLiveTab.guid) == nil {
             makeTabNormalOpened(tabId: attachedLiveTab.guid)
+            let splitId: String?
             switch newTabSlot {
             case .left:
-                createSplit(leftTabId: attachedLiveTab.guid,
-                            rightTabId: partnerTabId,
-                            layout: .vertical)
+                splitId = createSplit(leftTabId: attachedLiveTab.guid,
+                                      rightTabId: partnerTabId,
+                                      layout: .vertical)
             case .right:
-                createSplit(leftTabId: partnerTabId,
-                            rightTabId: attachedLiveTab.guid,
-                            layout: .vertical)
+                splitId = createSplit(leftTabId: partnerTabId,
+                                      rightTabId: attachedLiveTab.guid,
+                                      layout: .vertical)
             }
-            return true
+            return splitId != nil
         }
         // Attached-and-IS-partner: the partner tab was the bookmark's live
         // representation and is now detached above. Opening another tab on
@@ -1203,15 +1205,13 @@ extension BrowserState {
         // opposite side.
         if attachedLiveTab?.guid == partnerTabId {
             let oppositeSlot: SplitSlot = (newTabSlot == .left) ? .right : .left
-            openNewTabAsSplit(partnerTabId: partnerTabId, newTabSlot: oppositeSlot)
-            return true
+            return openNewTabAsSplit(partnerTabId: partnerTabId, newTabSlot: oppositeSlot)
         }
         // Bookmark has no live representation: materialize a fresh unbound
         // tab on the bookmark URL as the new pane.
-        openNewTabAsSplit(partnerTabId: partnerTabId,
-                          newTabSlot: newTabSlot,
-                          partnerNavigateURL: URLProcessor.processUserInput(url))
-        return true
+        return openNewTabAsSplit(partnerTabId: partnerTabId,
+                                 newTabSlot: newTabSlot,
+                                 partnerNavigateURL: URLProcessor.processUserInput(url))
     }
 
     /// Opens a fresh tab (on `partnerNavigateURL` when given, else a
@@ -1229,12 +1229,17 @@ extension BrowserState {
     ///   - boundBookmarkGuid: When non-nil, the resulting split's id is
     ///     registered in `splitBookmarkBindings` under this bookmark guid so
     ///     a subsequent click on the bookmark activates the existing split.
+    /// - Returns: `true` when the new-tab split command was dispatched.
+    @discardableResult
     func openNewTabAsSplit(partnerTabId: Int,
                            newTabSlot: SplitSlot = .right,
                            partnerNavigateURL: String? = nil,
                            boundBookmarkGuid: String? = nil,
-                           insertionIndex: Int? = nil) {
-        guard splitGroup(forTabId: partnerTabId) == nil else { return }
+                           insertionIndex: Int? = nil) -> Bool {
+        guard splitGroup(forTabId: partnerTabId) == nil,
+              ChromiumLauncher.sharedInstance().bridge != nil else {
+            return false
+        }
         // Splits never live in the pinned strip. If the partner is currently
         // pinned, demote it to the normal list first and leave a fresh
         // unopened pinned placeholder pointing at the same URL at the
@@ -1292,6 +1297,7 @@ extension BrowserState {
                 .clearPendingSplitPartner(withTabId: partnerId.int64Value,
                                           windowId: wid.int64Value)
         }
+        return true
     }
 
     /// Right-click "Open as Split" on an *unopened* pinned cell. The pinned

--- a/Sources/UserInterface/Common/Tabs/Tab.swift
+++ b/Sources/UserInterface/Common/Tabs/Tab.swift
@@ -470,6 +470,68 @@ class Tab: WebContentRepresentable {
     func makeSelfActive() {
         webContentWrapper?.setAsActiveTab()
     }
+
+    /// Performs the Option-click split action for this tab. A split may only
+    /// involve two plain tabs: if either side already belongs to a split —
+    /// including a persisted pinned split pair whose panes are not live —
+    /// callers receive `false` and preserve their normal selection behavior
+    /// instead.
+    @MainActor
+    @discardableResult
+    func performSplitAction(in browserState: BrowserState) -> Bool {
+        guard let focusedTab = browserState.focusingTab,
+              browserState.tabs.contains(where: { $0.guid == focusedTab.guid }),
+              let route = TabSplitActionRoute.resolve(
+                  selectedTabId: guid,
+                  focusedTabId: focusedTab.guid,
+                  // `splitMembership(forCellTab:)` rather than a plain
+                  // `splitGroup(forTabId:)`: this cell may be a pinned record
+                  // whose synthetic guid hides a live pane — or a closed
+                  // pinned split pair — and both must keep click-to-restore.
+                  selectedTabIsInSplit: browserState.splitMembership(forCellTab: self) != nil,
+                  focusedTabIsInSplit: browserState.splitGroup(forTabId: focusedTab.guid) != nil
+              ) else {
+            return false
+        }
+
+        // A closed pinned entry has no live Chromium tab to pair directly.
+        // Treat it as the target URL, keeping the currently focused tab on
+        // the left and creating a fresh right-hand pane from the saved URL.
+        if !isOpenned {
+            guard case let .splitWithFocused(focusedTabId) = route,
+                  let pinnedDBGuid = guidInLocalDB,
+                  !pinnedDBGuid.isEmpty,
+                  let pinnedURL = pinnedUrl ?? url,
+                  !pinnedURL.isEmpty,
+                  browserState.pinnedTabs.contains(where: {
+                      $0.guidInLocalDB == pinnedDBGuid
+                  }) else {
+                return false
+            }
+            browserState.makeTabNormalOpened(tabId: focusedTabId)
+            return browserState.openNewTabAsSplit(
+                partnerTabId: focusedTabId,
+                partnerNavigateURL: URLProcessor.processUserInput(pinnedURL)
+            )
+        }
+
+        guard browserState.tabs.contains(where: { $0.guid == guid }) else {
+            return false
+        }
+
+        switch route {
+        case .openNewPartner:
+            return browserState.openNewTabAsSplit(partnerTabId: guid)
+        case let .splitWithFocused(focusedTabId):
+            browserState.makeTabNormalOpened(tabId: guid)
+            browserState.makeTabNormalOpened(tabId: focusedTabId)
+            return browserState.createSplit(
+                leftTabId: focusedTabId,
+                rightTabId: guid,
+                layout: .vertical
+            ) != nil
+        }
+    }
     
     func goBack() {
         webContentWrapper?.goBack()
@@ -516,6 +578,30 @@ class Tab: WebContentRepresentable {
     func tearDown() {
         cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
+    }
+}
+
+/// Resolves the command an Option-click should dispatch without entangling
+/// pointer handling with BrowserState mutation. The route stays nil whenever
+/// a second split would be created, allowing each view to fall back to its
+/// established selection path.
+enum TabSplitActionRoute: Equatable {
+    case openNewPartner
+    case splitWithFocused(tabId: Int)
+
+    static func resolve(selectedTabId: Int,
+                        focusedTabId: Int?,
+                        selectedTabIsInSplit: Bool,
+                        focusedTabIsInSplit: Bool) -> Self? {
+        guard let focusedTabId,
+              !selectedTabIsInSplit,
+              !focusedTabIsInSplit else {
+            return nil
+        }
+        if selectedTabId == focusedTabId {
+            return .openNewPartner
+        }
+        return .splitWithFocused(tabId: focusedTabId)
     }
 }
 

--- a/Sources/UserInterface/HorizontalBar/TabStrip/TabStrip.swift
+++ b/Sources/UserInterface/HorizontalBar/TabStrip/TabStrip.swift
@@ -7,6 +7,13 @@ import AppKit
 import Combine
 import SnapKit
 
+extension NSEvent.ModifierFlags {
+    var isPureOptionClick: Bool {
+        let selectionModifiers: Self = [.command, .option, .shift, .control]
+        return intersection(selectionModifiers) == .option
+    }
+}
+
 enum TabStripMultiSelectionUnit: Hashable {
     case tab(Int)
     case splitPair(left: Int, right: Int)
@@ -2894,6 +2901,20 @@ final class TabStrip: NSView, TitlebarAwareHitTestable {
         isPinned: Bool,
         modifierFlags: NSEvent.ModifierFlags
     ) {
+        if modifierFlags.isPureOptionClick {
+            let didPerformSplit = MainActor.assumeIsolated {
+                tab.performSplitAction(in: browserState)
+            }
+
+            if didPerformSplit {
+                multiSelectionRangeAnchor = nil
+                if browserState.multiSelection.isActive {
+                    browserState.clearMultiSelection()
+                }
+                return
+            }
+        }
+
         guard !isPinned else {
             multiSelectionRangeAnchor = nil
             if browserState.multiSelection.isActive {

--- a/Sources/UserInterface/HorizontalBar/TabStrip/Views/TabItemView.swift
+++ b/Sources/UserInterface/HorizontalBar/TabStrip/Views/TabItemView.swift
@@ -68,6 +68,7 @@ final class TabItemView: NSView {
     // MARK: - Drag Gesture State
     private var isDraggingInternal = false
     private var mouseDownPoint: CGPoint?
+    private var mouseDownModifierFlags: NSEvent.ModifierFlags?
 
     // MARK: - Tracking Area
     private var hoverTrackingArea: NSTrackingArea?
@@ -883,7 +884,9 @@ final class TabItemView: NSView {
 
     override func mouseUp(with event: NSEvent) {
         viewModel.isPressed = false
-        
+        let modifierFlags = mouseDownModifierFlags ?? event.modifierFlags
+        mouseDownModifierFlags = nil
+
         if isDraggingInternal {
             isDraggingInternal = false
             onDragEnd?()
@@ -919,20 +922,22 @@ final class TabItemView: NSView {
             // pane's tab so each favicon acts as its own click target.
             if pinnedSplitPartner != nil, point.x > bounds.midX, onSecondarySelect != nil {
                 if event.clickCount == 2, let onSecondaryDoubleSelect {
-                    onSecondaryDoubleSelect(event.modifierFlags)
+                    onSecondaryDoubleSelect(modifierFlags)
                 } else {
-                    onSecondarySelect?(event.modifierFlags)
+                    onSecondarySelect?(modifierFlags)
                 }
             } else if event.clickCount == 2, let onDoubleSelect {
-                onDoubleSelect(event.modifierFlags)
+                onDoubleSelect(modifierFlags)
             } else {
-                onSelect?(event.modifierFlags)
+                onSelect?(modifierFlags)
             }
         }
         mouseDownPoint = nil
     }
 
     override func mouseDown(with event: NSEvent) {
+        mouseDownModifierFlags = event.modifierFlags
+
         mouseDownPoint = convert(event.locationInWindow, from: nil)
         isDraggingInternal = false
 

--- a/Sources/UserInterface/Sidebar/TabList/BookmarkModel+Sidebar.swift
+++ b/Sources/UserInterface/Sidebar/TabList/BookmarkModel+Sidebar.swift
@@ -263,6 +263,25 @@ extension Bookmark: ContextMenuRepresentable {
         pb.setString(URLProcessor.phiBrandEnsuredUrlString(raw), forType: .string)
     }
 
+    /// Mirrors `openInSplitView` for Option-click, minus its two-fresh-tabs
+    /// fallback: with no eligible focused partner the click falls back to the
+    /// caller's normal open behavior instead. Split bookmarks (two URLs) keep
+    /// their click-to-restore semantics.
+    @MainActor
+    func performSplitAction(in state: BrowserState) -> Bool {
+        guard !isFolder,
+              let url, !url.isEmpty,
+              (secondaryUrl ?? "").isEmpty,
+              let focusedTab = state.focusingTab,
+              state.tabs.contains(where: { $0.guid == focusedTab.guid }),
+              state.splitGroup(forTabId: focusedTab.guid) == nil else {
+            return false
+        }
+        return state.formSplitFromBookmark(bookmarkGuid: guid,
+                                           partnerTabId: focusedTab.guid,
+                                           newTabSlot: .right)
+    }
+
     @MainActor
     @objc private func openInSplitView() {
         guard let url, !url.isEmpty,

--- a/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
+++ b/Sources/UserInterface/Sidebar/TabList/SidebarTabListViewController.swift
@@ -694,9 +694,27 @@ class SidebarTabListViewController: NSViewController {
             return
         }
 
-        let modifierFlags = NSApp.currentEvent?.modifierFlags ?? []
+        let modifierFlags = (sender as? SideBarOutlineView)?.consumeMouseDownModifierFlags()
+            ?? NSApp.currentEvent?.modifierFlags
+            ?? []
         let isCommandClick = modifierFlags.contains(.command)
         let isShiftClick = modifierFlags.contains(.shift)
+        if modifierFlags.isPureOptionClick,
+           let bookmark = bookmarkForRow(clickedRow) {
+            let didPerformSplit = MainActor.assumeIsolated {
+                bookmark.performSplitAction(in: browserState)
+            }
+            if didPerformSplit {
+                cancelPendingBookmarkRenameClick()
+                endBookmarkEditing(except: bookmark)
+                multiSelectionRangeAnchor = nil
+                if browserState.multiSelection.isActive {
+                    browserState.clearMultiSelection()
+                }
+                return
+            }
+        }
+
         if !isCommandClick,
            !isShiftClick,
            let bookmark = bookmarkForRow(clickedRow), !bookmark.isFolder {
@@ -4954,10 +4972,24 @@ extension SidebarTabListViewController: SideBarOutlineViewDelegate {
         )
     }
 
-    func outlineView(_ outlineView: SideBarOutlineView, didClickRow row: Int) {
+    func outlineView(_ outlineView: SideBarOutlineView,
+                     didClickRow row: Int,
+                     modifierFlags: NSEvent.ModifierFlags) {
         guard row >= 0,
               let item = outlineView.item(atRow: row) as? SidebarItem else {
             return
+        }
+        if let tab = item as? Tab, modifierFlags.isPureOptionClick {
+            let didPerformSplit = MainActor.assumeIsolated {
+                tab.performSplitAction(in: browserState)
+            }
+            if didPerformSplit {
+                multiSelectionRangeAnchor = nil
+                if browserState.multiSelection.isActive {
+                    browserState.clearMultiSelection()
+                }
+                return
+            }
         }
         // In an agent Space the user may click tabs to look around while the
         // agent keeps control: switching does NOT take over. `focuseTab` moves
@@ -4967,7 +4999,6 @@ extension SidebarTabListViewController: SideBarOutlineViewDelegate {
         // Normal tab rows are delivered here (the outline view's standard
         // action never fires for them), so multi-selection must be handled
         // on this path rather than `outlineViewClicked`.
-        let modifierFlags = NSApp.currentEvent?.modifierFlags ?? []
         if handleModifiedMultiSelectionClick(for: item, modifierFlags: modifierFlags) {
             return
         }

--- a/Sources/UserInterface/Sidebar/TabList/Views/GroupTabsTableView.swift
+++ b/Sources/UserInterface/Sidebar/TabList/Views/GroupTabsTableView.swift
@@ -141,6 +141,7 @@ final class GroupTabsTableView: NSTableView {
     override func mouseUp(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
         let upRow = row(at: point)
+        let modifierFlags = pendingMouseDownEvent?.modifierFlags ?? event.modifierFlags
         if !manualDragInProgress,
            let clickedRow = pendingDragRow,
            clickedRow >= 0,
@@ -152,7 +153,11 @@ final class GroupTabsTableView: NSTableView {
                                             didRequest: pendingInteractionTarget,
                                             row: clickedRow)
             } else if pendingInteractionTarget == nil {
-                phiTableDelegate?.tableView(self, didClickRow: clickedRow)
+                phiTableDelegate?.tableView(
+                    self,
+                    didClickRow: clickedRow,
+                    modifierFlags: modifierFlags
+                )
             }
         }
         resetPendingDragState()
@@ -223,7 +228,8 @@ protocol GroupTabsTableViewDelegate: AnyObject {
                    beginDraggingRow row: Int,
                    with event: NSEvent)
     func tableView(_ tableView: GroupTabsTableView,
-                   didClickRow row: Int)
+                   didClickRow row: Int,
+                   modifierFlags: NSEvent.ModifierFlags)
     func tableView(_ tableView: GroupTabsTableView,
                    didMiddleClickRow row: Int,
                    at location: NSPoint)

--- a/Sources/UserInterface/Sidebar/TabList/Views/SideBarOutlineView.swift
+++ b/Sources/UserInterface/Sidebar/TabList/Views/SideBarOutlineView.swift
@@ -215,7 +215,9 @@ protocol SideBarOutlineViewDelegate: AnyObject {
     func outlineView(_ outlineView: SideBarOutlineView,
                      didMiddleClickRow row: Int,
                      at location: NSPoint)
-    func outlineView(_ outlineView: SideBarOutlineView, didClickRow row: Int)
+    func outlineView(_ outlineView: SideBarOutlineView,
+                     didClickRow row: Int,
+                     modifierFlags: NSEvent.ModifierFlags)
     func outlineView(_ outlineView: SideBarOutlineView,
                      beginDraggingTabAtRow row: Int,
                      with mouseDownEvent: NSEvent)
@@ -249,6 +251,12 @@ class SideBarOutlineView: DiffableOutlineView {
     
     /// Delegate for handling middle mouse button click events
     weak var phiOutlineDelegate: SideBarOutlineViewDelegate?
+    private var lastMouseDownModifierFlags: NSEvent.ModifierFlags?
+
+    func consumeMouseDownModifierFlags() -> NSEvent.ModifierFlags? {
+        defer { lastMouseDownModifierFlags = nil }
+        return lastMouseDownModifierFlags
+    }
 
     private var pendingTabDragRow: Int?
     private var pendingTabDragStartPoint: NSPoint?
@@ -335,7 +343,13 @@ class SideBarOutlineView: DiffableOutlineView {
             AppLogDebug(
                 "[SIDEBAR_TAB_DRAG_THRESHOLD] forwarding mouseDown to super row=\(index)"
             )
+            // The row action (`outlineViewClicked`) fires inside super's
+            // tracking loop, which also swallows the matching mouseUp —
+            // scope the exposed mouse-down modifiers to exactly that window
+            // so an unconsumed click can't leak stale flags.
+            lastMouseDownModifierFlags = event.modifierFlags
             super.mouseDown(with: event)
+            lastMouseDownModifierFlags = nil
             AppLogDebug(
                 "[SIDEBAR_TAB_DRAG_THRESHOLD] super mouseDown returned row=\(index)"
             )
@@ -405,7 +419,12 @@ class SideBarOutlineView: DiffableOutlineView {
                 let point = convert(event.locationInWindow, from: nil)
                 if pendingRow == row(at: point) {
                     AppLogDebug("[SIDEBAR_TAB_DRAG_THRESHOLD] click normal tab row=\(pendingRow)")
-                    phiOutlineDelegate?.outlineView(self, didClickRow: pendingRow)
+                    let modifierFlags = pendingTabMouseDownEvent?.modifierFlags ?? event.modifierFlags
+                    phiOutlineDelegate?.outlineView(
+                        self,
+                        didClickRow: pendingRow,
+                        modifierFlags: modifierFlags
+                    )
                 }
             }
             return

--- a/Sources/UserInterface/Sidebar/TabList/Views/TabGroupCellView.swift
+++ b/Sources/UserInterface/Sidebar/TabList/Views/TabGroupCellView.swift
@@ -1081,12 +1081,23 @@ extension TabGroupCellView: GroupTabsTableViewDelegate {
     }
 
     func tableView(_ tableView: GroupTabsTableView,
-                   didClickRow row: Int) {
+                   didClickRow row: Int,
+                   modifierFlags: NSEvent.ModifierFlags) {
         guard currentMemberOrder.indices.contains(row) else {
             return
         }
         let key = currentMemberOrder[row]
-        let modifierFlags = NSApp.currentEvent?.modifierFlags ?? []
+        if modifierFlags.isPureOptionClick,
+           let tab = tabsByGuid[key],
+           let state = configuredBrowserState {
+            let didPerformSplit = MainActor.assumeIsolated {
+                tab.performSplitAction(in: state)
+            }
+            if didPerformSplit {
+                state.clearMultiSelection()
+                return
+            }
+        }
         if let pair = splitPairsByKey[key],
            groupCellDelegate?.tabGroupCell(
                self,

--- a/Tests/PhiBrowserTests/TabMultiSelectionTests.swift
+++ b/Tests/PhiBrowserTests/TabMultiSelectionTests.swift
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an Apache license that can be
 // found in the LICENSE file.
 
+import AppKit
 import XCTest
 @testable import Phi
 
@@ -26,5 +27,64 @@ final class TabMultiSelectionTests: XCTestCase {
         var sel = TabMultiSelection.empty
         sel.toggle(1); sel.toggle(2); sel.toggle(3); sel.toggle(2)
         XCTAssertEqual(sel.guids, [1, 3])
+    }
+
+    func testPureOptionClickExcludesSelectionModifiers() {
+        var modifiers: NSEvent.ModifierFlags = [.option]
+        XCTAssertTrue(modifiers.isPureOptionClick)
+
+        for modifier in [NSEvent.ModifierFlags.command, .shift, .control] {
+            modifiers.insert(modifier)
+            XCTAssertFalse(modifiers.isPureOptionClick)
+            modifiers.remove(modifier)
+        }
+    }
+
+    func testTabSplitActionRouteChoosesTheExpectedSplitCommand() {
+        XCTAssertEqual(
+            TabSplitActionRoute.resolve(
+                selectedTabId: 1,
+                focusedTabId: 1,
+                selectedTabIsInSplit: false,
+                focusedTabIsInSplit: false
+            ),
+            .openNewPartner
+        )
+        XCTAssertEqual(
+            TabSplitActionRoute.resolve(
+                selectedTabId: 2,
+                focusedTabId: 1,
+                selectedTabIsInSplit: false,
+                focusedTabIsInSplit: false
+            ),
+            .splitWithFocused(tabId: 1)
+        )
+    }
+
+    func testTabSplitActionRouteRejectsMissingOrSplitParticipants() {
+        XCTAssertNil(
+            TabSplitActionRoute.resolve(
+                selectedTabId: 1,
+                focusedTabId: nil,
+                selectedTabIsInSplit: false,
+                focusedTabIsInSplit: false
+            )
+        )
+        XCTAssertNil(
+            TabSplitActionRoute.resolve(
+                selectedTabId: 2,
+                focusedTabId: 1,
+                selectedTabIsInSplit: true,
+                focusedTabIsInSplit: false
+            )
+        )
+        XCTAssertNil(
+            TabSplitActionRoute.resolve(
+                selectedTabId: 2,
+                focusedTabId: 1,
+                selectedTabIsInSplit: false,
+                focusedTabIsInSplit: true
+            )
+        )
     }
 }


### PR DESCRIPTION
## As-is

Splitting is already supported through context-menu actions, but it is not exposed as a direct pointer gesture across the places users select content:

- A user must right-click a tab or bookmark, locate the split action, then invoke it.
- A normal sidebar bookmark click opens that bookmark as a standalone tab rather than pairing it with the focused tab.
- Tab interaction is implemented through distinct AppKit event paths in the top strip, sidebar, and embedded tab-group table, so a shortcut added to only one surface would be inconsistent.
- Command and Shift are already established multi-selection modifiers. Any split shortcut that accepts combined modifiers would unexpectedly clear selection state.

For a comparison, reference, or side-by-side research workflow, this forces a repeated context-menu detour for an operation users perform frequently.

## To-be

A pure `Option`-click performs the existing split action directly on every eligible tab surface:

| Target | Result |
| --- | --- |
| Focused tab | Open a new split partner. |
| Another normal tab | Split it with the focused tab; the current tab remains left and the target is right. |
| Sidebar bookmark | Open the bookmark as the right pane beside the focused tab. |
| Tab-group member | Match normal-tab split behavior. |

Existing split pairs — live groups, pinned records whose synthetic guid hides a live pane, and closed pinned split pairs — retain normal selection behavior; nested splits are never created.

Only a pure `Option` gesture activates this action. `Command` + `Option`, `Shift` + `Option`, and `Control` + `Option` retain their existing selection semantics and never clear multi-selection.

## Design notes

- Routing is factored into a pure `TabSplitActionRoute` so the dispatch decision is unit-testable without touching `BrowserState`.
- `openNewTabAsSplit` / `formSplitFromBookmark` report whether a split command was actually dispatched (missing bridge, ineligible partner), so every surface falls back to its normal selection path instead of swallowing the click.
- Each surface passes its own window's `BrowserState` instead of resolving `activeWindowController`, keeping the gesture deterministic with multiple windows open.
- The custom AppKit controls carry modifier flags captured at mouse-down through their deferred mouse-up handling; `SideBarOutlineView` scopes the captured flags to the `super.mouseDown` tracking-loop window so stale flags cannot leak into a later action.

## History

Supersedes #72. This PR consolidates its three commits into a reviewable sequence and fixes the issues found while re-reviewing them: the persisted-pinned-split guard (`splitMembership(forCellTab:)` instead of only `splitGroup(forTabId:)`), failure propagation for split dispatch, per-window state resolution, stale modifier-flag lifecycle in the sidebar outline view, and multi-selection anchor reset parity between the tab strip and sidebar.

## Verification

- Based on current upstream `main` (f2d66a8).
- `xcodebuild test -only-testing:PhiBrowserTests/TabMultiSelectionTests`: 6 tests passed, 0 failures.
- Manual smoke checklist (to run before merge): Option-click on the focused tab, another normal tab, a sidebar bookmark, and a grouped tab performs the expected split; Option-click on existing split pairs (including closed pinned split cells) and with Command/Shift/Control combinations keeps normal selection behavior.

https://claude.ai/code/session_01PB7ynH51JvG81xdnCc2P5T
