### PR TITLE
feat: export Sentinel AI data with browser backups

### DIFF
--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3703C9822F69558C00E7CF6D /* BrowserState+ToggleAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9812F69558C00E7CF6D /* BrowserState+ToggleAI.swift */; };
 		3703C9842F6956E600E7CF6D /* SentinelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9832F6956E600E7CF6D /* SentinelHelper.swift */; };
 		3703C9862F6956E600E7CF6D /* SentinelVersionGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */; };
+		3AC6117E11925E637EB4711A /* SentinelBackupCoordination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E8BEE1510290AB35D5C5AD /* SentinelBackupCoordination.swift */; };
 		F9E478A224C44EA7BC0D85CC /* AccountDeletedEventAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */; };
 		370D03AC2F0E463B0087A1C9 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D03A32F0E463B0087A1C9 /* Mapper.swift */; };
 		370D03AD2F0E463B0087A1C9 /* ThemedColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D03A82F0E463B0087A1C9 /* ThemedColor.swift */; };
@@ -574,6 +575,7 @@
 		3703C9812F69558C00E7CF6D /* BrowserState+ToggleAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserState+ToggleAI.swift"; sourceTree = "<group>"; };
 		3703C9832F6956E600E7CF6D /* SentinelHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelHelper.swift; sourceTree = "<group>"; };
 		3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelVersionGuard.swift; sourceTree = "<group>"; };
+		11E8BEE1510290AB35D5C5AD /* SentinelBackupCoordination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelBackupCoordination.swift; sourceTree = "<group>"; };
 		19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletedEventAuthentication.swift; sourceTree = "<group>"; };
 		370D039F2F0E463B0087A1C9 /* Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 		370D03A02F0E463B0087A1C9 /* Bags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bags.swift; sourceTree = "<group>"; };
@@ -1868,6 +1870,7 @@
 				19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */,
 				3703C9832F6956E600E7CF6D /* SentinelHelper.swift */,
 				3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */,
+				11E8BEE1510290AB35D5C5AD /* SentinelBackupCoordination.swift */,
 				6A44C5FF60DF6F7860A061D4 /* SentinelWatchdog.swift */,
 				37CC00012F9D000100000001 /* SentinelIPCClient.swift */,
 				54A100202FE0000000000020 /* TimeMachine */,
@@ -2597,6 +2600,7 @@
 				F9E478A224C44EA7BC0D85CC /* AccountDeletedEventAuthentication.swift in Sources */,
 				3703C9842F6956E600E7CF6D /* SentinelHelper.swift in Sources */,
 				3703C9862F6956E600E7CF6D /* SentinelVersionGuard.swift in Sources */,
+				3AC6117E11925E637EB4711A /* SentinelBackupCoordination.swift in Sources */,
 				793C1DDEA1022CC850FEFFF9 /* SentinelWatchdog.swift in Sources */,
 				37CC00022F9D000100000001 /* SentinelIPCClient.swift in Sources */,
 				CCB53DCF2E6EC437004BF233 /* OmniBoxTextField.swift in Sources */,

--- a/Sources/Application/AppController+UserDataBackup.swift
+++ b/Sources/Application/AppController+UserDataBackup.swift
@@ -4,9 +4,32 @@
 // found in the LICENSE file.
 
 import AppKit
+import Darwin
 import Foundation
 import SwiftData
 import UniformTypeIdentifiers
+
+struct PhiUserDataExportSelection: Equatable {
+    var includeBrowserData: Bool
+    var includeAIData: Bool
+
+    var isExportable: Bool {
+        includeBrowserData || includeAIData
+    }
+}
+
+@MainActor
+private final class PhiUserDataExportSelectionBox {
+    var selection: PhiUserDataExportSelection
+    var readState: (() -> PhiUserDataExportSelection)?
+
+    init(browserDataAvailable: Bool) {
+        selection = PhiUserDataExportSelection(
+            includeBrowserData: browserDataAvailable,
+            includeAIData: true
+        )
+    }
+}
 
 extension AppController {
     private enum PhiUserDataBackupPromptResult {
@@ -139,7 +162,7 @@ extension AppController {
     private func promptBackupBeforeClearingPhiUserData() -> PhiUserDataBackupPromptResult {
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("Back Up User Data First?", comment: "Debug clear data - Alert title asking whether to export Phi user data before clearing")
-        alert.informativeText = NSLocalizedString("You can save a zip of your Phi user data folder before local files are removed and the app quits.", comment: "Debug clear data - Alert body explaining optional zip backup before clearing user data")
+        alert.informativeText = NSLocalizedString("You can save a zip of your browser and AI data before local files are removed and the app quits.", comment: "Debug clear data - Alert body explaining optional zip backup before clearing user data")
         alert.alertStyle = .informational
         alert.addButton(withTitle: NSLocalizedString("Backup...", comment: "Debug clear data - Alert button to open the save panel for a Phi user data zip"))
         alert.addButton(withTitle: NSLocalizedString("Skip Backup", comment: "Debug clear data - Alert button to clear data without creating a backup zip"))
@@ -155,19 +178,64 @@ extension AppController {
     }
 
     @MainActor
+    private func makeExportAccessoryView(
+        box: PhiUserDataExportSelectionBox,
+        browserDataAvailable: Bool
+    ) -> NSView {
+        let browserCheckbox = NSButton(
+            checkboxWithTitle: NSLocalizedString(
+                "Browser data",
+                comment: "Manage User Data - Export category checkbox for Phi browser data"
+            ),
+            target: nil,
+            action: nil
+        )
+        browserCheckbox.state = box.selection.includeBrowserData ? .on : .off
+        browserCheckbox.isEnabled = browserDataAvailable
+
+        let aiCheckbox = NSButton(
+            checkboxWithTitle: NSLocalizedString(
+                "AI data",
+                comment: "Manage User Data - Export category checkbox for Sentinel AI data"
+            ),
+            target: nil,
+            action: nil
+        )
+        aiCheckbox.state = box.selection.includeAIData ? .on : .off
+
+        box.readState = {
+            PhiUserDataExportSelection(
+                includeBrowserData: browserCheckbox.state == .on,
+                includeAIData: aiCheckbox.state == .on
+            )
+        }
+
+        let stack = NSStackView(views: [browserCheckbox, aiCheckbox])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 320, height: 64))
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -12),
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8)
+        ])
+        return container
+    }
+
+    @MainActor
     private func performPhiUserDataBackupExport() -> Bool {
         let fm = FileManager.default
-        let phiPath = FileSystemUtils.phiBrowserDataDirectory()
-
-        if !fm.fileExists(atPath: phiPath) {
-            let alert = NSAlert()
-            alert.messageText = NSLocalizedString("No Phi User Data to Back Up", comment: "Debug clear data - Alert title when the Phi data folder is missing before backup")
-            alert.informativeText = NSLocalizedString("The Phi user data folder was not found. Continuing will still remove other local application data and quit.", comment: "Debug clear data - Alert body when Phi folder is missing; clearing will still proceed for other locations")
-            alert.alertStyle = .informational
-            alert.addButton(withTitle: NSLocalizedString("OK", comment: "Generic - OK button to dismiss an alert"))
-            alert.runModal()
-            return true
-        }
+        let browserDataAvailable = Self.isDirectory(
+            at: URL(
+                fileURLWithPath: FileSystemUtils.phiBrowserDataDirectory(),
+                isDirectory: true
+            )
+        )
 
         let panel = NSSavePanel()
         panel.canCreateDirectories = true
@@ -176,13 +244,102 @@ extension AppController {
         panel.title = NSLocalizedString("Back Up Phi User Data", comment: "Debug clear data - NSSavePanel title for saving Phi user data directory as zip")
         panel.prompt = NSLocalizedString("Save", comment: "Debug clear data - NSSavePanel confirm button title when saving Phi user data backup zip")
 
+        let selectionBox = PhiUserDataExportSelectionBox(
+            browserDataAvailable: browserDataAvailable
+        )
+        panel.accessoryView = makeExportAccessoryView(
+            box: selectionBox,
+            browserDataAvailable: browserDataAvailable
+        )
+
         guard panel.runModal() == .OK, let destinationZIP = panel.url else {
             return false
         }
 
+        let selection = selectionBox.readState?() ?? selectionBox.selection
+        guard selection.isExportable else {
+            let alert = NSAlert()
+            alert.messageText = NSLocalizedString(
+                "Select at least one category to back up.",
+                comment: "Manage User Data - Alert when the user unchecks both export categories"
+            )
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: NSLocalizedString("OK", comment: "Generic - OK button to dismiss an alert"))
+            alert.runModal()
+            return false
+        }
+
+        let stagingDirectory = fm.temporaryDirectory.appendingPathComponent(
+            "PhiDataExport-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let stagedZIP = stagingDirectory.appendingPathComponent(
+            "Phi-data.zip",
+            isDirectory: false
+        )
+
         do {
-            syncCurrentChromiumProfileDisplayNamesToLocalStore()
-            try zipPhiBrowserDataDirectory(to: destinationZIP)
+            try fm.createDirectory(
+                at: stagingDirectory,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+            defer {
+                try? fm.removeItem(at: stagingDirectory)
+            }
+
+            if selection.includeBrowserData {
+                guard browserDataAvailable else {
+                    throw NSError(
+                        domain: "PhiUserDataBackup",
+                        code: 2,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: NSLocalizedString(
+                                "The Phi browser data folder is no longer available.",
+                                comment: "Manage User Data - Error when browser data disappears before backup starts"
+                            )
+                        ]
+                    )
+                }
+                syncCurrentChromiumProfileDisplayNamesToLocalStore()
+                try zipPhiBrowserDataDirectory(to: stagedZIP)
+            }
+
+            if selection.includeAIData {
+                let aiResult = coordinateAIDataExport()
+                switch aiResult.result {
+                case .packed(let tarURL):
+                    do {
+                        try Self.appendAIDataArchive(tarURL, to: stagedZIP)
+                        aiResult.session?.cleanup()
+                    } catch {
+                        aiResult.session?.cleanup()
+                        AppLogWarn("[Manage User Data] Failed to add AI data to backup: \(error.localizedDescription)")
+                        warnAIDataDegraded(
+                            reason: .exportFailed,
+                            browserDataIncluded: selection.includeBrowserData
+                        )
+                        guard selection.includeBrowserData else {
+                            return false
+                        }
+                    }
+                case .skipped(let reason):
+                    if reason.shouldRetainSessionForLateWrite {
+                        aiResult.session?.scheduleCleanup()
+                    } else {
+                        aiResult.session?.cleanup()
+                    }
+                    warnAIDataDegraded(
+                        reason: reason,
+                        browserDataIncluded: selection.includeBrowserData
+                    )
+                    guard selection.includeBrowserData else {
+                        return false
+                    }
+                }
+            }
+
+            try Self.publishBackup(from: stagedZIP, to: destinationZIP)
             AppLogInfo("[Debug] Phi user data backup saved to \(destinationZIP.path)")
             return true
         } catch {
@@ -195,6 +352,114 @@ extension AppController {
             errorAlert.runModal()
             return false
         }
+    }
+
+    @MainActor
+    private func coordinateAIDataExport() -> (
+        result: AIDataExportCoordinator.Result,
+        session: SentinelAIDataExportSession?
+    ) {
+        let service = SentinelAIDataExportService()
+        let session: SentinelAIDataExportSession
+        do {
+            session = try service.prepareSession()
+        } catch {
+            AppLogWarn("[Manage User Data] Cannot prepare AI data export: \(error.localizedDescription)")
+            return (.skipped(reason: .exportFailed), nil)
+        }
+
+        let cancellation = SentinelExportCancellation()
+        let result = presentAIDataExportProgress(cancelBox: cancellation) {
+            await service.coordinate(
+                session: session,
+                isCancelled: {
+                    cancellation.isCancelled
+                }
+            )
+        }
+        return (result, session)
+    }
+
+    @MainActor
+    private func presentAIDataExportProgress(
+        cancelBox: SentinelExportCancellation,
+        _ work: @escaping () async -> AIDataExportCoordinator.Result
+    ) -> AIDataExportCoordinator.Result {
+        let alert = NSAlert()
+        alert.messageText = NSLocalizedString(
+            "Backing Up AI Data",
+            comment: "Manage User Data - Progress title while Sentinel exports AI data"
+        )
+        alert.addButton(withTitle: NSLocalizedString(
+            "Cancel",
+            comment: "Manage User Data - Cancel button on the AI data backup progress modal"
+        ))
+
+        let progress = NSProgressIndicator(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 20)
+        )
+        progress.style = .bar
+        progress.isIndeterminate = true
+        progress.startAnimation(nil)
+        alert.accessoryView = progress
+
+        var workResult: AIDataExportCoordinator.Result?
+        let task = Task { @MainActor in
+            let result = await work()
+            guard !Task.isCancelled else {
+                return
+            }
+            workResult = result
+            NSApp.stopModal()
+        }
+
+        let response = alert.runModal()
+        if response == .stop, let workResult {
+            return workResult
+        }
+
+        cancelBox.cancel()
+        task.cancel()
+        return .skipped(reason: .cancelled)
+    }
+
+    @MainActor
+    private func warnAIDataDegraded(
+        reason: AIDataExportCoordinator.SkipReason,
+        browserDataIncluded: Bool
+    ) {
+        let detail: String
+        switch (browserDataIncluded, reason) {
+        case (true, .sentinelUnavailable):
+            detail = NSLocalizedString("AI data was not included because Sentinel could not be started. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export is skipped because Sentinel is unavailable")
+        case (true, .timedOut):
+            detail = NSLocalizedString("AI data was not included because Sentinel did not respond in time. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export times out")
+        case (true, .exportFailed):
+            detail = NSLocalizedString("AI data was not included because Sentinel could not export it. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export fails")
+        case (true, .invalidResponsePath):
+            detail = NSLocalizedString("AI data was not included because Sentinel returned an unexpected file. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export returns an unexpected path")
+        case (true, .cancelled):
+            detail = NSLocalizedString("AI data backup was cancelled. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export is cancelled")
+        case (false, .sentinelUnavailable):
+            detail = NSLocalizedString("AI data could not be backed up because Sentinel could not be started. No backup was created.", comment: "Manage User Data - Warning when an AI-only export cannot start Sentinel")
+        case (false, .timedOut):
+            detail = NSLocalizedString("AI data could not be backed up because Sentinel did not respond in time. No backup was created.", comment: "Manage User Data - Warning when an AI-only export times out")
+        case (false, .exportFailed):
+            detail = NSLocalizedString("AI data could not be backed up because Sentinel could not export it. No backup was created.", comment: "Manage User Data - Warning when an AI-only export fails")
+        case (false, .invalidResponsePath):
+            detail = NSLocalizedString("AI data could not be backed up because Sentinel returned an unexpected file. No backup was created.", comment: "Manage User Data - Warning when an AI-only export returns an unexpected path")
+        case (false, .cancelled):
+            detail = NSLocalizedString("AI data backup was cancelled. No backup was created.", comment: "Manage User Data - Warning when an AI-only export is cancelled")
+        }
+
+        let alert = NSAlert()
+        alert.messageText = browserDataIncluded
+            ? NSLocalizedString("AI Data Not Backed Up", comment: "Manage User Data - Alert title when AI data is skipped but browser data succeeds")
+            : NSLocalizedString("Backup Failed", comment: "Debug clear data - Alert title when exporting Phi user data zip fails")
+        alert.informativeText = detail
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: NSLocalizedString("OK", comment: "Generic - OK button to dismiss an alert"))
+        alert.runModal()
     }
 
     private func defaultPhiUserDataBackupFileName() -> String {
@@ -265,19 +530,181 @@ extension AppController {
             try fm.removeItem(at: destinationZIP)
         }
 
+        try Self.runZip(
+            arguments: ["-r", "-q", destinationZIP.path, phiFolderName],
+            currentDirectoryURL: parentURL
+        )
+    }
+
+    static func appendAIDataArchive(_ tarURL: URL, to destinationZIP: URL) throws {
+        let fm = FileManager.default
+        let entryName = SentinelAIDataExportSession.archiveFileName
+        let stagingParent = fm.temporaryDirectory.appendingPathComponent(
+            "PhiAIDataZip-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fm.createDirectory(
+            at: stagingParent,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        defer {
+            try? fm.removeItem(at: stagingParent)
+        }
+
+        try copyOpenedRegularFile(
+            from: tarURL,
+            to: stagingParent.appendingPathComponent(entryName)
+        )
+        try runZip(
+            arguments: ["-q", destinationZIP.path, entryName],
+            currentDirectoryURL: stagingParent
+        )
+    }
+
+    private static func copyOpenedRegularFile(
+        from sourceURL: URL,
+        to destinationURL: URL
+    ) throws {
+        let sourceDescriptor = sourceURL.withUnsafeFileSystemRepresentation {
+            guard let fileSystemPath = $0 else {
+                return Int32(-1)
+            }
+            return Darwin.open(
+                fileSystemPath,
+                O_RDONLY | O_NOFOLLOW | O_CLOEXEC
+            )
+        }
+        guard sourceDescriptor >= 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Could not safely open the AI data archive."
+                ]
+            )
+        }
+
+        let sourceHandle = FileHandle(
+            fileDescriptor: sourceDescriptor,
+            closeOnDealloc: true
+        )
+        defer {
+            try? sourceHandle.close()
+        }
+
+        var fileStatus = stat()
+        guard Darwin.fstat(sourceDescriptor, &fileStatus) == 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Could not inspect the AI data archive."
+                ]
+            )
+        }
+        guard fileStatus.st_mode & S_IFMT == S_IFREG else {
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "The AI data archive is not a regular file."
+                ]
+            )
+        }
+
+        guard FileManager.default.createFile(
+            atPath: destinationURL.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: 6,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Could not stage the AI data archive."
+                ]
+            )
+        }
+
+        let destinationHandle = try FileHandle(forWritingTo: destinationURL)
+        defer {
+            try? destinationHandle.close()
+        }
+        while let chunk = try sourceHandle.read(upToCount: 1024 * 1024),
+              !chunk.isEmpty {
+            try destinationHandle.write(contentsOf: chunk)
+        }
+        try destinationHandle.synchronize()
+    }
+
+    private static func runZip(
+        arguments: [String],
+        currentDirectoryURL: URL
+    ) throws {
         let stderrPipe = Pipe()
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
-        process.arguments = ["-r", "-q", destinationZIP.path, phiFolderName]
-        process.currentDirectoryURL = parentURL
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectoryURL
         process.standardError = stderrPipe
         try process.run()
         process.waitUntilExit()
         guard process.terminationStatus == 0 else {
-            let errText = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let detail = errText.isEmpty ? "zip exited with status \(process.terminationStatus)." : errText
-            throw NSError(domain: "PhiUserDataBackup", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: detail])
+            let errText = String(
+                data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let detail = errText.isEmpty
+                ? "zip exited with status \(process.terminationStatus)."
+                : errText
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: detail]
+            )
+        }
+    }
+
+    private static func publishBackup(
+        from stagedZIP: URL,
+        to destinationZIP: URL
+    ) throws {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: stagedZIP.path) else {
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: 3,
+                userInfo: [
+                    NSLocalizedDescriptionKey: NSLocalizedString(
+                        "No backup archive was produced.",
+                        comment: "Manage User Data - Error when export produced no zip"
+                    )
+                ]
+            )
+        }
+
+        let temporaryDestination = destinationZIP
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                ".\(destinationZIP.lastPathComponent).\(UUID().uuidString).tmp"
+            )
+        defer {
+            try? fm.removeItem(at: temporaryDestination)
+        }
+
+        try fm.copyItem(at: stagedZIP, to: temporaryDestination)
+        if fm.fileExists(atPath: destinationZIP.path) {
+            _ = try fm.replaceItemAt(
+                destinationZIP,
+                withItemAt: temporaryDestination
+            )
+        } else {
+            try fm.moveItem(at: temporaryDestination, to: destinationZIP)
         }
     }
 

--- a/Sources/Application/SentinelBackupCoordination.swift
+++ b/Sources/Application/SentinelBackupCoordination.swift
@@ -1,0 +1,511 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+
+enum SentinelAIDataExport {
+    static let requestName = Notification.Name("com.phibrowser.sentinel.exportAIData.request")
+    static let responseName = Notification.Name("com.phibrowser.sentinel.exportAIData.response")
+
+    struct Response: Equatable {
+        enum Status: String {
+            case completed
+            case error
+        }
+
+        let status: Status
+        let path: String?
+        let error: String?
+    }
+
+    static func requestUserInfo(
+        requestID: String,
+        destinationPath: String
+    ) -> [String: String] {
+        [
+            "requestID": requestID,
+            "destinationPath": destinationPath
+        ]
+    }
+
+    static func parseResponse(_ info: [String: String]) -> Response? {
+        guard let rawStatus = info["status"],
+              let status = Response.Status(rawValue: rawStatus) else {
+            return nil
+        }
+        return Response(
+            status: status,
+            path: info["path"],
+            error: info["error"]
+        )
+    }
+}
+
+protocol SentinelNotificationSubscription: AnyObject {
+    func cancel()
+}
+
+protocol SentinelNotificationTransport {
+    func post(
+        name: Notification.Name,
+        object: String,
+        userInfo: [String: String]
+    )
+
+    func observe(
+        name: Notification.Name,
+        object: String,
+        handler: @escaping ([String: String]) -> Void
+    ) -> SentinelNotificationSubscription
+}
+
+final class DistributedSentinelNotificationTransport: SentinelNotificationTransport {
+    private final class Subscription: SentinelNotificationSubscription {
+        private let token: NSObjectProtocol
+
+        init(token: NSObjectProtocol) {
+            self.token = token
+        }
+
+        func cancel() {
+            DistributedNotificationCenter.default().removeObserver(token)
+        }
+    }
+
+    func post(
+        name: Notification.Name,
+        object: String,
+        userInfo: [String: String]
+    ) {
+        DistributedNotificationCenter.default().postNotificationName(
+            name,
+            object: object,
+            userInfo: userInfo,
+            deliverImmediately: true
+        )
+    }
+
+    func observe(
+        name: Notification.Name,
+        object: String,
+        handler: @escaping ([String: String]) -> Void
+    ) -> SentinelNotificationSubscription {
+        let token = DistributedNotificationCenter.default().addObserver(
+            forName: name,
+            object: object,
+            queue: nil
+        ) { notification in
+            var info: [String: String] = [:]
+            for (key, value) in notification.userInfo ?? [:] {
+                if let key = key as? String, let value = value as? String {
+                    info[key] = value
+                }
+            }
+            handler(info)
+        }
+        return Subscription(token: token)
+    }
+}
+
+enum SentinelCoordinationResult<Response> {
+    case response(Response)
+    case timedOut
+    case cancelled
+}
+
+final class SentinelBackupCoordinationClient {
+    private let transport: SentinelNotificationTransport
+    private let sentinelBundleID: String
+    private let browserBundleID: String
+    private let retryDelays: [TimeInterval]
+
+    init(
+        transport: SentinelNotificationTransport = DistributedSentinelNotificationTransport(),
+        sentinelBundleID: String = SentinelHelper.loginItemIdentifier(),
+        browserBundleID: String = Bundle.main.bundleIdentifier ?? "",
+        retryDelays: [TimeInterval] = [0, 0.5, 1, 2, 4, 8]
+    ) {
+        self.transport = transport
+        self.sentinelBundleID = sentinelBundleID
+        self.browserBundleID = browserBundleID
+        self.retryDelays = retryDelays
+    }
+
+    func requestExportAIData(
+        requestID: String,
+        destinationPath: String,
+        timeout: TimeInterval = 10 * 60
+    ) async -> SentinelCoordinationResult<SentinelAIDataExport.Response> {
+        let state = SendState<SentinelAIDataExport.Response>()
+        let payload = SentinelAIDataExport.requestUserInfo(
+            requestID: requestID,
+            destinationPath: destinationPath
+        ).merging(["browserBundleID": browserBundleID]) { current, _ in current }
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let subscription = transport.observe(
+                    name: SentinelAIDataExport.responseName,
+                    object: sentinelBundleID
+                ) { info in
+                    guard info["requestID"] == requestID,
+                          let response = SentinelAIDataExport.parseResponse(info) else {
+                        return
+                    }
+                    state.resolve(.response(response))
+                }
+                state.install(
+                    continuation: continuation,
+                    subscription: subscription
+                )
+
+                for delay in retryDelays {
+                    let retryTask = Task {
+                        if delay > 0 {
+                            try? await Task.sleep(
+                                nanoseconds: UInt64(delay * 1_000_000_000)
+                            )
+                        }
+                        state.performIfPending {
+                            transport.post(
+                                name: SentinelAIDataExport.requestName,
+                                object: sentinelBundleID,
+                                userInfo: payload
+                            )
+                        }
+                    }
+                    state.add(task: retryTask)
+                }
+
+                let timeoutTask = Task {
+                    try? await Task.sleep(
+                        nanoseconds: UInt64(max(0, timeout) * 1_000_000_000)
+                    )
+                    state.resolve(.timedOut)
+                }
+                state.add(task: timeoutTask)
+            }
+        } onCancel: {
+            state.resolve(.cancelled)
+        }
+    }
+}
+
+struct SentinelAIDataExportSession {
+    static let archiveFileName = "ai-data.tar.gz"
+    private static let sessionLifetime: TimeInterval = 24 * 60 * 60
+
+    let requestID: UUID
+    let directoryURL: URL
+    let archiveURL: URL
+
+    static func prepare(
+        sharedContainerURL: URL,
+        sentinelBundleID: String,
+        requestID: UUID,
+        now: Date = Date(),
+        fileManager: FileManager = .default
+    ) throws -> SentinelAIDataExportSession {
+        let scopeURL = sharedContainerURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Caches", isDirectory: true)
+            .appendingPathComponent("SentinelExports", isDirectory: true)
+            .appendingPathComponent(sentinelBundleID, isDirectory: true)
+
+        try fileManager.createDirectory(
+            at: scopeURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        removeExpiredSessions(
+            in: scopeURL,
+            olderThan: now.addingTimeInterval(-sessionLifetime),
+            fileManager: fileManager
+        )
+
+        let directoryURL = scopeURL.appendingPathComponent(
+            requestID.uuidString,
+            isDirectory: true
+        )
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return SentinelAIDataExportSession(
+            requestID: requestID,
+            directoryURL: directoryURL,
+            archiveURL: directoryURL.appendingPathComponent(
+                archiveFileName,
+                isDirectory: false
+            )
+        )
+    }
+
+    func cleanup(fileManager: FileManager = .default) {
+        try? fileManager.removeItem(at: directoryURL)
+    }
+
+    func scheduleCleanup(after delay: TimeInterval = 15 * 60) {
+        let directoryURL = directoryURL
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + max(0, delay)
+        ) {
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+    }
+
+    private static func removeExpiredSessions(
+        in scopeURL: URL,
+        olderThan expirationDate: Date,
+        fileManager: FileManager
+    ) {
+        let resourceKeys: Set<URLResourceKey> = [
+            .contentModificationDateKey,
+            .isDirectoryKey,
+            .isSymbolicLinkKey
+        ]
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: scopeURL,
+            includingPropertiesForKeys: Array(resourceKeys),
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        for child in children {
+            guard let values = try? child.resourceValues(forKeys: resourceKeys),
+                  values.isDirectory == true,
+                  values.isSymbolicLink != true,
+                  let modifiedAt = values.contentModificationDate,
+                  modifiedAt < expirationDate else {
+                continue
+            }
+            try? fileManager.removeItem(at: child)
+        }
+    }
+}
+
+@MainActor
+struct SentinelAIDataExportService {
+    func prepareSession() throws -> SentinelAIDataExportSession {
+        guard let sharedContainerURL = FileSystemUtils.sharedContainerURL() else {
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: 4,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "The shared App Group container is unavailable."
+                ]
+            )
+        }
+        return try SentinelAIDataExportSession.prepare(
+            sharedContainerURL: sharedContainerURL,
+            sentinelBundleID: SentinelHelper.loginItemIdentifier(),
+            requestID: UUID()
+        )
+    }
+
+    func coordinate(
+        session: SentinelAIDataExportSession,
+        isCancelled: @escaping () -> Bool
+    ) async -> AIDataExportCoordinator.Result {
+        let coordinator = AIDataExportCoordinator(
+            ensureSentinelRunning: {
+                if SentinelHelper.isRunning {
+                    return true
+                }
+                SentinelHelper.launch()
+                for _ in 0..<32 {
+                    if SentinelHelper.isRunning {
+                        return true
+                    }
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                }
+                return SentinelHelper.isRunning
+            },
+            requestExport: { requestID, destinationPath in
+                await SentinelBackupCoordinationClient().requestExportAIData(
+                    requestID: requestID,
+                    destinationPath: destinationPath
+                )
+            },
+            isRegularFile: { url in
+                guard let attributes = try? FileManager.default.attributesOfItem(
+                    atPath: url.path
+                ) else {
+                    return false
+                }
+                return attributes[.type] as? FileAttributeType == .typeRegular
+            },
+            isCancelled: isCancelled
+        )
+        return await coordinator.coordinate(
+            requestID: session.requestID.uuidString,
+            destinationTarURL: session.archiveURL
+        )
+    }
+}
+
+final class SentinelExportCancellation {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}
+
+struct AIDataExportCoordinator {
+    enum Result: Equatable {
+        case packed(tarURL: URL)
+        case skipped(reason: SkipReason)
+    }
+
+    enum SkipReason: Equatable {
+        case sentinelUnavailable
+        case timedOut
+        case exportFailed
+        case invalidResponsePath
+        case cancelled
+
+        var shouldRetainSessionForLateWrite: Bool {
+            switch self {
+            case .sentinelUnavailable, .exportFailed:
+                return false
+            case .timedOut, .invalidResponsePath, .cancelled:
+                return true
+            }
+        }
+    }
+
+    let ensureSentinelRunning: () async -> Bool
+    let requestExport: (
+        _ requestID: String,
+        _ destinationPath: String
+    ) async -> SentinelCoordinationResult<SentinelAIDataExport.Response>
+    let isRegularFile: (URL) -> Bool
+    let isCancelled: () -> Bool
+
+    func coordinate(
+        requestID: String,
+        destinationTarURL: URL
+    ) async -> Result {
+        if isCancelled() {
+            return .skipped(reason: .cancelled)
+        }
+        guard await ensureSentinelRunning() else {
+            return .skipped(reason: .sentinelUnavailable)
+        }
+        if isCancelled() {
+            return .skipped(reason: .cancelled)
+        }
+
+        switch await requestExport(requestID, destinationTarURL.path) {
+        case .timedOut:
+            return .skipped(reason: .timedOut)
+        case .cancelled:
+            return .skipped(reason: .cancelled)
+        case .response(let response):
+            guard !isCancelled() else {
+                return .skipped(reason: .cancelled)
+            }
+            switch response.status {
+            case .error:
+                return .skipped(reason: .exportFailed)
+            case .completed:
+                guard let responsePath = response.path else {
+                    return .skipped(reason: .exportFailed)
+                }
+                guard responsePath == destinationTarURL.path else {
+                    return .skipped(reason: .invalidResponsePath)
+                }
+                guard isRegularFile(destinationTarURL) else {
+                    return .skipped(reason: .exportFailed)
+                }
+                return .packed(tarURL: destinationTarURL)
+            }
+        }
+    }
+}
+
+private final class SendState<Response> {
+    typealias Result = SentinelCoordinationResult<Response>
+    typealias Continuation = CheckedContinuation<Result, Never>
+
+    private let lock = NSLock()
+    private var resolvedResult: Result?
+    private var continuation: Continuation?
+    private var subscription: SentinelNotificationSubscription?
+    private var tasks: [Task<Void, Never>] = []
+
+    func install(
+        continuation: Continuation,
+        subscription: SentinelNotificationSubscription
+    ) {
+        lock.lock()
+        if let resolvedResult {
+            lock.unlock()
+            subscription.cancel()
+            continuation.resume(returning: resolvedResult)
+            return
+        }
+        self.continuation = continuation
+        self.subscription = subscription
+        lock.unlock()
+    }
+
+    func add(task: Task<Void, Never>) {
+        lock.lock()
+        let shouldCancel = resolvedResult != nil
+        if !shouldCancel {
+            tasks.append(task)
+        }
+        lock.unlock()
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func performIfPending(_ body: () -> Void) {
+        lock.lock()
+        let shouldPerform = resolvedResult == nil
+        lock.unlock()
+        if shouldPerform {
+            body()
+        }
+    }
+
+    func resolve(_ result: Result) {
+        lock.lock()
+        guard resolvedResult == nil else {
+            lock.unlock()
+            return
+        }
+        resolvedResult = result
+        let continuation = continuation
+        self.continuation = nil
+        let subscription = subscription
+        self.subscription = nil
+        let tasks = tasks
+        self.tasks = []
+        lock.unlock()
+
+        subscription?.cancel()
+        for task in tasks {
+            task.cancel()
+        }
+        continuation?.resume(returning: result)
+    }
+}

--- a/Tests/PhiBrowserTests/PhiUserDataExportTests.swift
+++ b/Tests/PhiBrowserTests/PhiUserDataExportTests.swift
@@ -1,0 +1,237 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+import XCTest
+@testable import Phi
+
+final class PhiUserDataExportTests: XCTestCase {
+    func testSelectionRequiresAtLeastOneCategory() {
+        XCTAssertFalse(PhiUserDataExportSelection(
+            includeBrowserData: false,
+            includeAIData: false
+        ).isExportable)
+        XCTAssertTrue(PhiUserDataExportSelection(
+            includeBrowserData: true,
+            includeAIData: false
+        ).isExportable)
+        XCTAssertTrue(PhiUserDataExportSelection(
+            includeBrowserData: false,
+            includeAIData: true
+        ).isExportable)
+    }
+
+    func testSentinelExportSessionUsesScopedCanonicalPath() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let requestID = UUID()
+
+        let session = try SentinelAIDataExportSession.prepare(
+            sharedContainerURL: root,
+            sentinelBundleID: "com.phibrowser.canary.Sentinel",
+            requestID: requestID
+        )
+
+        XCTAssertEqual(session.requestID, requestID)
+        XCTAssertEqual(
+            session.archiveURL,
+            root
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Caches", isDirectory: true)
+                .appendingPathComponent("SentinelExports", isDirectory: true)
+                .appendingPathComponent("com.phibrowser.canary.Sentinel", isDirectory: true)
+                .appendingPathComponent(requestID.uuidString, isDirectory: true)
+                .appendingPathComponent("ai-data.tar.gz")
+        )
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: session.directoryURL.path,
+            isDirectory: &isDirectory
+        ))
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    func testLateWriteOutcomesRetainSessionForExpirationCleanup() {
+        XCTAssertTrue(
+            AIDataExportCoordinator.SkipReason.timedOut
+                .shouldRetainSessionForLateWrite
+        )
+        XCTAssertTrue(
+            AIDataExportCoordinator.SkipReason.invalidResponsePath
+                .shouldRetainSessionForLateWrite
+        )
+        XCTAssertTrue(
+            AIDataExportCoordinator.SkipReason.cancelled
+                .shouldRetainSessionForLateWrite
+        )
+        XCTAssertFalse(
+            AIDataExportCoordinator.SkipReason.sentinelUnavailable
+                .shouldRetainSessionForLateWrite
+        )
+        XCTAssertFalse(
+            AIDataExportCoordinator.SkipReason.exportFailed
+                .shouldRetainSessionForLateWrite
+        )
+    }
+
+    func testPreparingSessionRemovesExpiredSibling() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let expired = try SentinelAIDataExportSession.prepare(
+            sharedContainerURL: root,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            requestID: UUID(),
+            now: now
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-25 * 60 * 60)],
+            ofItemAtPath: expired.directoryURL.path
+        )
+
+        _ = try SentinelAIDataExportSession.prepare(
+            sharedContainerURL: root,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            requestID: UUID(),
+            now: now
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: expired.directoryURL.path
+        ))
+    }
+
+    func testAppendAIDataArchiveUsesCanonicalRootEntryName() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let source = root.appendingPathComponent("sentinel-export.tar.gz")
+        let destination = root.appendingPathComponent("backup.zip")
+        try Data("AI backup".utf8).write(to: source)
+
+        try AppController.appendAIDataArchive(source, to: destination)
+
+        XCTAssertEqual(
+            try zipEntries(in: destination),
+            ["ai-data.tar.gz"]
+        )
+    }
+
+    func testAppendAIDataArchivePreservesExistingBrowserRoot() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let phiDirectory = root.appendingPathComponent("Phi", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: phiDirectory,
+            withIntermediateDirectories: false
+        )
+        try Data("browser".utf8).write(
+            to: phiDirectory.appendingPathComponent("state.json")
+        )
+        let destination = root.appendingPathComponent("backup.zip")
+        try run(
+            executable: "/usr/bin/zip",
+            arguments: ["-r", "-q", destination.path, "Phi"],
+            currentDirectory: root
+        )
+
+        let aiArchive = root.appendingPathComponent("ai-data.tar.gz")
+        try Data("AI backup".utf8).write(to: aiArchive)
+        try AppController.appendAIDataArchive(aiArchive, to: destination)
+
+        XCTAssertEqual(
+            Set(try zipEntries(in: destination)),
+            Set(["Phi/", "Phi/state.json", "ai-data.tar.gz"])
+        )
+    }
+
+    func testAppendAIDataArchiveRejectsSymbolicLink() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let archiveTarget = root.appendingPathComponent("target.tar.gz")
+        let archiveLink = root.appendingPathComponent("ai-data.tar.gz")
+        let destination = root.appendingPathComponent("backup.zip")
+        try Data("not Sentinel output".utf8).write(to: archiveTarget)
+        try FileManager.default.createSymbolicLink(
+            at: archiveLink,
+            withDestinationURL: archiveTarget
+        )
+
+        XCTAssertThrowsError(
+            try AppController.appendAIDataArchive(
+                archiveLink,
+                to: destination
+            )
+        )
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: destination.path
+        ))
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "PhiUserDataExportTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try! FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: false
+        )
+        return url
+    }
+
+    private func zipEntries(in archive: URL) throws -> [String] {
+        let output = try run(
+            executable: "/usr/bin/unzip",
+            arguments: ["-Z1", archive.path]
+        )
+        return output
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+    }
+
+    @discardableResult
+    private func run(
+        executable: String,
+        arguments: [String],
+        currentDirectory: URL? = nil
+    ) throws -> String {
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectory
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            throw NSError(
+                domain: "PhiUserDataExportTests",
+                code: Int(process.terminationStatus),
+                userInfo: [
+                    NSLocalizedDescriptionKey: String(
+                        data: errorData,
+                        encoding: .utf8
+                    ) ?? "Command failed"
+                ]
+            )
+        }
+        return String(data: outputData, encoding: .utf8) ?? ""
+    }
+}

--- a/Tests/PhiBrowserTests/SentinelBackupCoordinationTests.swift
+++ b/Tests/PhiBrowserTests/SentinelBackupCoordinationTests.swift
@@ -1,0 +1,432 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import XCTest
+@testable import Phi
+
+final class SentinelBackupCoordinationTests: XCTestCase {
+    func testExportContractNamesAndPayload() {
+        XCTAssertEqual(
+            SentinelAIDataExport.requestName.rawValue,
+            "com.phibrowser.sentinel.exportAIData.request"
+        )
+        XCTAssertEqual(
+            SentinelAIDataExport.responseName.rawValue,
+            "com.phibrowser.sentinel.exportAIData.response"
+        )
+
+        XCTAssertEqual(
+            SentinelAIDataExport.requestUserInfo(
+                requestID: "request-1",
+                destinationPath: "/tmp/ai-data.tar.gz"
+            ),
+            [
+                "requestID": "request-1",
+                "destinationPath": "/tmp/ai-data.tar.gz"
+            ]
+        )
+
+        XCTAssertEqual(
+            SentinelAIDataExport.parseResponse([
+                "status": "completed",
+                "path": "/tmp/ai-data.tar.gz"
+            ]),
+            .init(
+                status: .completed,
+                path: "/tmp/ai-data.tar.gz",
+                error: nil
+            )
+        )
+        XCTAssertNil(SentinelAIDataExport.parseResponse(["status": "unknown"]))
+    }
+
+    func testClientRoutesRequestAndInjectsBrowserBundleID() async {
+        let transport = TestSentinelNotificationTransport()
+        transport.onPost = { posted in
+            transport.deliver(
+                name: SentinelAIDataExport.responseName,
+                object: posted.object,
+                userInfo: [
+                    "requestID": posted.userInfo["requestID"] ?? "",
+                    "status": "completed",
+                    "path": posted.userInfo["destinationPath"] ?? ""
+                ]
+            )
+        }
+        let client = SentinelBackupCoordinationClient(
+            transport: transport,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            retryDelays: [0]
+        )
+
+        let result = await client.requestExportAIData(
+            requestID: "request-1",
+            destinationPath: "/tmp/ai-data.tar.gz",
+            timeout: 1
+        )
+
+        guard case .response(let response) = result else {
+            return XCTFail("Expected completed response")
+        }
+        XCTAssertEqual(response.status, .completed)
+        XCTAssertEqual(transport.posts.count, 1)
+        XCTAssertEqual(
+            transport.posts.first?.userInfo["browserBundleID"],
+            "com.phibrowser.Mac"
+        )
+        XCTAssertEqual(
+            transport.observedObjects,
+            ["com.phibrowser.Sentinel"]
+        )
+        XCTAssertEqual(transport.activeSubscriptionCount, 0)
+    }
+
+    func testClientIgnoresMismatchedRequestID() async {
+        let transport = TestSentinelNotificationTransport()
+        transport.onPost = { posted in
+            transport.deliver(
+                name: SentinelAIDataExport.responseName,
+                object: posted.object,
+                userInfo: [
+                    "requestID": "another-request",
+                    "status": "completed",
+                    "path": "/tmp/ai-data.tar.gz"
+                ]
+            )
+        }
+        let client = SentinelBackupCoordinationClient(
+            transport: transport,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            retryDelays: [0]
+        )
+
+        let result = await client.requestExportAIData(
+            requestID: "request-1",
+            destinationPath: "/tmp/ai-data.tar.gz",
+            timeout: 0.01
+        )
+
+        guard case .timedOut = result else {
+            return XCTFail("Expected timeout")
+        }
+        XCTAssertEqual(transport.activeSubscriptionCount, 0)
+    }
+
+    func testClientRetriesUntilSentinelResponds() async {
+        let transport = TestSentinelNotificationTransport()
+        transport.onPost = { posted in
+            guard transport.posts.count == 3 else {
+                return
+            }
+            transport.deliver(
+                name: SentinelAIDataExport.responseName,
+                object: posted.object,
+                userInfo: [
+                    "requestID": posted.userInfo["requestID"] ?? "",
+                    "status": "completed",
+                    "path": posted.userInfo["destinationPath"] ?? ""
+                ]
+            )
+        }
+        let client = SentinelBackupCoordinationClient(
+            transport: transport,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            retryDelays: [0, 0.01, 0.02]
+        )
+
+        let result = await client.requestExportAIData(
+            requestID: "request-1",
+            destinationPath: "/tmp/ai-data.tar.gz",
+            timeout: 1
+        )
+
+        guard case .response(let response) = result else {
+            return XCTFail("Expected completed response after retries")
+        }
+        XCTAssertEqual(response.status, .completed)
+        XCTAssertEqual(transport.posts.count, 3)
+        XCTAssertEqual(transport.activeSubscriptionCount, 0)
+    }
+
+    func testClientCancellationStopsWaitingAndRetries() async {
+        let transport = TestSentinelNotificationTransport()
+        let client = SentinelBackupCoordinationClient(
+            transport: transport,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            retryDelays: [0, 1]
+        )
+
+        let requestTask = Task {
+            await client.requestExportAIData(
+                requestID: "request-1",
+                destinationPath: "/tmp/ai-data.tar.gz",
+                timeout: 60
+            )
+        }
+        for _ in 0..<100 where transport.posts.isEmpty {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(transport.posts.count, 1)
+        XCTAssertEqual(transport.activeSubscriptionCount, 1)
+
+        requestTask.cancel()
+        let result = await requestTask.value
+        guard case .cancelled = result else {
+            return XCTFail("Expected cancellation")
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(transport.posts.count, 1)
+        XCTAssertEqual(transport.activeSubscriptionCount, 0)
+    }
+}
+
+final class AIDataExportCoordinatorTests: XCTestCase {
+    func testUnavailableSentinelSkipsExport() async {
+        let coordinator = makeCoordinator(
+            ensureSentinelRunning: { false },
+            response: .timedOut,
+            isRegularFile: { _ in true }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .sentinelUnavailable))
+    }
+
+    func testCompletedExportRequiresExactExpectedPath() async {
+        let coordinator = makeCoordinator(
+            response: .response(.init(
+                status: .completed,
+                path: "/tmp/unexpected.tar.gz",
+                error: nil
+            )),
+            isRegularFile: { _ in true }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .invalidResponsePath))
+    }
+
+    func testCompletedExportRejectsNormalizedEquivalentPath() async {
+        let coordinator = makeCoordinator(
+            response: .response(.init(
+                status: .completed,
+                path: "/tmp/subdirectory/../ai-data.tar.gz",
+                error: nil
+            )),
+            isRegularFile: { _ in true }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .invalidResponsePath))
+    }
+
+    func testCompletedExportRequiresRegularFile() async {
+        let coordinator = makeCoordinator(
+            response: .response(.init(
+                status: .completed,
+                path: "/tmp/ai-data.tar.gz",
+                error: nil
+            )),
+            isRegularFile: { _ in false }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .exportFailed))
+    }
+
+    func testCompletedExportReturnsExpectedArchive() async {
+        let expectedURL = URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        let coordinator = makeCoordinator(
+            response: .response(.init(
+                status: .completed,
+                path: expectedURL.path,
+                error: nil
+            )),
+            isRegularFile: { $0 == expectedURL }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: expectedURL
+        )
+
+        XCTAssertEqual(result, .packed(tarURL: expectedURL))
+    }
+
+    func testCancelledRequestSkipsExport() async {
+        let coordinator = makeCoordinator(
+            response: .cancelled,
+            isRegularFile: { _ in true }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .cancelled))
+    }
+
+    private func makeCoordinator(
+        ensureSentinelRunning: @escaping () async -> Bool = { true },
+        response: SentinelCoordinationResult<SentinelAIDataExport.Response>,
+        isRegularFile: @escaping (URL) -> Bool
+    ) -> AIDataExportCoordinator {
+        AIDataExportCoordinator(
+            ensureSentinelRunning: ensureSentinelRunning,
+            requestExport: { _, _ in response },
+            isRegularFile: isRegularFile,
+            isCancelled: { false }
+        )
+    }
+}
+
+private final class TestSentinelNotificationTransport:
+    SentinelNotificationTransport
+{
+    struct Posted {
+        let name: Notification.Name
+        let object: String
+        let userInfo: [String: String]
+    }
+
+    private final class Registration {
+        let name: Notification.Name
+        let object: String
+        let handler: ([String: String]) -> Void
+        var isCancelled = false
+
+        init(
+            name: Notification.Name,
+            object: String,
+            handler: @escaping ([String: String]) -> Void
+        ) {
+            self.name = name
+            self.object = object
+            self.handler = handler
+        }
+    }
+
+    private final class Subscription: SentinelNotificationSubscription {
+        private let onCancel: () -> Void
+
+        init(onCancel: @escaping () -> Void) {
+            self.onCancel = onCancel
+        }
+
+        func cancel() {
+            onCancel()
+        }
+    }
+
+    private let lock = NSLock()
+    private var storedPosts: [Posted] = []
+    private var storedObservedObjects: [String] = []
+    private var registrations: [Registration] = []
+    var onPost: ((Posted) -> Void)?
+
+    var posts: [Posted] {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return storedPosts
+    }
+
+    var observedObjects: [String] {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return storedObservedObjects
+    }
+
+    var activeSubscriptionCount: Int {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return registrations.filter { !$0.isCancelled }.count
+    }
+
+    func post(
+        name: Notification.Name,
+        object: String,
+        userInfo: [String: String]
+    ) {
+        let posted = Posted(
+            name: name,
+            object: object,
+            userInfo: userInfo
+        )
+        lock.lock()
+        storedPosts.append(posted)
+        let onPost = onPost
+        lock.unlock()
+        onPost?(posted)
+    }
+
+    func observe(
+        name: Notification.Name,
+        object: String,
+        handler: @escaping ([String: String]) -> Void
+    ) -> SentinelNotificationSubscription {
+        let registration = Registration(
+            name: name,
+            object: object,
+            handler: handler
+        )
+        lock.lock()
+        registrations.append(registration)
+        storedObservedObjects.append(object)
+        lock.unlock()
+        return Subscription {
+            self.lock.lock()
+            registration.isCancelled = true
+            self.lock.unlock()
+        }
+    }
+
+    func deliver(
+        name: Notification.Name,
+        object: String,
+        userInfo: [String: String]
+    ) {
+        lock.lock()
+        let handlers: [([String: String]) -> Void] =
+            registrations.compactMap { registration in
+                guard !registration.isCancelled,
+                      registration.name == name,
+                      registration.object == object else {
+                    return nil
+                }
+                return registration.handler
+            }
+        lock.unlock()
+        for handler in handlers {
+            handler(userInfo)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- coordinate Sentinel AI data export as part of browser user-data backups
- add export request/response handling and failure reporting
- add focused tests for backup coordination and exported user data

## Verification

- Canary build succeeded
- 12 selected tests passed