### PR TITLE
Merge account deletion credential fencing into dev

### DIFF
--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3703C9822F69558C00E7CF6D /* BrowserState+ToggleAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9812F69558C00E7CF6D /* BrowserState+ToggleAI.swift */; };
 		3703C9842F6956E600E7CF6D /* SentinelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9832F6956E600E7CF6D /* SentinelHelper.swift */; };
 		3703C9862F6956E600E7CF6D /* SentinelVersionGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */; };
+		F9E478A224C44EA7BC0D85CC /* AccountDeletedEventAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */; };
 		370D03AC2F0E463B0087A1C9 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D03A32F0E463B0087A1C9 /* Mapper.swift */; };
 		370D03AD2F0E463B0087A1C9 /* ThemedColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D03A82F0E463B0087A1C9 /* ThemedColor.swift */; };
 		370D03AE2F0E463B0087A1C9 /* Key.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D03A22F0E463B0087A1C9 /* Key.swift */; };
@@ -573,6 +574,7 @@
 		3703C9812F69558C00E7CF6D /* BrowserState+ToggleAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserState+ToggleAI.swift"; sourceTree = "<group>"; };
 		3703C9832F6956E600E7CF6D /* SentinelHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelHelper.swift; sourceTree = "<group>"; };
 		3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelVersionGuard.swift; sourceTree = "<group>"; };
+		19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletedEventAuthentication.swift; sourceTree = "<group>"; };
 		370D039F2F0E463B0087A1C9 /* Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 		370D03A02F0E463B0087A1C9 /* Bags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bags.swift; sourceTree = "<group>"; };
 		370D03A12F0E463B0087A1C9 /* ColorRole.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorRole.swift; sourceTree = "<group>"; };
@@ -1863,6 +1865,7 @@
 				8EB01BEA3010BCED0043E59D /* UserDataRemoval.swift */,
 				CC9AF3432EC192BC00C27C98 /* AppControlle+LaunchInfo.swift */,
 				CCBF0F9F2ECEC1AE005E729B /* AppController+Deeplink.swift */,
+				19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */,
 				3703C9832F6956E600E7CF6D /* SentinelHelper.swift */,
 				3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */,
 				6A44C5FF60DF6F7860A061D4 /* SentinelWatchdog.swift */,
@@ -2591,6 +2594,7 @@
 				CCB53DCE2E6EC437004BF233 /* OmniBoxModels.swift in Sources */,
 				37C1B28F2EE1364D00DD4496 /* EnvironmentChecker.swift in Sources */,
 				37C1B28A2EE0457F00DD4496 /* LivingDownloadsListView.swift in Sources */,
+				F9E478A224C44EA7BC0D85CC /* AccountDeletedEventAuthentication.swift in Sources */,
 				3703C9842F6956E600E7CF6D /* SentinelHelper.swift in Sources */,
 				3703C9862F6956E600E7CF6D /* SentinelVersionGuard.swift in Sources */,
 				793C1DDEA1022CC850FEFFF9 /* SentinelWatchdog.swift in Sources */,

--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		3703C9822F69558C00E7CF6D /* BrowserState+ToggleAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9812F69558C00E7CF6D /* BrowserState+ToggleAI.swift */; };
 		3703C9842F6956E600E7CF6D /* SentinelHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9832F6956E600E7CF6D /* SentinelHelper.swift */; };
 		3703C9862F6956E600E7CF6D /* SentinelVersionGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */; };
+		3AC6117E11925E637EB4711A /* SentinelBackupCoordination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E8BEE1510290AB35D5C5AD /* SentinelBackupCoordination.swift */; };
 		F9E478A224C44EA7BC0D85CC /* AccountDeletedEventAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */; };
 		370D03AC2F0E463B0087A1C9 /* Mapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D03A32F0E463B0087A1C9 /* Mapper.swift */; };
 		370D03AD2F0E463B0087A1C9 /* ThemedColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 370D03A82F0E463B0087A1C9 /* ThemedColor.swift */; };
@@ -574,6 +575,7 @@
 		3703C9812F69558C00E7CF6D /* BrowserState+ToggleAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BrowserState+ToggleAI.swift"; sourceTree = "<group>"; };
 		3703C9832F6956E600E7CF6D /* SentinelHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelHelper.swift; sourceTree = "<group>"; };
 		3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelVersionGuard.swift; sourceTree = "<group>"; };
+		11E8BEE1510290AB35D5C5AD /* SentinelBackupCoordination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentinelBackupCoordination.swift; sourceTree = "<group>"; };
 		19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountDeletedEventAuthentication.swift; sourceTree = "<group>"; };
 		370D039F2F0E463B0087A1C9 /* Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 		370D03A02F0E463B0087A1C9 /* Bags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bags.swift; sourceTree = "<group>"; };
@@ -1868,6 +1870,7 @@
 				19B477B37CF44BC48335A032 /* AccountDeletedEventAuthentication.swift */,
 				3703C9832F6956E600E7CF6D /* SentinelHelper.swift */,
 				3703C9852F6956E600E7CF6D /* SentinelVersionGuard.swift */,
+				11E8BEE1510290AB35D5C5AD /* SentinelBackupCoordination.swift */,
 				6A44C5FF60DF6F7860A061D4 /* SentinelWatchdog.swift */,
 				37CC00012F9D000100000001 /* SentinelIPCClient.swift */,
 				54A100202FE0000000000020 /* TimeMachine */,
@@ -2597,6 +2600,7 @@
 				F9E478A224C44EA7BC0D85CC /* AccountDeletedEventAuthentication.swift in Sources */,
 				3703C9842F6956E600E7CF6D /* SentinelHelper.swift in Sources */,
 				3703C9862F6956E600E7CF6D /* SentinelVersionGuard.swift in Sources */,
+				3AC6117E11925E637EB4711A /* SentinelBackupCoordination.swift in Sources */,
 				793C1DDEA1022CC850FEFFF9 /* SentinelWatchdog.swift in Sources */,
 				37CC00022F9D000100000001 /* SentinelIPCClient.swift in Sources */,
 				CCB53DCF2E6EC437004BF233 /* OmniBoxTextField.swift in Sources */,

--- a/Sources/Application/AccountDeletedEventAuthentication.swift
+++ b/Sources/Application/AccountDeletedEventAuthentication.swift
@@ -1,0 +1,188 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import CryptoKit
+import Foundation
+import Security
+
+struct AccountDeletedSignedContent: Codable, Equatable {
+    let signatureVersion: String
+    let notificationName: String
+    let sentinelBundleID: String
+    let browserBundleID: String
+    let requestID: String
+    let auth0Sub: String
+    let issuedAt: String
+}
+
+enum SentinelAccountDeletedEventError: Error, Equatable, CustomStringConvertible {
+    case missingField(String)
+    case signingKeyUnavailable
+    case invalidIssuedAt
+    case signingFailed
+
+    var description: String {
+        switch self {
+        case .missingField(let field): return "missing field \(field)"
+        case .signingKeyUnavailable: return "signing key unavailable"
+        case .invalidIssuedAt: return "invalid issuedAt"
+        case .signingFailed: return "signing failed"
+        }
+    }
+}
+
+enum AccountDeletedEventAuthentication {
+    static let signatureVersion = "1"
+    static let keyByteCount = 32
+
+    static func signature(
+        for content: AccountDeletedSignedContent,
+        key: Data
+    ) throws -> String {
+        guard key.count == keyByteCount else {
+            throw SentinelAccountDeletedEventError.signingKeyUnavailable
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let message = try encoder.encode(content)
+        let authenticationCode = HMAC<SHA256>.authenticationCode(
+            for: message,
+            using: SymmetricKey(data: key)
+        )
+        return Data(authenticationCode).base64EncodedString()
+    }
+}
+
+final class AccountDeletedSigningKeyStore {
+    static let shared = AccountDeletedSigningKeyStore()
+
+    static let service = "com.phibrowser.sentinel.account-deleted-auth"
+    static let account = "hmac-v1"
+
+    private enum ReadResult {
+        case found(Data)
+        case notFound
+        case failed
+    }
+
+    private let appGroupAccessGroup = "group.com.phibrowser.shared"
+
+    private init() {}
+
+    func readOrCreate() -> Data? {
+        guard let accessGroup = resolvedAccessGroup() else {
+            return nil
+        }
+
+        switch read(accessGroup: accessGroup) {
+        case .found(let key):
+            return key
+        case .notFound:
+            return create(accessGroup: accessGroup)
+        case .failed:
+            return nil
+        }
+    }
+
+    private func read(accessGroup: String) -> ReadResult {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: Self.account,
+            kSecAttrAccessGroup as String: accessGroup,
+            kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        let status = runKeychainOperationWithRetry {
+            item = nil
+            return SecItemCopyMatching(query as CFDictionary, &item)
+        }
+        if status == errSecItemNotFound {
+            return .notFound
+        }
+        guard status == errSecSuccess,
+              let key = item as? Data,
+              key.count == AccountDeletedEventAuthentication.keyByteCount else {
+            return .failed
+        }
+        return .found(key)
+    }
+
+    private func create(accessGroup: String) -> Data? {
+        var key = Data(count: AccountDeletedEventAuthentication.keyByteCount)
+        let randomStatus = key.withUnsafeMutableBytes { buffer in
+            SecRandomCopyBytes(
+                kSecRandomDefault,
+                AccountDeletedEventAuthentication.keyByteCount,
+                buffer.baseAddress!
+            )
+        }
+        guard randomStatus == errSecSuccess else {
+            return nil
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Self.service,
+            kSecAttrAccount as String: Self.account,
+            kSecAttrAccessGroup as String: accessGroup,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+            kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+            kSecUseDataProtectionKeychain as String: true,
+            kSecValueData as String: key
+        ]
+        let status = runKeychainOperationWithRetry(
+            terminalStatuses: [errSecSuccess, errSecItemNotFound, errSecDuplicateItem]
+        ) {
+            SecItemAdd(query as CFDictionary, nil)
+        }
+        if status == errSecSuccess {
+            return key
+        }
+        if status == errSecDuplicateItem,
+           case .found(let existingKey) = read(accessGroup: accessGroup) {
+            return existingKey
+        }
+        return nil
+    }
+
+    private func resolvedAccessGroup() -> String? {
+        let groups = entitlementValues(for: "com.apple.security.application-groups")
+        return groups.contains(appGroupAccessGroup) ? appGroupAccessGroup : nil
+    }
+
+    private func entitlementValues(for key: String) -> [String] {
+        guard let task = SecTaskCreateFromSelf(nil),
+              let rawValue = SecTaskCopyValueForEntitlement(
+                task,
+                key as CFString,
+                nil
+              ) else {
+            return []
+        }
+        if let values = rawValue as? [String] {
+            return values
+        }
+        if let value = rawValue as? String {
+            return [value]
+        }
+        return []
+    }
+
+    private func runKeychainOperationWithRetry(
+        terminalStatuses: Set<OSStatus> = [errSecSuccess, errSecItemNotFound],
+        operation: () -> OSStatus
+    ) -> OSStatus {
+        let first = operation()
+        guard !terminalStatuses.contains(first) else {
+            return first
+        }
+        Thread.sleep(forTimeInterval: 0.15)
+        return operation()
+    }
+}

--- a/Sources/Application/AccountDeletionLocalDataRemoval.swift
+++ b/Sources/Application/AccountDeletionLocalDataRemoval.swift
@@ -20,10 +20,12 @@ import WebKit
 ///    confirmation, so a crash anywhere later in the finalize leaves a
 ///    marked, startup-recoverable removal instead of untouched data —
 ///    without this ordering the unprotected window would span the website
-///    data sweep's 10-second ceiling. What a late crash can still leave
-///    behind — website data and credentials — are both accepted residue
-///    directions (the sweep-timeout residue below, and the credential
-///    layer's 401 forced sign-out on the next launch).
+///    data sweep's 10-second ceiling. Credentials are handled separately:
+///    the finalize clears them before entering this removal and leaves a
+///    durable startup fence active across relaunches. Automatic restoration
+///    remains blocked until an explicit new login takes the shared-token
+///    lock, clears both stores again, and releases the fence. Website-data
+///    sweep timeout remains the only accepted residue direction here.
 /// 2. WKWebView website data (`~/Library/WebKit/<bundleId>`): the account
 ///    web windows keep their signed-in sessions there, outside the data
 ///    roots above. Cleared in-process before the quit, with the same

--- a/Sources/Application/AppController+UserDataBackup.swift
+++ b/Sources/Application/AppController+UserDataBackup.swift
@@ -4,9 +4,32 @@
 // found in the LICENSE file.
 
 import AppKit
+import Darwin
 import Foundation
 import SwiftData
 import UniformTypeIdentifiers
+
+struct PhiUserDataExportSelection: Equatable {
+    var includeBrowserData: Bool
+    var includeAIData: Bool
+
+    var isExportable: Bool {
+        includeBrowserData || includeAIData
+    }
+}
+
+@MainActor
+private final class PhiUserDataExportSelectionBox {
+    var selection: PhiUserDataExportSelection
+    var readState: (() -> PhiUserDataExportSelection)?
+
+    init(browserDataAvailable: Bool) {
+        selection = PhiUserDataExportSelection(
+            includeBrowserData: browserDataAvailable,
+            includeAIData: true
+        )
+    }
+}
 
 extension AppController {
     private enum PhiUserDataBackupPromptResult {
@@ -139,7 +162,7 @@ extension AppController {
     private func promptBackupBeforeClearingPhiUserData() -> PhiUserDataBackupPromptResult {
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("Back Up User Data First?", comment: "Debug clear data - Alert title asking whether to export Phi user data before clearing")
-        alert.informativeText = NSLocalizedString("You can save a zip of your Phi user data folder before local files are removed and the app quits.", comment: "Debug clear data - Alert body explaining optional zip backup before clearing user data")
+        alert.informativeText = NSLocalizedString("You can save a zip of your browser and AI data before local files are removed and the app quits.", comment: "Debug clear data - Alert body explaining optional zip backup before clearing user data")
         alert.alertStyle = .informational
         alert.addButton(withTitle: NSLocalizedString("Backup...", comment: "Debug clear data - Alert button to open the save panel for a Phi user data zip"))
         alert.addButton(withTitle: NSLocalizedString("Skip Backup", comment: "Debug clear data - Alert button to clear data without creating a backup zip"))
@@ -155,19 +178,64 @@ extension AppController {
     }
 
     @MainActor
+    private func makeExportAccessoryView(
+        box: PhiUserDataExportSelectionBox,
+        browserDataAvailable: Bool
+    ) -> NSView {
+        let browserCheckbox = NSButton(
+            checkboxWithTitle: NSLocalizedString(
+                "Browser data",
+                comment: "Manage User Data - Export category checkbox for Phi browser data"
+            ),
+            target: nil,
+            action: nil
+        )
+        browserCheckbox.state = box.selection.includeBrowserData ? .on : .off
+        browserCheckbox.isEnabled = browserDataAvailable
+
+        let aiCheckbox = NSButton(
+            checkboxWithTitle: NSLocalizedString(
+                "AI data",
+                comment: "Manage User Data - Export category checkbox for Sentinel AI data"
+            ),
+            target: nil,
+            action: nil
+        )
+        aiCheckbox.state = box.selection.includeAIData ? .on : .off
+
+        box.readState = {
+            PhiUserDataExportSelection(
+                includeBrowserData: browserCheckbox.state == .on,
+                includeAIData: aiCheckbox.state == .on
+            )
+        }
+
+        let stack = NSStackView(views: [browserCheckbox, aiCheckbox])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 320, height: 64))
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 12),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: container.trailingAnchor, constant: -12),
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 8),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -8)
+        ])
+        return container
+    }
+
+    @MainActor
     private func performPhiUserDataBackupExport() -> Bool {
         let fm = FileManager.default
-        let phiPath = FileSystemUtils.phiBrowserDataDirectory()
-
-        if !fm.fileExists(atPath: phiPath) {
-            let alert = NSAlert()
-            alert.messageText = NSLocalizedString("No Phi User Data to Back Up", comment: "Debug clear data - Alert title when the Phi data folder is missing before backup")
-            alert.informativeText = NSLocalizedString("The Phi user data folder was not found. Continuing will still remove other local application data and quit.", comment: "Debug clear data - Alert body when Phi folder is missing; clearing will still proceed for other locations")
-            alert.alertStyle = .informational
-            alert.addButton(withTitle: NSLocalizedString("OK", comment: "Generic - OK button to dismiss an alert"))
-            alert.runModal()
-            return true
-        }
+        let browserDataAvailable = Self.isDirectory(
+            at: URL(
+                fileURLWithPath: FileSystemUtils.phiBrowserDataDirectory(),
+                isDirectory: true
+            )
+        )
 
         let panel = NSSavePanel()
         panel.canCreateDirectories = true
@@ -176,13 +244,102 @@ extension AppController {
         panel.title = NSLocalizedString("Back Up Phi User Data", comment: "Debug clear data - NSSavePanel title for saving Phi user data directory as zip")
         panel.prompt = NSLocalizedString("Save", comment: "Debug clear data - NSSavePanel confirm button title when saving Phi user data backup zip")
 
+        let selectionBox = PhiUserDataExportSelectionBox(
+            browserDataAvailable: browserDataAvailable
+        )
+        panel.accessoryView = makeExportAccessoryView(
+            box: selectionBox,
+            browserDataAvailable: browserDataAvailable
+        )
+
         guard panel.runModal() == .OK, let destinationZIP = panel.url else {
             return false
         }
 
+        let selection = selectionBox.readState?() ?? selectionBox.selection
+        guard selection.isExportable else {
+            let alert = NSAlert()
+            alert.messageText = NSLocalizedString(
+                "Select at least one category to back up.",
+                comment: "Manage User Data - Alert when the user unchecks both export categories"
+            )
+            alert.alertStyle = .informational
+            alert.addButton(withTitle: NSLocalizedString("OK", comment: "Generic - OK button to dismiss an alert"))
+            alert.runModal()
+            return false
+        }
+
+        let stagingDirectory = fm.temporaryDirectory.appendingPathComponent(
+            "PhiDataExport-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let stagedZIP = stagingDirectory.appendingPathComponent(
+            "Phi-data.zip",
+            isDirectory: false
+        )
+
         do {
-            syncCurrentChromiumProfileDisplayNamesToLocalStore()
-            try zipPhiBrowserDataDirectory(to: destinationZIP)
+            try fm.createDirectory(
+                at: stagingDirectory,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: 0o700]
+            )
+            defer {
+                try? fm.removeItem(at: stagingDirectory)
+            }
+
+            if selection.includeBrowserData {
+                guard browserDataAvailable else {
+                    throw NSError(
+                        domain: "PhiUserDataBackup",
+                        code: 2,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: NSLocalizedString(
+                                "The Phi browser data folder is no longer available.",
+                                comment: "Manage User Data - Error when browser data disappears before backup starts"
+                            )
+                        ]
+                    )
+                }
+                syncCurrentChromiumProfileDisplayNamesToLocalStore()
+                try zipPhiBrowserDataDirectory(to: stagedZIP)
+            }
+
+            if selection.includeAIData {
+                let aiResult = coordinateAIDataExport()
+                switch aiResult.result {
+                case .packed(let tarURL):
+                    do {
+                        try Self.appendAIDataArchive(tarURL, to: stagedZIP)
+                        aiResult.session?.cleanup()
+                    } catch {
+                        aiResult.session?.cleanup()
+                        AppLogWarn("[Manage User Data] Failed to add AI data to backup: \(error.localizedDescription)")
+                        warnAIDataDegraded(
+                            reason: .exportFailed,
+                            browserDataIncluded: selection.includeBrowserData
+                        )
+                        guard selection.includeBrowserData else {
+                            return false
+                        }
+                    }
+                case .skipped(let reason):
+                    if reason.shouldRetainSessionForLateWrite {
+                        aiResult.session?.scheduleCleanup()
+                    } else {
+                        aiResult.session?.cleanup()
+                    }
+                    warnAIDataDegraded(
+                        reason: reason,
+                        browserDataIncluded: selection.includeBrowserData
+                    )
+                    guard selection.includeBrowserData else {
+                        return false
+                    }
+                }
+            }
+
+            try Self.publishBackup(from: stagedZIP, to: destinationZIP)
             AppLogInfo("[Debug] Phi user data backup saved to \(destinationZIP.path)")
             return true
         } catch {
@@ -195,6 +352,114 @@ extension AppController {
             errorAlert.runModal()
             return false
         }
+    }
+
+    @MainActor
+    private func coordinateAIDataExport() -> (
+        result: AIDataExportCoordinator.Result,
+        session: SentinelAIDataExportSession?
+    ) {
+        let service = SentinelAIDataExportService()
+        let session: SentinelAIDataExportSession
+        do {
+            session = try service.prepareSession()
+        } catch {
+            AppLogWarn("[Manage User Data] Cannot prepare AI data export: \(error.localizedDescription)")
+            return (.skipped(reason: .exportFailed), nil)
+        }
+
+        let cancellation = SentinelExportCancellation()
+        let result = presentAIDataExportProgress(cancelBox: cancellation) {
+            await service.coordinate(
+                session: session,
+                isCancelled: {
+                    cancellation.isCancelled
+                }
+            )
+        }
+        return (result, session)
+    }
+
+    @MainActor
+    private func presentAIDataExportProgress(
+        cancelBox: SentinelExportCancellation,
+        _ work: @escaping () async -> AIDataExportCoordinator.Result
+    ) -> AIDataExportCoordinator.Result {
+        let alert = NSAlert()
+        alert.messageText = NSLocalizedString(
+            "Backing Up AI Data",
+            comment: "Manage User Data - Progress title while Sentinel exports AI data"
+        )
+        alert.addButton(withTitle: NSLocalizedString(
+            "Cancel",
+            comment: "Manage User Data - Cancel button on the AI data backup progress modal"
+        ))
+
+        let progress = NSProgressIndicator(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 20)
+        )
+        progress.style = .bar
+        progress.isIndeterminate = true
+        progress.startAnimation(nil)
+        alert.accessoryView = progress
+
+        var workResult: AIDataExportCoordinator.Result?
+        let task = Task { @MainActor in
+            let result = await work()
+            guard !Task.isCancelled else {
+                return
+            }
+            workResult = result
+            NSApp.stopModal()
+        }
+
+        let response = alert.runModal()
+        if response == .stop, let workResult {
+            return workResult
+        }
+
+        cancelBox.cancel()
+        task.cancel()
+        return .skipped(reason: .cancelled)
+    }
+
+    @MainActor
+    private func warnAIDataDegraded(
+        reason: AIDataExportCoordinator.SkipReason,
+        browserDataIncluded: Bool
+    ) {
+        let detail: String
+        switch (browserDataIncluded, reason) {
+        case (true, .sentinelUnavailable):
+            detail = NSLocalizedString("AI data was not included because Sentinel could not be started. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export is skipped because Sentinel is unavailable")
+        case (true, .timedOut):
+            detail = NSLocalizedString("AI data was not included because Sentinel did not respond in time. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export times out")
+        case (true, .exportFailed):
+            detail = NSLocalizedString("AI data was not included because Sentinel could not export it. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export fails")
+        case (true, .invalidResponsePath):
+            detail = NSLocalizedString("AI data was not included because Sentinel returned an unexpected file. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export returns an unexpected path")
+        case (true, .cancelled):
+            detail = NSLocalizedString("AI data backup was cancelled. Only browser data was backed up.", comment: "Manage User Data - Warning when AI export is cancelled")
+        case (false, .sentinelUnavailable):
+            detail = NSLocalizedString("AI data could not be backed up because Sentinel could not be started. No backup was created.", comment: "Manage User Data - Warning when an AI-only export cannot start Sentinel")
+        case (false, .timedOut):
+            detail = NSLocalizedString("AI data could not be backed up because Sentinel did not respond in time. No backup was created.", comment: "Manage User Data - Warning when an AI-only export times out")
+        case (false, .exportFailed):
+            detail = NSLocalizedString("AI data could not be backed up because Sentinel could not export it. No backup was created.", comment: "Manage User Data - Warning when an AI-only export fails")
+        case (false, .invalidResponsePath):
+            detail = NSLocalizedString("AI data could not be backed up because Sentinel returned an unexpected file. No backup was created.", comment: "Manage User Data - Warning when an AI-only export returns an unexpected path")
+        case (false, .cancelled):
+            detail = NSLocalizedString("AI data backup was cancelled. No backup was created.", comment: "Manage User Data - Warning when an AI-only export is cancelled")
+        }
+
+        let alert = NSAlert()
+        alert.messageText = browserDataIncluded
+            ? NSLocalizedString("AI Data Not Backed Up", comment: "Manage User Data - Alert title when AI data is skipped but browser data succeeds")
+            : NSLocalizedString("Backup Failed", comment: "Debug clear data - Alert title when exporting Phi user data zip fails")
+        alert.informativeText = detail
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: NSLocalizedString("OK", comment: "Generic - OK button to dismiss an alert"))
+        alert.runModal()
     }
 
     private func defaultPhiUserDataBackupFileName() -> String {
@@ -265,19 +530,181 @@ extension AppController {
             try fm.removeItem(at: destinationZIP)
         }
 
+        try Self.runZip(
+            arguments: ["-r", "-q", destinationZIP.path, phiFolderName],
+            currentDirectoryURL: parentURL
+        )
+    }
+
+    static func appendAIDataArchive(_ tarURL: URL, to destinationZIP: URL) throws {
+        let fm = FileManager.default
+        let entryName = SentinelAIDataExportSession.archiveFileName
+        let stagingParent = fm.temporaryDirectory.appendingPathComponent(
+            "PhiAIDataZip-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try fm.createDirectory(
+            at: stagingParent,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        defer {
+            try? fm.removeItem(at: stagingParent)
+        }
+
+        try copyOpenedRegularFile(
+            from: tarURL,
+            to: stagingParent.appendingPathComponent(entryName)
+        )
+        try runZip(
+            arguments: ["-q", destinationZIP.path, entryName],
+            currentDirectoryURL: stagingParent
+        )
+    }
+
+    private static func copyOpenedRegularFile(
+        from sourceURL: URL,
+        to destinationURL: URL
+    ) throws {
+        let sourceDescriptor = sourceURL.withUnsafeFileSystemRepresentation {
+            guard let fileSystemPath = $0 else {
+                return Int32(-1)
+            }
+            return Darwin.open(
+                fileSystemPath,
+                O_RDONLY | O_NOFOLLOW | O_CLOEXEC
+            )
+        }
+        guard sourceDescriptor >= 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Could not safely open the AI data archive."
+                ]
+            )
+        }
+
+        let sourceHandle = FileHandle(
+            fileDescriptor: sourceDescriptor,
+            closeOnDealloc: true
+        )
+        defer {
+            try? sourceHandle.close()
+        }
+
+        var fileStatus = stat()
+        guard Darwin.fstat(sourceDescriptor, &fileStatus) == 0 else {
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(errno),
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Could not inspect the AI data archive."
+                ]
+            )
+        }
+        guard fileStatus.st_mode & S_IFMT == S_IFREG else {
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: 5,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "The AI data archive is not a regular file."
+                ]
+            )
+        }
+
+        guard FileManager.default.createFile(
+            atPath: destinationURL.path,
+            contents: nil,
+            attributes: [.posixPermissions: 0o600]
+        ) else {
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: 6,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "Could not stage the AI data archive."
+                ]
+            )
+        }
+
+        let destinationHandle = try FileHandle(forWritingTo: destinationURL)
+        defer {
+            try? destinationHandle.close()
+        }
+        while let chunk = try sourceHandle.read(upToCount: 1024 * 1024),
+              !chunk.isEmpty {
+            try destinationHandle.write(contentsOf: chunk)
+        }
+        try destinationHandle.synchronize()
+    }
+
+    private static func runZip(
+        arguments: [String],
+        currentDirectoryURL: URL
+    ) throws {
         let stderrPipe = Pipe()
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/zip")
-        process.arguments = ["-r", "-q", destinationZIP.path, phiFolderName]
-        process.currentDirectoryURL = parentURL
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectoryURL
         process.standardError = stderrPipe
         try process.run()
         process.waitUntilExit()
         guard process.terminationStatus == 0 else {
-            let errText = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            let detail = errText.isEmpty ? "zip exited with status \(process.terminationStatus)." : errText
-            throw NSError(domain: "PhiUserDataBackup", code: Int(process.terminationStatus), userInfo: [NSLocalizedDescriptionKey: detail])
+            let errText = String(
+                data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let detail = errText.isEmpty
+                ? "zip exited with status \(process.terminationStatus)."
+                : errText
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: Int(process.terminationStatus),
+                userInfo: [NSLocalizedDescriptionKey: detail]
+            )
+        }
+    }
+
+    private static func publishBackup(
+        from stagedZIP: URL,
+        to destinationZIP: URL
+    ) throws {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: stagedZIP.path) else {
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: 3,
+                userInfo: [
+                    NSLocalizedDescriptionKey: NSLocalizedString(
+                        "No backup archive was produced.",
+                        comment: "Manage User Data - Error when export produced no zip"
+                    )
+                ]
+            )
+        }
+
+        let temporaryDestination = destinationZIP
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                ".\(destinationZIP.lastPathComponent).\(UUID().uuidString).tmp"
+            )
+        defer {
+            try? fm.removeItem(at: temporaryDestination)
+        }
+
+        try fm.copyItem(at: stagedZIP, to: temporaryDestination)
+        if fm.fileExists(atPath: destinationZIP.path) {
+            _ = try fm.replaceItemAt(
+                destinationZIP,
+                withItemAt: temporaryDestination
+            )
+        } else {
+            try fm.moveItem(at: temporaryDestination, to: destinationZIP)
         }
     }
 

--- a/Sources/Application/SentinelBackupCoordination.swift
+++ b/Sources/Application/SentinelBackupCoordination.swift
@@ -1,0 +1,511 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+
+enum SentinelAIDataExport {
+    static let requestName = Notification.Name("com.phibrowser.sentinel.exportAIData.request")
+    static let responseName = Notification.Name("com.phibrowser.sentinel.exportAIData.response")
+
+    struct Response: Equatable {
+        enum Status: String {
+            case completed
+            case error
+        }
+
+        let status: Status
+        let path: String?
+        let error: String?
+    }
+
+    static func requestUserInfo(
+        requestID: String,
+        destinationPath: String
+    ) -> [String: String] {
+        [
+            "requestID": requestID,
+            "destinationPath": destinationPath
+        ]
+    }
+
+    static func parseResponse(_ info: [String: String]) -> Response? {
+        guard let rawStatus = info["status"],
+              let status = Response.Status(rawValue: rawStatus) else {
+            return nil
+        }
+        return Response(
+            status: status,
+            path: info["path"],
+            error: info["error"]
+        )
+    }
+}
+
+protocol SentinelNotificationSubscription: AnyObject {
+    func cancel()
+}
+
+protocol SentinelNotificationTransport {
+    func post(
+        name: Notification.Name,
+        object: String,
+        userInfo: [String: String]
+    )
+
+    func observe(
+        name: Notification.Name,
+        object: String,
+        handler: @escaping ([String: String]) -> Void
+    ) -> SentinelNotificationSubscription
+}
+
+final class DistributedSentinelNotificationTransport: SentinelNotificationTransport {
+    private final class Subscription: SentinelNotificationSubscription {
+        private let token: NSObjectProtocol
+
+        init(token: NSObjectProtocol) {
+            self.token = token
+        }
+
+        func cancel() {
+            DistributedNotificationCenter.default().removeObserver(token)
+        }
+    }
+
+    func post(
+        name: Notification.Name,
+        object: String,
+        userInfo: [String: String]
+    ) {
+        DistributedNotificationCenter.default().postNotificationName(
+            name,
+            object: object,
+            userInfo: userInfo,
+            deliverImmediately: true
+        )
+    }
+
+    func observe(
+        name: Notification.Name,
+        object: String,
+        handler: @escaping ([String: String]) -> Void
+    ) -> SentinelNotificationSubscription {
+        let token = DistributedNotificationCenter.default().addObserver(
+            forName: name,
+            object: object,
+            queue: nil
+        ) { notification in
+            var info: [String: String] = [:]
+            for (key, value) in notification.userInfo ?? [:] {
+                if let key = key as? String, let value = value as? String {
+                    info[key] = value
+                }
+            }
+            handler(info)
+        }
+        return Subscription(token: token)
+    }
+}
+
+enum SentinelCoordinationResult<Response> {
+    case response(Response)
+    case timedOut
+    case cancelled
+}
+
+final class SentinelBackupCoordinationClient {
+    private let transport: SentinelNotificationTransport
+    private let sentinelBundleID: String
+    private let browserBundleID: String
+    private let retryDelays: [TimeInterval]
+
+    init(
+        transport: SentinelNotificationTransport = DistributedSentinelNotificationTransport(),
+        sentinelBundleID: String = SentinelHelper.loginItemIdentifier(),
+        browserBundleID: String = Bundle.main.bundleIdentifier ?? "",
+        retryDelays: [TimeInterval] = [0, 0.5, 1, 2, 4, 8]
+    ) {
+        self.transport = transport
+        self.sentinelBundleID = sentinelBundleID
+        self.browserBundleID = browserBundleID
+        self.retryDelays = retryDelays
+    }
+
+    func requestExportAIData(
+        requestID: String,
+        destinationPath: String,
+        timeout: TimeInterval = 10 * 60
+    ) async -> SentinelCoordinationResult<SentinelAIDataExport.Response> {
+        let state = SendState<SentinelAIDataExport.Response>()
+        let payload = SentinelAIDataExport.requestUserInfo(
+            requestID: requestID,
+            destinationPath: destinationPath
+        ).merging(["browserBundleID": browserBundleID]) { current, _ in current }
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                let subscription = transport.observe(
+                    name: SentinelAIDataExport.responseName,
+                    object: sentinelBundleID
+                ) { info in
+                    guard info["requestID"] == requestID,
+                          let response = SentinelAIDataExport.parseResponse(info) else {
+                        return
+                    }
+                    state.resolve(.response(response))
+                }
+                state.install(
+                    continuation: continuation,
+                    subscription: subscription
+                )
+
+                for delay in retryDelays {
+                    let retryTask = Task {
+                        if delay > 0 {
+                            try? await Task.sleep(
+                                nanoseconds: UInt64(delay * 1_000_000_000)
+                            )
+                        }
+                        state.performIfPending {
+                            transport.post(
+                                name: SentinelAIDataExport.requestName,
+                                object: sentinelBundleID,
+                                userInfo: payload
+                            )
+                        }
+                    }
+                    state.add(task: retryTask)
+                }
+
+                let timeoutTask = Task {
+                    try? await Task.sleep(
+                        nanoseconds: UInt64(max(0, timeout) * 1_000_000_000)
+                    )
+                    state.resolve(.timedOut)
+                }
+                state.add(task: timeoutTask)
+            }
+        } onCancel: {
+            state.resolve(.cancelled)
+        }
+    }
+}
+
+struct SentinelAIDataExportSession {
+    static let archiveFileName = "ai-data.tar.gz"
+    private static let sessionLifetime: TimeInterval = 24 * 60 * 60
+
+    let requestID: UUID
+    let directoryURL: URL
+    let archiveURL: URL
+
+    static func prepare(
+        sharedContainerURL: URL,
+        sentinelBundleID: String,
+        requestID: UUID,
+        now: Date = Date(),
+        fileManager: FileManager = .default
+    ) throws -> SentinelAIDataExportSession {
+        let scopeURL = sharedContainerURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Caches", isDirectory: true)
+            .appendingPathComponent("SentinelExports", isDirectory: true)
+            .appendingPathComponent(sentinelBundleID, isDirectory: true)
+
+        try fileManager.createDirectory(
+            at: scopeURL,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        removeExpiredSessions(
+            in: scopeURL,
+            olderThan: now.addingTimeInterval(-sessionLifetime),
+            fileManager: fileManager
+        )
+
+        let directoryURL = scopeURL.appendingPathComponent(
+            requestID.uuidString,
+            isDirectory: true
+        )
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
+        return SentinelAIDataExportSession(
+            requestID: requestID,
+            directoryURL: directoryURL,
+            archiveURL: directoryURL.appendingPathComponent(
+                archiveFileName,
+                isDirectory: false
+            )
+        )
+    }
+
+    func cleanup(fileManager: FileManager = .default) {
+        try? fileManager.removeItem(at: directoryURL)
+    }
+
+    func scheduleCleanup(after delay: TimeInterval = 15 * 60) {
+        let directoryURL = directoryURL
+        DispatchQueue.global(qos: .utility).asyncAfter(
+            deadline: .now() + max(0, delay)
+        ) {
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+    }
+
+    private static func removeExpiredSessions(
+        in scopeURL: URL,
+        olderThan expirationDate: Date,
+        fileManager: FileManager
+    ) {
+        let resourceKeys: Set<URLResourceKey> = [
+            .contentModificationDateKey,
+            .isDirectoryKey,
+            .isSymbolicLinkKey
+        ]
+        guard let children = try? fileManager.contentsOfDirectory(
+            at: scopeURL,
+            includingPropertiesForKeys: Array(resourceKeys),
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+
+        for child in children {
+            guard let values = try? child.resourceValues(forKeys: resourceKeys),
+                  values.isDirectory == true,
+                  values.isSymbolicLink != true,
+                  let modifiedAt = values.contentModificationDate,
+                  modifiedAt < expirationDate else {
+                continue
+            }
+            try? fileManager.removeItem(at: child)
+        }
+    }
+}
+
+@MainActor
+struct SentinelAIDataExportService {
+    func prepareSession() throws -> SentinelAIDataExportSession {
+        guard let sharedContainerURL = FileSystemUtils.sharedContainerURL() else {
+            throw NSError(
+                domain: "PhiUserDataBackup",
+                code: 4,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "The shared App Group container is unavailable."
+                ]
+            )
+        }
+        return try SentinelAIDataExportSession.prepare(
+            sharedContainerURL: sharedContainerURL,
+            sentinelBundleID: SentinelHelper.loginItemIdentifier(),
+            requestID: UUID()
+        )
+    }
+
+    func coordinate(
+        session: SentinelAIDataExportSession,
+        isCancelled: @escaping () -> Bool
+    ) async -> AIDataExportCoordinator.Result {
+        let coordinator = AIDataExportCoordinator(
+            ensureSentinelRunning: {
+                if SentinelHelper.isRunning {
+                    return true
+                }
+                SentinelHelper.launch()
+                for _ in 0..<32 {
+                    if SentinelHelper.isRunning {
+                        return true
+                    }
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                }
+                return SentinelHelper.isRunning
+            },
+            requestExport: { requestID, destinationPath in
+                await SentinelBackupCoordinationClient().requestExportAIData(
+                    requestID: requestID,
+                    destinationPath: destinationPath
+                )
+            },
+            isRegularFile: { url in
+                guard let attributes = try? FileManager.default.attributesOfItem(
+                    atPath: url.path
+                ) else {
+                    return false
+                }
+                return attributes[.type] as? FileAttributeType == .typeRegular
+            },
+            isCancelled: isCancelled
+        )
+        return await coordinator.coordinate(
+            requestID: session.requestID.uuidString,
+            destinationTarURL: session.archiveURL
+        )
+    }
+}
+
+final class SentinelExportCancellation {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return cancelled
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+}
+
+struct AIDataExportCoordinator {
+    enum Result: Equatable {
+        case packed(tarURL: URL)
+        case skipped(reason: SkipReason)
+    }
+
+    enum SkipReason: Equatable {
+        case sentinelUnavailable
+        case timedOut
+        case exportFailed
+        case invalidResponsePath
+        case cancelled
+
+        var shouldRetainSessionForLateWrite: Bool {
+            switch self {
+            case .sentinelUnavailable, .exportFailed:
+                return false
+            case .timedOut, .invalidResponsePath, .cancelled:
+                return true
+            }
+        }
+    }
+
+    let ensureSentinelRunning: () async -> Bool
+    let requestExport: (
+        _ requestID: String,
+        _ destinationPath: String
+    ) async -> SentinelCoordinationResult<SentinelAIDataExport.Response>
+    let isRegularFile: (URL) -> Bool
+    let isCancelled: () -> Bool
+
+    func coordinate(
+        requestID: String,
+        destinationTarURL: URL
+    ) async -> Result {
+        if isCancelled() {
+            return .skipped(reason: .cancelled)
+        }
+        guard await ensureSentinelRunning() else {
+            return .skipped(reason: .sentinelUnavailable)
+        }
+        if isCancelled() {
+            return .skipped(reason: .cancelled)
+        }
+
+        switch await requestExport(requestID, destinationTarURL.path) {
+        case .timedOut:
+            return .skipped(reason: .timedOut)
+        case .cancelled:
+            return .skipped(reason: .cancelled)
+        case .response(let response):
+            guard !isCancelled() else {
+                return .skipped(reason: .cancelled)
+            }
+            switch response.status {
+            case .error:
+                return .skipped(reason: .exportFailed)
+            case .completed:
+                guard let responsePath = response.path else {
+                    return .skipped(reason: .exportFailed)
+                }
+                guard responsePath == destinationTarURL.path else {
+                    return .skipped(reason: .invalidResponsePath)
+                }
+                guard isRegularFile(destinationTarURL) else {
+                    return .skipped(reason: .exportFailed)
+                }
+                return .packed(tarURL: destinationTarURL)
+            }
+        }
+    }
+}
+
+private final class SendState<Response> {
+    typealias Result = SentinelCoordinationResult<Response>
+    typealias Continuation = CheckedContinuation<Result, Never>
+
+    private let lock = NSLock()
+    private var resolvedResult: Result?
+    private var continuation: Continuation?
+    private var subscription: SentinelNotificationSubscription?
+    private var tasks: [Task<Void, Never>] = []
+
+    func install(
+        continuation: Continuation,
+        subscription: SentinelNotificationSubscription
+    ) {
+        lock.lock()
+        if let resolvedResult {
+            lock.unlock()
+            subscription.cancel()
+            continuation.resume(returning: resolvedResult)
+            return
+        }
+        self.continuation = continuation
+        self.subscription = subscription
+        lock.unlock()
+    }
+
+    func add(task: Task<Void, Never>) {
+        lock.lock()
+        let shouldCancel = resolvedResult != nil
+        if !shouldCancel {
+            tasks.append(task)
+        }
+        lock.unlock()
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func performIfPending(_ body: () -> Void) {
+        lock.lock()
+        let shouldPerform = resolvedResult == nil
+        lock.unlock()
+        if shouldPerform {
+            body()
+        }
+    }
+
+    func resolve(_ result: Result) {
+        lock.lock()
+        guard resolvedResult == nil else {
+            lock.unlock()
+            return
+        }
+        resolvedResult = result
+        let continuation = continuation
+        self.continuation = nil
+        let subscription = subscription
+        self.subscription = nil
+        let tasks = tasks
+        self.tasks = []
+        lock.unlock()
+
+        subscription?.cancel()
+        for task in tasks {
+            task.cancel()
+        }
+        continuation?.resume(returning: result)
+    }
+}

--- a/Sources/Application/SentinelHelper.swift
+++ b/Sources/Application/SentinelHelper.swift
@@ -76,36 +76,112 @@ struct SentinelOpenDashboardRequest: Equatable {
 struct SentinelAccountDeletedEvent: Equatable {
     static let notificationName = Notification.Name("com.phibrowser.sentinel.accountDeleted")
 
+    let signatureVersion: String
     let requestID: String
     let sentinelBundleID: String
     let browserBundleID: String
-    /// The deleted account's Auth0 sub; nil when the shared token was
-    /// unreadable at post time. A nil sub is omitted from `userInfo` —
-    /// handling a missing sub is the receiver's decision.
-    let auth0Sub: String?
+    let auth0Sub: String
+    let issuedAt: String
+    let signature: String
+
+    private init(
+        signatureVersion: String,
+        requestID: String,
+        sentinelBundleID: String,
+        browserBundleID: String,
+        auth0Sub: String,
+        issuedAt: String,
+        signature: String
+    ) {
+        self.signatureVersion = signatureVersion
+        self.requestID = requestID
+        self.sentinelBundleID = sentinelBundleID
+        self.browserBundleID = browserBundleID
+        self.auth0Sub = auth0Sub
+        self.issuedAt = issuedAt
+        self.signature = signature
+    }
+
+    var signedContent: AccountDeletedSignedContent {
+        AccountDeletedSignedContent(
+            signatureVersion: signatureVersion,
+            notificationName: Self.notificationName.rawValue,
+            sentinelBundleID: sentinelBundleID,
+            browserBundleID: browserBundleID,
+            requestID: requestID,
+            auth0Sub: auth0Sub,
+            issuedAt: issuedAt
+        )
+    }
 
     var userInfo: [String: String] {
-        var info = [
+        [
+            "signatureVersion": signatureVersion,
             "requestID": requestID,
-            "browserBundleID": browserBundleID
+            "browserBundleID": browserBundleID,
+            "auth0Sub": auth0Sub,
+            "issuedAt": issuedAt,
+            "signature": signature
         ]
-        if let auth0Sub {
-            info["auth0Sub"] = auth0Sub
-        }
-        return info
     }
 
     static func make(
         sentinelBundleID: String,
         browserBundleID: String,
         auth0Sub: String?,
-        requestID: String = UUID().uuidString
-    ) -> SentinelAccountDeletedEvent {
-        SentinelAccountDeletedEvent(
-            requestID: requestID,
+        signingKey: Data?,
+        requestID: String = UUID().uuidString,
+        issuedAt: String = String(Int64(Date().timeIntervalSince1970))
+    ) throws -> SentinelAccountDeletedEvent {
+        guard !sentinelBundleID.isEmpty else {
+            throw SentinelAccountDeletedEventError.missingField("sentinelBundleID")
+        }
+        guard !browserBundleID.isEmpty else {
+            throw SentinelAccountDeletedEventError.missingField("browserBundleID")
+        }
+        guard !requestID.isEmpty else {
+            throw SentinelAccountDeletedEventError.missingField("requestID")
+        }
+        guard let auth0Sub, !auth0Sub.isEmpty else {
+            throw SentinelAccountDeletedEventError.missingField("auth0Sub")
+        }
+        guard Int64(issuedAt) != nil else {
+            throw SentinelAccountDeletedEventError.invalidIssuedAt
+        }
+        guard let signingKey,
+              signingKey.count == AccountDeletedEventAuthentication.keyByteCount else {
+            throw SentinelAccountDeletedEventError.signingKeyUnavailable
+        }
+
+        let content = AccountDeletedSignedContent(
+            signatureVersion: AccountDeletedEventAuthentication.signatureVersion,
+            notificationName: Self.notificationName.rawValue,
             sentinelBundleID: sentinelBundleID,
             browserBundleID: browserBundleID,
-            auth0Sub: auth0Sub
+            requestID: requestID,
+            auth0Sub: auth0Sub,
+            issuedAt: issuedAt
+        )
+        let signature: String
+        do {
+            signature = try AccountDeletedEventAuthentication.signature(
+                for: content,
+                key: signingKey
+            )
+        } catch let error as SentinelAccountDeletedEventError {
+            throw error
+        } catch {
+            throw SentinelAccountDeletedEventError.signingFailed
+        }
+
+        return SentinelAccountDeletedEvent(
+            signatureVersion: content.signatureVersion,
+            requestID: content.requestID,
+            sentinelBundleID: content.sentinelBundleID,
+            browserBundleID: content.browserBundleID,
+            auth0Sub: content.auth0Sub,
+            issuedAt: content.issuedAt,
+            signature: signature
         )
     }
 }
@@ -273,11 +349,27 @@ enum SentinelHelper {
             AppLogWarn("Posting account deleted event while Sentinel is not running; the event will be lost (bundleID \(identifier))")
         }
 
-        let event = SentinelAccountDeletedEvent.make(
-            sentinelBundleID: identifier,
-            browserBundleID: Bundle.main.bundleIdentifier ?? "",
-            auth0Sub: SharedAuthTokenStore.shared.read()?.auth0Sub
-        )
+        let auth0Sub = SharedAuthTokenStore.shared.read()?.auth0Sub
+        guard let auth0Sub, !auth0Sub.isEmpty else {
+            AppLogError("Skipped account deleted event: missing auth0 subject")
+            return
+        }
+
+        let signingKey = AccountDeletedSigningKeyStore.shared.readOrCreate()
+        let event: SentinelAccountDeletedEvent
+        do {
+            event = try SentinelAccountDeletedEvent.make(
+                sentinelBundleID: identifier,
+                browserBundleID: Bundle.main.bundleIdentifier ?? "",
+                auth0Sub: auth0Sub,
+                signingKey: signingKey
+            )
+        } catch {
+            let category = (error as? SentinelAccountDeletedEventError)?.description ?? "signing failed"
+            AppLogError("Skipped account deleted event: \(category)")
+            return
+        }
+
         DistributedNotificationCenter.default().postNotificationName(
             SentinelAccountDeletedEvent.notificationName,
             object: event.sentinelBundleID,

--- a/Sources/UserInterface/AccountDeletion/AccountDeletionCoordinator.swift
+++ b/Sources/UserInterface/AccountDeletion/AccountDeletionCoordinator.swift
@@ -54,6 +54,11 @@ final class AccountDeletionCoordinator {
     /// Sentinel that chooses to exit is not resurrected), then posts the
     /// Account Deleted Event. Fire-and-forget — no wait, no retry.
     typealias AnnounceAccountDeleted = @MainActor () -> Void
+    /// Returns false when the shared-token lock or durable credential fence
+    /// is unavailable; the finalize must not notify Sentinel, suspend, or
+    /// quit.
+    typealias BeginCredentialDeletion = @MainActor () -> Bool
+    typealias ClearInitialCredentials = () async -> Void
     typealias ClearCredentials = () async -> Void
     /// Removes everything Phi keeps on this Mac outside the credential
     /// layer. Async because the WKWebView website-data clearing only
@@ -112,6 +117,8 @@ final class AccountDeletionCoordinator {
     private let verifyDeletion: VerifyDeletion
     private let renewCredentials: RenewCredentials
     private let announceAccountDeleted: AnnounceAccountDeleted
+    private let beginCredentialDeletion: BeginCredentialDeletion
+    private let clearInitialCredentials: ClearInitialCredentials
     private let clearCredentials: ClearCredentials
     private let clearLocalData: ClearLocalData
     private let quit: Quit
@@ -189,6 +196,18 @@ final class AccountDeletionCoordinator {
             SentinelWatchdog.shared.stop()
             SentinelHelper.postAccountDeletedEvent()
         },
+        beginCredentialDeletion: @escaping BeginCredentialDeletion = {
+            // Persist the crash-recovery fence and freeze credential writers
+            // before Sentinel is notified. No suspension is allowed between
+            // this and the announcement.
+            return AuthManager.shared.beginAccountDeletionFinalization()
+        },
+        clearInitialCredentials: @escaping ClearInitialCredentials = {
+            // The signed event has captured the account identity. Clear both
+            // credential stores without posting the ordinary token-change
+            // notification, which could otherwise race Sentinel's verifier.
+            await AuthManager.shared.clearInitialAccountDeletionCredentials()
+        },
         clearCredentials: @escaping ClearCredentials = {
             // Local-only by design (2026-07-23 decision) — unlike logout,
             // no remote Auth0 `clearSession` runs here. The deletion is
@@ -196,11 +215,10 @@ final class AccountDeletionCoordinator {
             // account anyway; the external-browser teardown would flash
             // the default browser right before the quit, and a callback
             // arriving after the quit would relaunch the freshly wiped
-            // Phi. A reauthentication still in flight cannot resurrect
-            // credentials either: the finalize runs this clear after its
-            // last long suspension (see `finalizeDeletion`), and the quit
-            // destroys the process holding the pending transaction, so a
-            // later callback is dropped.
+            // Phi. The account-deletion fence already cleared credentials
+            // before the long-running local-data removal; this final clear
+            // verifies the stores again and posts the ordinary shared-token
+            // change notification.
             await AuthManager.shared.clearLocalAccountData()
         },
         clearLocalData: @escaping ClearLocalData = {
@@ -225,6 +243,8 @@ final class AccountDeletionCoordinator {
         self.verifyDeletion = verifyDeletion
         self.renewCredentials = renewCredentials
         self.announceAccountDeleted = announceAccountDeleted
+        self.beginCredentialDeletion = beginCredentialDeletion
+        self.clearInitialCredentials = clearInitialCredentials
         self.clearCredentials = clearCredentials
         self.clearLocalData = clearLocalData
         self.quit = quit
@@ -379,22 +399,23 @@ final class AccountDeletionCoordinator {
     }
 
     /// Runs the finalize after the user confirmed it on the submitted or
-    /// already-running dialog: the deletion is announced to Sentinel, the
-    /// credential layer and the on-disk data are each cleared exactly once,
-    /// then the process force-quits. Only valid once the deletion is booked
-    /// server-side; the immediate `.finalizing` transition doubles as the
-    /// re-entry guard, so a double click cannot run the clears twice.
+    /// already-running dialog: the credential layer is fenced, the deletion
+    /// is announced to Sentinel, credentials and on-disk data are cleared,
+    /// credentials are verified clear again, then the process force-quits.
+    /// Only valid once the deletion is booked server-side; the immediate
+    /// `.finalizing` transition doubles as the re-entry guard, so a double
+    /// click cannot start another finalize sequence.
     ///
-    /// The Sentinel announcement runs first, before the wipe: the shared
-    /// token is still readable there (the event carries the account
-    /// identifier), and the local-data clear's long suspensions keep Phi
-    /// alive afterwards, giving Sentinel the longest receive window.
+    /// The durable fence is persisted immediately before the Sentinel
+    /// announcement, with no suspension between them. The shared token is
+    /// still readable for the event, and a crash after Sentinel accepts it
+    /// cannot leave the browser able to restore deleted credentials.
     ///
-    /// The credential clear runs last, after the local-data clear's long
-    /// suspensions (the WKWebView sweep): an in-flight reauthentication or
-    /// token renewal landing mid-finalize gets wiped by the clear instead
-    /// of outliving it, and no suspension remains between the clear and
-    /// the quit for a late callback to slip into.
+    /// The credential fence runs before the local-data clear's long
+    /// suspensions (the WKWebView sweep), so reopening Phi during cleanup
+    /// cannot restore the deleted account from Auth0's local keychain. The
+    /// final clear catches an in-flight Auth0 write, and the durable fence
+    /// makes a crash fail closed on the next launch.
     func finalizeDeletion() async {
         switch state {
         case .requestSubmitted, .deletionAlreadyRunning:
@@ -404,8 +425,17 @@ final class AccountDeletionCoordinator {
             AppLogInfo("🗑️ [AccountDeletion] No deletion booked server-side, ignoring finalize")
             return
         }
+        let bookedState = state
         state = .finalizing
+        guard beginCredentialDeletion() else {
+            state = bookedState
+            AppLogError(
+                "🗑️ [AccountDeletion] Credential safety preflight unavailable; finalize remains pending"
+            )
+            return
+        }
         announceAccountDeleted()
+        await clearInitialCredentials()
         await clearLocalData()
         await clearCredentials()
         quit()

--- a/Sources/UserInterface/Onboarding/AuthManager+Provider.swift
+++ b/Sources/UserInterface/Onboarding/AuthManager+Provider.swift
@@ -8,11 +8,16 @@
 import Foundation
 import Auth0
 extension AuthManager {
-    func makeExternalBrowserAuthProvider() -> WebAuthProvider {
+    func makeExternalBrowserAuthProvider(
+        accountDeletionReplacementLoginToken: UUID? = nil
+    ) -> WebAuthProvider {
         return { [weak self] authorizeURL, callback in
             let listenerRegistration: (@escaping (URL) -> Void) -> (() -> Void) = { listener in
                 guard let self else { return {} }
-                return self.registerBrowserAuthCallbackListener(listener)
+                return self.registerBrowserAuthCallbackListener(
+                    listener,
+                    accountDeletionReplacementLoginToken: accountDeletionReplacementLoginToken
+                )
             }
 
             return AuthManagerExternalBrowserWebAuthUserAgent(
@@ -27,7 +32,17 @@ extension AuthManager {
         guard url.host == domain else {
             return false
         }
-        let callback = browserAuthCallbackQueue.sync { pendingBrowserAuthCallback }
+        let (callback, replacementLoginToken) = browserAuthCallbackQueue.sync {
+            (
+                pendingBrowserAuthCallback,
+                pendingBrowserAuthCallbackReplacementLoginToken
+            )
+        }
+        guard permitsExternalBrowserAuthentication(
+            accountDeletionReplacementLoginToken: replacementLoginToken
+        ) else {
+            return false
+        }
         guard let callback else {
             return false
         }
@@ -40,11 +55,21 @@ extension AuthManager {
         clearBrowserAuthCallbackListener()
     }
 
-    func registerBrowserAuthCallbackListener(_ listener: @escaping (URL) -> Void) -> (() -> Void) {
+    func registerBrowserAuthCallbackListener(
+        _ listener: @escaping (URL) -> Void,
+        accountDeletionReplacementLoginToken: UUID? = nil
+    ) -> (() -> Void) {
+        guard permitsExternalBrowserAuthentication(
+            accountDeletionReplacementLoginToken: accountDeletionReplacementLoginToken
+        ) else {
+            return {}
+        }
         let token = UUID()
         browserAuthCallbackQueue.sync {
             pendingBrowserAuthCallbackToken = token
             pendingBrowserAuthCallback = listener
+            pendingBrowserAuthCallbackReplacementLoginToken =
+                accountDeletionReplacementLoginToken
         }
         return { [weak self] in
             self?.clearBrowserAuthCallbackListener(for: token)
@@ -58,6 +83,7 @@ extension AuthManager {
             }
             pendingBrowserAuthCallbackToken = nil
             pendingBrowserAuthCallback = nil
+            pendingBrowserAuthCallbackReplacementLoginToken = nil
         }
     }
 

--- a/Sources/UserInterface/Onboarding/AuthManager.swift
+++ b/Sources/UserInterface/Onboarding/AuthManager.swift
@@ -8,6 +8,54 @@ import Auth0
 import WebKit
 import JWTDecode
 import PostHog
+import Security
+
+struct AccountDeletionCredentialFence {
+    private static let markerSuffix = ".phi-account-deletion-credentials.pending"
+
+    let markerURL: URL
+
+    static var currentProduct: AccountDeletionCredentialFence {
+        let dataRoot = URL(
+            fileURLWithPath: FileSystemUtils.applicationSupportDirctory(),
+            isDirectory: true
+        )
+        return AccountDeletionCredentialFence(
+            markerURL: dataRoot.deletingLastPathComponent().appendingPathComponent(
+                dataRoot.lastPathComponent + markerSuffix,
+                isDirectory: false
+            )
+        )
+    }
+
+    var isActive: Bool {
+        FileManager.default.fileExists(atPath: markerURL.path)
+    }
+
+    func activate() -> Bool {
+        do {
+            try FileManager.default.createDirectory(
+                at: markerURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("account-deletion-v1".utf8).write(to: markerURL, options: .atomic)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    func deactivate() -> Bool {
+        do {
+            if isActive {
+                try FileManager.default.removeItem(at: markerURL)
+            }
+            return !isActive
+        } catch {
+            return false
+        }
+    }
+}
 
 final class AuthFailureTraceBuffer {
     private struct Entry {
@@ -104,10 +152,24 @@ final class AuthFailureTraceBuffer {
 class AuthManager {
     static let shared = AuthManager()
     private(set) var currentCredentials: Credentials?
+
+    private let accountDeletionStateLock = NSLock()
+    private var accountDeletionInProgress = false
+    private var accountDeletionReplacementLoginToken: UUID?
+    private var accountDeletionHoldsSharedTokenLock = false
+    private let accountDeletionCredentialFence = AccountDeletionCredentialFence.currentProduct
+    private var accountDeletionFenceAwaitingExplicitLogin = false
+
+    var isAccountDeletionInProgress: Bool {
+        accountDeletionStateLock.lock()
+        defer { accountDeletionStateLock.unlock() }
+        return accountDeletionInProgress
+    }
     
     let browserAuthCallbackQueue = DispatchQueue(label: "com.phi.auth.browser-callback")
     var pendingBrowserAuthCallback: ((URL) -> Void)?
     var pendingBrowserAuthCallbackToken: UUID?
+    var pendingBrowserAuthCallbackReplacementLoginToken: UUID?
 
     private lazy var authURLSession: URLSession = {
         let configuration = URLSessionConfiguration.default
@@ -115,7 +177,7 @@ class AuthManager {
         return URLSession(configuration: configuration)
     }()
     
-    private lazy var credentialManager: CredentialsManager =  {
+    private var credentialStoreKey: String {
         let storeKey: String
         #if DEBUG
         if Self.useStagingAuth0 {
@@ -129,12 +191,16 @@ class AuthManager {
         // Keep the release key stable so existing users do not lose cached credentials.
         storeKey = "credentials"
         #endif
+        return storeKey
+    }
+
+    private lazy var credentialManager: CredentialsManager =  {
         // Keep Auth0's automatic retry window short. With rotating refresh tokens, a
         // missed successful response leaves the client holding the previous RT; delayed
         // retries can then exceed Auth0's overlap period and destroy the token family.
         return CredentialsManager(
             authentication: Auth0.authentication(clientId: clicentId, domain: domain, session: authURLSession),
-            storeKey: storeKey,
+            storeKey: credentialStoreKey,
             maxRetries: 1
         )
     }()
@@ -218,8 +284,39 @@ class AuthManager {
         #endif
     }()
 
+    init() {
+        guard accountDeletionCredentialFence.isActive else {
+            return
+        }
+
+        setAccountDeletionInProgress(true)
+        accountDeletionFenceAwaitingExplicitLogin = true
+        let storesCleared = clearCredentialStores(postSharedTokenChange: true)
+        if storesCleared {
+            AppLogInfo(
+                "[AccountDeletion] Cleared fenced credentials; automatic session recovery remains blocked until explicit login"
+            )
+        } else {
+            AppLogError("[AccountDeletion] Startup credential recovery failed; login remains fenced")
+        }
+    }
+
     @MainActor
     func login() async -> Result<Credentials, Error> {
+        let isReplacingDeletedAccount = isAccountDeletionInProgress
+            && accountDeletionFenceAwaitingExplicitLogin
+        guard !isAccountDeletionInProgress || isReplacingDeletedAccount else {
+            return .failure(CancellationError())
+        }
+        let replacementLoginToken = isReplacingDeletedAccount ? UUID() : nil
+        if let replacementLoginToken {
+            setAccountDeletionReplacementLoginToken(replacementLoginToken)
+        }
+        defer {
+            if let replacementLoginToken {
+                clearAccountDeletionReplacementLoginToken(replacementLoginToken)
+            }
+        }
         recordTrace("login-started")
         do {
             // Browser URL scheme handling conflicts with AuthenticationServices, so login runs
@@ -227,9 +324,53 @@ class AuthManager {
             let results = try await Auth0.webAuth(clientId: clicentId, domain: domain)
                 .audience(audience)
                 .scope("openid profile email offline_access")
-                .provider(makeExternalBrowserAuthProvider())
+                .provider(
+                    makeExternalBrowserAuthProvider(
+                        accountDeletionReplacementLoginToken: replacementLoginToken
+                    )
+                )
                 .start()
-            _ = credentialManager.store(credentials: results)
+
+            let holdsDeletionRecoveryLock: Bool
+            if isReplacingDeletedAccount {
+                // Sentinel can have one pre-deletion renewal still waiting on
+                // Auth0. Serialize the replacement login behind that writer,
+                // clear its result, then install the new account while still
+                // holding the cross-process lock.
+                holdsDeletionRecoveryLock = await acquireSharedLock(timeout: 50)
+                guard holdsDeletionRecoveryLock else {
+                    recordTrace("login-blocked-account-deletion-lock-timeout")
+                    return .failure(CancellationError())
+                }
+            } else {
+                holdsDeletionRecoveryLock = false
+            }
+            defer {
+                if holdsDeletionRecoveryLock {
+                    SharedTokenLock.shared.unlock()
+                }
+            }
+
+            if isReplacingDeletedAccount {
+                guard clearLocalAccountData(postSharedTokenChange: false),
+                      accountDeletionCredentialFence.deactivate() else {
+                    AppLogError(
+                        "[AccountDeletion] Could not release the credential fence for explicit login"
+                    )
+                    return .failure(CancellationError())
+                }
+                accountDeletionFenceAwaitingExplicitLogin = false
+                setAccountDeletionInProgress(false)
+            }
+
+            guard !isAccountDeletionInProgress else {
+                _ = clearCredentialStores(postSharedTokenChange: false)
+                return .failure(CancellationError())
+            }
+            guard storeCredentialsIfAllowed(results) else {
+                _ = clearCredentialStores(postSharedTokenChange: false)
+                return .failure(CancellationError())
+            }
             self.currentCredentials = results
             self.lastRenewAttemptAt = Date()
             self.reauthenticationState = .normal
@@ -308,6 +449,57 @@ class AuthManager {
         }
     }
 
+    /// Starts the irreversible local-auth half of account deletion by
+    /// freezing credential writers and persisting the durable fence. The
+    /// caller posts the signed event synchronously after this returns, while
+    /// the account identity is still present, then performs the silent clear.
+    @MainActor
+    func beginAccountDeletionFinalization() -> Bool {
+        setAccountDeletionInProgress(true)
+        clearAccountDeletionReplacementLoginToken()
+        guard SharedTokenLock.shared.lockWithTimeout(5) else {
+            AppLogError("[AccountDeletion] Failed to acquire the shared-token lock")
+            return false
+        }
+        let fenceActivated = accountDeletionCredentialFence.activate()
+        guard fenceActivated else {
+            SharedTokenLock.shared.unlock()
+            AppLogError("[AccountDeletion] Failed to persist the credential fence")
+            return false
+        }
+        accountDeletionHoldsSharedTokenLock = true
+        return true
+    }
+
+    /// Cancels in-process writers and performs the first credential clear
+    /// immediately after the signed deletion event has been posted.
+    @MainActor
+    func clearInitialAccountDeletionCredentials() async {
+        cancelOngoingWebAuthentication()
+        if isRenewing {
+            authURLSession.invalidateAndCancel()
+        }
+
+        let holdsSharedLock: Bool
+        if accountDeletionHoldsSharedTokenLock {
+            holdsSharedLock = true
+        } else {
+            // Defense in depth for direct callers that did not run the
+            // coordinator's fenced preflight.
+            holdsSharedLock = await acquireSharedLock(timeout: 5)
+        }
+        defer {
+            if holdsSharedLock {
+                SharedTokenLock.shared.unlock()
+            }
+            accountDeletionHoldsSharedTokenLock = false
+        }
+        let storesCleared = clearLocalAccountData(postSharedTokenChange: false)
+        if !storesCleared {
+            AppLogError("[AccountDeletion] Initial credential clear failed")
+        }
+    }
+
     /// Clears every piece of local account state: the stored credentials, the
     /// cross-process token store, the cached account identity (profile, avatar
     /// bytes, current account reference) and the timers that assume a live
@@ -319,9 +511,8 @@ class AuthManager {
     /// reauthentication state lives in the account's defaults, so it has to be
     /// dropped while the account reference is still around.
     @MainActor
-    func clearLocalAccountData() {
-        _ = credentialManager.clear()
-        SharedAuthTokenStore.shared.clear()
+    @discardableResult
+    func clearLocalAccountData(postSharedTokenChange: Bool = true) -> Bool {
         currentCredentials = nil
         lastRenewAttemptAt = nil
         lastSuccessfulSyncAt = nil
@@ -330,6 +521,79 @@ class AuthManager {
         stopRenewTimer()
         stopHeartbeat()
         AccountController.shared.clearCachedAccount()
+        return clearCredentialStores(postSharedTokenChange: postSharedTokenChange)
+    }
+
+    func setAccountDeletionInProgress(_ value: Bool) {
+        accountDeletionStateLock.lock()
+        accountDeletionInProgress = value
+        accountDeletionStateLock.unlock()
+    }
+
+    func permitsExternalBrowserAuthentication(
+        accountDeletionReplacementLoginToken token: UUID?
+    ) -> Bool {
+        accountDeletionStateLock.lock()
+        defer { accountDeletionStateLock.unlock() }
+        guard accountDeletionInProgress else {
+            return true
+        }
+        guard let token else {
+            return false
+        }
+        return token == accountDeletionReplacementLoginToken
+    }
+
+    func setAccountDeletionReplacementLoginToken(_ token: UUID) {
+        accountDeletionStateLock.lock()
+        accountDeletionReplacementLoginToken = token
+        accountDeletionStateLock.unlock()
+    }
+
+    func clearAccountDeletionReplacementLoginToken(_ token: UUID? = nil) {
+        accountDeletionStateLock.lock()
+        defer { accountDeletionStateLock.unlock() }
+        guard token == nil || token == accountDeletionReplacementLoginToken else {
+            return
+        }
+        accountDeletionReplacementLoginToken = nil
+    }
+
+    private func clearCredentialStores(postSharedTokenChange: Bool) -> Bool {
+        _ = credentialManager.clear()
+        var localStatus = storedAuth0CredentialStatus()
+        if localStatus == errSecSuccess {
+            _ = credentialManager.clear()
+            localStatus = storedAuth0CredentialStatus()
+        }
+        let localCleared = localStatus == errSecItemNotFound
+        if !localCleared {
+            AppLogError(
+                "[Auth] Local Auth0 credential verification failed with OSStatus \(localStatus)"
+            )
+        }
+
+        let sharedCleared = SharedAuthTokenStore.shared.clear(
+            postChangeNotification: postSharedTokenChange
+        )
+        return localCleared && sharedCleared
+    }
+
+    private func storeCredentialsIfAllowed(_ credentials: Credentials) -> Bool {
+        guard !isAccountDeletionInProgress else {
+            return false
+        }
+        return credentialManager.store(credentials: credentials)
+    }
+
+    private func storedAuth0CredentialStatus() -> OSStatus {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: Bundle.main.bundleIdentifier ?? FileSystemUtils.bundleId,
+            kSecAttrAccount as String: credentialStoreKey,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+        return SecItemCopyMatching(query as CFDictionary, nil)
     }
 
     /// User-initiated logout: best-effort remote session teardown followed by
@@ -370,6 +634,11 @@ class AuthManager {
     }
     
     func refreshAuthStatus() async {
+        guard !isAccountDeletionInProgress else {
+            currentCredentials = nil
+            recordTrace("refresh-auth-status-skipped-account-deletion")
+            return
+        }
         recordTrace("refresh-auth-status-started")
         await MainActor.run {
             hydrateAccountForReauthenticationIfNeeded()
@@ -398,6 +667,9 @@ class AuthManager {
 
     /// Alwayws used to determin wheather the use has logged in
     func hasRecoverableLoginSession() -> Bool {
+        guard !isAccountDeletionInProgress else {
+            return false
+        }
 #if DEBUG
         if EnvironmentChecker.isRunningPreview {
             return false
@@ -411,6 +683,9 @@ class AuthManager {
     }
     
     func getActiveCredentials() async -> Credentials? {
+        guard !isAccountDeletionInProgress else {
+            return nil
+        }
 #if DEBUG
         if EnvironmentChecker.isRunningPreview {
             return nil
@@ -456,6 +731,10 @@ class AuthManager {
         if hasLocallyValidCredentials {
             do {
                 let credential = try await credentialManager.credentials()
+                guard !isAccountDeletionInProgress else {
+                    _ = clearCredentialStores(postSharedTokenChange: false)
+                    return nil
+                }
                 self.currentCredentials = credential
                 recordTrace(
                     "active-credentials-restored-from-local-store",
@@ -482,10 +761,16 @@ class AuthManager {
     }
     
     func storedUserInfo() -> UserInfo? {
-        credentialManager.user
+        guard !isAccountDeletionInProgress else {
+            return nil
+        }
+        return credentialManager.user
     }
 
     func checkLoginStatusOnChromiumLaunch() -> Bool {
+        guard !isAccountDeletionInProgress else {
+            return false
+        }
         // Hot path: Chromium polls this on every page load / tab change. Once
         // login has finished and we have credentials in memory, the answer is
         // already settled — `transitionToLoggedOutState` clears
@@ -522,6 +807,9 @@ class AuthManager {
     }
     
     func getAccessTokenSyncly() -> String? {
+        guard !isAccountDeletionInProgress else {
+            return nil
+        }
         if hasReauthenticationGraceSession() {
             return nil
         }
@@ -589,6 +877,7 @@ class AuthManager {
     /// fast-path optimization to avoid spawning a Task that the preflight
     /// would immediately skip; the preflight still does its own check.
     func shouldRenewOnReopen() -> Bool {
+        if isAccountDeletionInProgress { return false }
         if isRenewing { return false }
         return shouldRenewNow()
     }
@@ -606,6 +895,10 @@ class AuthManager {
         }
 
         let preflight = await MainActor.run { () -> RenewPreflightDecision in
+            if isAccountDeletionInProgress {
+                recordTrace("renew-skipped", details: ["reason": "account_deletion"])
+                return .skip
+            }
             if hasReauthenticationGraceSession() {
                 recordTrace("renew-skipped", details: ["reason": "reauthentication_required"])
                 AppLogInfo("[TokenRenew] skip renew: reauthentication is required")
@@ -724,7 +1017,7 @@ class AuthManager {
             refreshToken: refreshToken,
             expiresIn: sharedExpiresAt
         )
-        if credentialManager.store(credentials: imported) {
+        if storeCredentialsIfAllowed(imported) {
             self.currentCredentials = imported
             self.lastSuccessfulSyncAt = sharedToken.updatedAt
             recordTrace("renew-imported-shared-token", details: sharedTokenDetails(sharedToken))
@@ -818,6 +1111,15 @@ class AuthManager {
                 }()
 
                 Task { @MainActor in
+                    if self.isAccountDeletionInProgress {
+                        _ = self.clearCredentialStores(postSharedTokenChange: false)
+                        self.currentCredentials = nil
+                        self.isRenewing = false
+                        self.recordTrace("renew-result-discarded-account-deletion")
+                        continuation.resume(returning: nil)
+                        return
+                    }
+
                     switch result {
                     case .success(let credentials):
                         self.lastRenewAttemptAt = Date()
@@ -924,6 +1226,11 @@ class AuthManager {
     func transitionToLoggedOutState() {
         Task { @MainActor [weak self] in
             guard let self else { return }
+            if self.isAccountDeletionInProgress {
+                self.recordTrace("forced-logout-absorbed-account-deletion")
+                _ = self.clearLocalAccountData(postSharedTokenChange: false)
+                return
+            }
             AppLogInfo("transition auth state to login: clearing local credentials after unrecoverable session loss")
             self.clearLocalAccountData()
             LoginController.shared.phase = .login
@@ -1015,12 +1322,17 @@ class AuthManager {
 
     @MainActor
     func storeReauthenticatedCredentials(_ credentials: Credentials) -> Bool {
+        guard !isAccountDeletionInProgress else {
+            return false
+        }
         guard reauthenticatedCredentialsMatchCurrentAccount(credentials) else {
             recordTrace("reauthentication-user-mismatch")
             return false
         }
 
-        _ = credentialManager.store(credentials: credentials)
+        guard storeCredentialsIfAllowed(credentials) else {
+            return false
+        }
         currentCredentials = credentials
         lastRenewAttemptAt = Date()
         if syncSharedTokens(credentials, renewedBy: "phi-reauthentication") {
@@ -1034,7 +1346,8 @@ class AuthManager {
 
     @MainActor
     func hydrateAccountForReauthenticationIfNeeded() {
-        guard AccountController.shared.account == nil,
+        guard !isAccountDeletionInProgress,
+              AccountController.shared.account == nil,
               let storedUserInfo = credentialManager.user else {
             return
         }
@@ -1062,6 +1375,9 @@ class AuthManager {
     }
 
     func recoverFromSharedStoreIfNeeded(reason: String) async {
+        guard !isAccountDeletionInProgress else {
+            return
+        }
         // Read the snapshot we need for the comparison on the main actor first to avoid
         // racing with renew callbacks and timer-driven mutations of `lastSuccessfulSyncAt`.
         let lastSyncedAt = await MainActor.run { lastSuccessfulSyncAt }
@@ -1095,6 +1411,9 @@ class AuthManager {
     /// shared token and leave the SDK with a rotated refresh token.
     @MainActor
     private func applySharedStoreRecoveryLocked(reason: String, lastSyncedAt: Date?) {
+        guard !isAccountDeletionInProgress else {
+            return
+        }
         guard let sharedToken = SharedAuthTokenStore.shared.read() else {
             recordTrace("shared-store-recovery-skipped", details: ["reason": "\(reason):no_shared_token"])
             return
@@ -1154,7 +1473,7 @@ class AuthManager {
             expiresIn: sharedExpiresAt
         )
 
-        if credentialManager.store(credentials: credentials) {
+        if storeCredentialsIfAllowed(credentials) {
             self.currentCredentials = credentials
             self.lastSuccessfulSyncAt = sharedToken.updatedAt
             recordTrace("shared-store-recovery-imported-token", details: sharedTokenDetails(sharedToken))
@@ -1274,6 +1593,9 @@ class AuthManager {
     /// pattern in Sentry if it actually happens.
     @discardableResult
     private func syncSharedTokens(_ credentials: Credentials, renewedBy: String = "phi") -> Bool {
+        guard !isAccountDeletionInProgress else {
+            return false
+        }
         let auth0Sub = User(from: credentials.idToken).sub
         let ok = SharedAuthTokenStore.shared.upsert(
             accessToken: credentials.accessToken,

--- a/Sources/Utilities/SharedAuthTokenStore.swift
+++ b/Sources/Utilities/SharedAuthTokenStore.swift
@@ -175,10 +175,15 @@ final class SharedAuthTokenStore {
         return nil
     }
 
-    func clear() {
+    /// Removes the shared token. Account deletion suppresses the first change
+    /// notification so the signed `accountDeleted` event reaches Sentinel
+    /// before Sentinel drops its in-memory account identity; the final clear
+    /// posts the normal notification.
+    @discardableResult
+    func clear(postChangeNotification: Bool = true) -> Bool {
         guard let accessGroup = resolvedAccessGroup() else {
             log(.error, "[SharedAuthTokenStore] clear failed: no resolvable access group")
-            return
+            return false
         }
 
         let query: [String: Any] = [
@@ -194,13 +199,16 @@ final class SharedAuthTokenStore {
             SecItemDelete(query as CFDictionary)
         }
         if status == errSecSuccess || status == errSecItemNotFound {
-            postDistributedChangeNotification(hasToken: false, auth0Sub: nil)
-            return
+            if postChangeNotification {
+                postDistributedChangeNotification(hasToken: false, auth0Sub: nil)
+            }
+            return true
         }
         // A failed clear leaves a stale (and possibly server-revoked) RT in the
         // shared store. Surface this loudly because subsequent recovery flows
         // will pick that token up and ferrt again.
         log(.error, "[SharedAuthTokenStore] SecItemDelete failed: \(Self.describe(status))")
+        return false
     }
 
     private func resolvedAccessGroup() -> String? {

--- a/Tests/PhiBrowserTests/AccountDeletionCoordinatorTests.swift
+++ b/Tests/PhiBrowserTests/AccountDeletionCoordinatorTests.swift
@@ -12,8 +12,8 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
 
     /// Records every invocation of the finalize edges in order — the
     /// Sentinel announcement plus the destructive edges. Only the finalize
-    /// may reach them — the announcement strictly first, each clear exactly
-    /// once, quit last — and every other path asserts the log stays empty.
+    /// may reach them: the credential fence precedes the announcement and
+    /// surrounds the long local-data removal, and quit runs last.
     private var destructiveEdgeEvents: [String] = []
 
     private func makeCoordinator(
@@ -24,7 +24,10 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
         renewCredentials: @escaping AccountDeletionCoordinator.RenewCredentials = { false },
         makeIdempotencyKey: @escaping () -> String = { "key-1" },
         now: @escaping () -> Date = Date.init,
-        clearCredentials: AccountDeletionCoordinator.ClearCredentials? = nil
+        beginCredentialDeletion: AccountDeletionCoordinator.BeginCredentialDeletion? = nil,
+        clearInitialCredentials: AccountDeletionCoordinator.ClearInitialCredentials? = nil,
+        clearCredentials: AccountDeletionCoordinator.ClearCredentials? = nil,
+        clearLocalData: AccountDeletionCoordinator.ClearLocalData? = nil
     ) -> AccountDeletionCoordinator {
         let coordinator = AccountDeletionCoordinator(
             requestDeletion: requestDeletion,
@@ -33,11 +36,22 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
             announceAccountDeleted: { [weak self] in
                 self?.destructiveEdgeEvents.append("announceAccountDeleted")
             },
+            beginCredentialDeletion: { [weak self] in
+                self?.destructiveEdgeEvents.append("beginCredentialDeletion")
+                return beginCredentialDeletion?() ?? true
+            },
+            clearInitialCredentials: { [weak self] in
+                self?.destructiveEdgeEvents.append("clearInitialCredentials")
+                await clearInitialCredentials?()
+            },
             clearCredentials: { [weak self] in
                 self?.destructiveEdgeEvents.append("clearCredentials")
                 await clearCredentials?()
             },
-            clearLocalData: { [weak self] in self?.destructiveEdgeEvents.append("clearLocalData") },
+            clearLocalData: { [weak self] in
+                self?.destructiveEdgeEvents.append("clearLocalData")
+                await clearLocalData?()
+            },
             quit: { [weak self] in self?.destructiveEdgeEvents.append("quit") },
             now: now,
             makeIdempotencyKey: makeIdempotencyKey
@@ -774,22 +788,49 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
 
     // MARK: - Finalize
 
-    func testFinalizeAnnouncesThenRunsBothClearsOnceThenQuitsLast() async {
-        let coordinator = makeCoordinator()
+    func testFinalizeClearsCredentialsBeforeAndAfterLongLocalDataRemoval() async {
+        var resumeLocalDataRemoval: CheckedContinuation<Void, Never>?
+        let coordinator = makeCoordinator(clearLocalData: {
+            await withCheckedContinuation { resumeLocalDataRemoval = $0 }
+        })
 
         await coordinator.start()
         await coordinator.submitCode("123456")
-        await coordinator.finalizeDeletion()
+
+        let finalize = Task { await coordinator.finalizeDeletion() }
+        await waitUntil { resumeLocalDataRemoval != nil }
 
         XCTAssertEqual(
             destructiveEdgeEvents,
-            ["announceAccountDeleted", "clearLocalData", "clearCredentials", "quit"],
-            "The Sentinel announcement strictly first, before the wipe; each clear exactly once; credentials after the local data's long suspensions, and the quit strictly last"
+            [
+                "beginCredentialDeletion",
+                "announceAccountDeleted",
+                "clearInitialCredentials",
+                "clearLocalData",
+            ],
+            "Credentials must be gone while the long local-data removal is still running"
+        )
+        XCTAssertEqual(coordinator.state, .finalizing)
+
+        resumeLocalDataRemoval?.resume()
+        await finalize.value
+
+        XCTAssertEqual(
+            destructiveEdgeEvents,
+            [
+                "beginCredentialDeletion",
+                "announceAccountDeleted",
+                "clearInitialCredentials",
+                "clearLocalData",
+                "clearCredentials",
+                "quit",
+            ],
+            "The final credential clear catches any write that landed during local-data removal"
         )
         XCTAssertEqual(coordinator.state, .finalizing)
     }
 
-    func testFinalizeFromAlreadyRunningRunsBothClearsOnceThenQuitsLast() async {
+    func testFinalizeFromAlreadyRunningUsesTheSameSafeClearOrder() async {
         var verifyCallCount = 0
         let coordinator = makeCoordinator(
             requestDeletion: { _ in .deletionAlreadyRunning },
@@ -802,10 +843,36 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
         XCTAssertEqual(verifyCallCount, 0, "The already-running branch never verifies")
         XCTAssertEqual(
             destructiveEdgeEvents,
-            ["announceAccountDeleted", "clearLocalData", "clearCredentials", "quit"],
-            "The already-running branch shares the normal finalize: announcement first, each clear exactly once, quit last"
+            [
+                "beginCredentialDeletion",
+                "announceAccountDeleted",
+                "clearInitialCredentials",
+                "clearLocalData",
+                "clearCredentials",
+                "quit",
+            ],
+            "The already-running branch shares the normal safe finalize order"
         )
         XCTAssertEqual(coordinator.state, .finalizing)
+    }
+
+    func testFinalizeStopsWhenCredentialSafetyPreflightFails() async {
+        let coordinator = makeCoordinator(beginCredentialDeletion: { false })
+
+        await coordinator.start()
+        await coordinator.submitCode("123456")
+        await coordinator.finalizeDeletion()
+
+        XCTAssertEqual(
+            destructiveEdgeEvents,
+            ["beginCredentialDeletion"],
+            "A failed lock or fence preflight must stop before notifying Sentinel, suspending cleanup, or quit"
+        )
+        XCTAssertEqual(
+            coordinator.state,
+            .requestSubmitted,
+            "The booked deletion remains retryable from the confirmation step"
+        )
     }
 
     func testFinalizeBeforeSubmissionIsIgnored() async {
@@ -822,45 +889,52 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
     }
 
     func testFinalizeWhileFinalizeInFlightIsIgnored() async {
-        var resumeClear: CheckedContinuation<Void, Never>?
-        let coordinator = makeCoordinator(clearCredentials: {
-            await withCheckedContinuation { resumeClear = $0 }
+        var resumeLocalDataRemoval: CheckedContinuation<Void, Never>?
+        let coordinator = makeCoordinator(clearLocalData: {
+            await withCheckedContinuation { resumeLocalDataRemoval = $0 }
         })
 
         await coordinator.start()
         await coordinator.submitCode("123456")
 
         let firstFinalize = Task { await coordinator.finalizeDeletion() }
-        await waitUntil { resumeClear != nil }
+        await waitUntil { resumeLocalDataRemoval != nil }
 
         await coordinator.finalizeDeletion()
 
-        resumeClear?.resume()
+        resumeLocalDataRemoval?.resume()
         await firstFinalize.value
 
         XCTAssertEqual(
             destructiveEdgeEvents,
-            ["announceAccountDeleted", "clearLocalData", "clearCredentials", "quit"],
-            "A double click on the confirmation must not announce or run the clears twice"
+            [
+                "beginCredentialDeletion",
+                "announceAccountDeleted",
+                "clearInitialCredentials",
+                "clearLocalData",
+                "clearCredentials",
+                "quit",
+            ],
+            "A double click on the confirmation must not start another finalize sequence"
         )
     }
 
     func testCancelDuringFinalizeIsIgnored() async {
-        var resumeClear: CheckedContinuation<Void, Never>?
-        let coordinator = makeCoordinator(clearCredentials: {
-            await withCheckedContinuation { resumeClear = $0 }
+        var resumeLocalDataRemoval: CheckedContinuation<Void, Never>?
+        let coordinator = makeCoordinator(clearLocalData: {
+            await withCheckedContinuation { resumeLocalDataRemoval = $0 }
         })
 
         await coordinator.start()
         await coordinator.submitCode("123456")
 
         let finalize = Task { await coordinator.finalizeDeletion() }
-        await waitUntil { resumeClear != nil }
+        await waitUntil { resumeLocalDataRemoval != nil }
 
         coordinator.cancel()
         XCTAssertEqual(coordinator.state, .finalizing)
 
-        resumeClear?.resume()
+        resumeLocalDataRemoval?.resume()
         await finalize.value
 
         XCTAssertEqual(destructiveEdgeEvents.last, "quit")
@@ -868,14 +942,14 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
 
     func testStartDuringFinalizeIsIgnored() async {
         var requestCallCount = 0
-        var resumeClear: CheckedContinuation<Void, Never>?
+        var resumeLocalDataRemoval: CheckedContinuation<Void, Never>?
         let coordinator = makeCoordinator(
             requestDeletion: { _ in
                 requestCallCount += 1
                 return .verificationCodeSent(requestID: "req-1")
             },
-            clearCredentials: {
-                await withCheckedContinuation { resumeClear = $0 }
+            clearLocalData: {
+                await withCheckedContinuation { resumeLocalDataRemoval = $0 }
             }
         )
 
@@ -883,12 +957,12 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
         await coordinator.submitCode("123456")
 
         let finalize = Task { await coordinator.finalizeDeletion() }
-        await waitUntil { resumeClear != nil }
+        await waitUntil { resumeLocalDataRemoval != nil }
 
         await coordinator.start()
         XCTAssertEqual(requestCallCount, 1)
 
-        resumeClear?.resume()
+        resumeLocalDataRemoval?.resume()
         await finalize.value
     }
 
@@ -933,5 +1007,64 @@ final class AccountDeletionCoordinatorTests: XCTestCase {
             ),
             "With nothing cached beforehand, any renewed credentials are worth the retry"
         )
+    }
+}
+
+final class AccountDeletionCredentialFenceTests: XCTestCase {
+    func testFencePersistsUntilExplicitlyDeactivated() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        let markerURL = directory.appendingPathComponent("credential-fence")
+        let firstInstance = AccountDeletionCredentialFence(markerURL: markerURL)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        XCTAssertFalse(firstInstance.isActive)
+        XCTAssertTrue(firstInstance.activate())
+
+        let relaunchedInstance = AccountDeletionCredentialFence(markerURL: markerURL)
+        XCTAssertTrue(relaunchedInstance.isActive)
+        XCTAssertTrue(relaunchedInstance.deactivate())
+        XCTAssertFalse(firstInstance.isActive)
+    }
+}
+
+final class AccountDeletionExternalBrowserAuthGateTests: XCTestCase {
+    func testOnlyAuthorizedReplacementLoginCallbackPassesDeletionFence() {
+        let authManager = AuthManager()
+        let authorizedToken = UUID()
+        let callbackURL = URL(string: "https://\(authManager.domain)/callback")!
+        var receivedURL: URL?
+
+        authManager.setAccountDeletionInProgress(true)
+        authManager.setAccountDeletionReplacementLoginToken(authorizedToken)
+        defer {
+            authManager.clearBrowserAuthCallbackListener()
+            authManager.clearAccountDeletionReplacementLoginToken()
+            authManager.setAccountDeletionInProgress(false)
+        }
+
+        _ = authManager.registerBrowserAuthCallbackListener(
+            { receivedURL = $0 },
+            accountDeletionReplacementLoginToken: nil
+        )
+        XCTAssertFalse(authManager.resumeExternalBrowserAuthentication(with: callbackURL))
+        XCTAssertNil(receivedURL)
+
+        _ = authManager.registerBrowserAuthCallbackListener(
+            { receivedURL = $0 },
+            accountDeletionReplacementLoginToken: UUID()
+        )
+        XCTAssertFalse(authManager.resumeExternalBrowserAuthentication(with: callbackURL))
+        XCTAssertNil(receivedURL)
+
+        let unregister = authManager.registerBrowserAuthCallbackListener(
+            { receivedURL = $0 },
+            accountDeletionReplacementLoginToken: authorizedToken
+        )
+        XCTAssertTrue(authManager.resumeExternalBrowserAuthentication(with: callbackURL))
+        XCTAssertEqual(receivedURL, callbackURL)
+        unregister()
     }
 }

--- a/Tests/PhiBrowserTests/PhiUserDataExportTests.swift
+++ b/Tests/PhiBrowserTests/PhiUserDataExportTests.swift
@@ -1,0 +1,237 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+import XCTest
+@testable import Phi
+
+final class PhiUserDataExportTests: XCTestCase {
+    func testSelectionRequiresAtLeastOneCategory() {
+        XCTAssertFalse(PhiUserDataExportSelection(
+            includeBrowserData: false,
+            includeAIData: false
+        ).isExportable)
+        XCTAssertTrue(PhiUserDataExportSelection(
+            includeBrowserData: true,
+            includeAIData: false
+        ).isExportable)
+        XCTAssertTrue(PhiUserDataExportSelection(
+            includeBrowserData: false,
+            includeAIData: true
+        ).isExportable)
+    }
+
+    func testSentinelExportSessionUsesScopedCanonicalPath() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let requestID = UUID()
+
+        let session = try SentinelAIDataExportSession.prepare(
+            sharedContainerURL: root,
+            sentinelBundleID: "com.phibrowser.canary.Sentinel",
+            requestID: requestID
+        )
+
+        XCTAssertEqual(session.requestID, requestID)
+        XCTAssertEqual(
+            session.archiveURL,
+            root
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Caches", isDirectory: true)
+                .appendingPathComponent("SentinelExports", isDirectory: true)
+                .appendingPathComponent("com.phibrowser.canary.Sentinel", isDirectory: true)
+                .appendingPathComponent(requestID.uuidString, isDirectory: true)
+                .appendingPathComponent("ai-data.tar.gz")
+        )
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: session.directoryURL.path,
+            isDirectory: &isDirectory
+        ))
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    func testLateWriteOutcomesRetainSessionForExpirationCleanup() {
+        XCTAssertTrue(
+            AIDataExportCoordinator.SkipReason.timedOut
+                .shouldRetainSessionForLateWrite
+        )
+        XCTAssertTrue(
+            AIDataExportCoordinator.SkipReason.invalidResponsePath
+                .shouldRetainSessionForLateWrite
+        )
+        XCTAssertTrue(
+            AIDataExportCoordinator.SkipReason.cancelled
+                .shouldRetainSessionForLateWrite
+        )
+        XCTAssertFalse(
+            AIDataExportCoordinator.SkipReason.sentinelUnavailable
+                .shouldRetainSessionForLateWrite
+        )
+        XCTAssertFalse(
+            AIDataExportCoordinator.SkipReason.exportFailed
+                .shouldRetainSessionForLateWrite
+        )
+    }
+
+    func testPreparingSessionRemovesExpiredSibling() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let now = Date(timeIntervalSince1970: 2_000_000)
+        let expired = try SentinelAIDataExportSession.prepare(
+            sharedContainerURL: root,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            requestID: UUID(),
+            now: now
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-25 * 60 * 60)],
+            ofItemAtPath: expired.directoryURL.path
+        )
+
+        _ = try SentinelAIDataExportSession.prepare(
+            sharedContainerURL: root,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            requestID: UUID(),
+            now: now
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: expired.directoryURL.path
+        ))
+    }
+
+    func testAppendAIDataArchiveUsesCanonicalRootEntryName() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let source = root.appendingPathComponent("sentinel-export.tar.gz")
+        let destination = root.appendingPathComponent("backup.zip")
+        try Data("AI backup".utf8).write(to: source)
+
+        try AppController.appendAIDataArchive(source, to: destination)
+
+        XCTAssertEqual(
+            try zipEntries(in: destination),
+            ["ai-data.tar.gz"]
+        )
+    }
+
+    func testAppendAIDataArchivePreservesExistingBrowserRoot() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let phiDirectory = root.appendingPathComponent("Phi", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: phiDirectory,
+            withIntermediateDirectories: false
+        )
+        try Data("browser".utf8).write(
+            to: phiDirectory.appendingPathComponent("state.json")
+        )
+        let destination = root.appendingPathComponent("backup.zip")
+        try run(
+            executable: "/usr/bin/zip",
+            arguments: ["-r", "-q", destination.path, "Phi"],
+            currentDirectory: root
+        )
+
+        let aiArchive = root.appendingPathComponent("ai-data.tar.gz")
+        try Data("AI backup".utf8).write(to: aiArchive)
+        try AppController.appendAIDataArchive(aiArchive, to: destination)
+
+        XCTAssertEqual(
+            Set(try zipEntries(in: destination)),
+            Set(["Phi/", "Phi/state.json", "ai-data.tar.gz"])
+        )
+    }
+
+    func testAppendAIDataArchiveRejectsSymbolicLink() throws {
+        let root = makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let archiveTarget = root.appendingPathComponent("target.tar.gz")
+        let archiveLink = root.appendingPathComponent("ai-data.tar.gz")
+        let destination = root.appendingPathComponent("backup.zip")
+        try Data("not Sentinel output".utf8).write(to: archiveTarget)
+        try FileManager.default.createSymbolicLink(
+            at: archiveLink,
+            withDestinationURL: archiveTarget
+        )
+
+        XCTAssertThrowsError(
+            try AppController.appendAIDataArchive(
+                archiveLink,
+                to: destination
+            )
+        )
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: destination.path
+        ))
+    }
+
+    private func makeTemporaryDirectory() -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "PhiUserDataExportTests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try! FileManager.default.createDirectory(
+            at: url,
+            withIntermediateDirectories: false
+        )
+        return url
+    }
+
+    private func zipEntries(in archive: URL) throws -> [String] {
+        let output = try run(
+            executable: "/usr/bin/unzip",
+            arguments: ["-Z1", archive.path]
+        )
+        return output
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+    }
+
+    @discardableResult
+    private func run(
+        executable: String,
+        arguments: [String],
+        currentDirectory: URL? = nil
+    ) throws -> String {
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectory
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+        try process.run()
+        process.waitUntilExit()
+
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0 else {
+            let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+            throw NSError(
+                domain: "PhiUserDataExportTests",
+                code: Int(process.terminationStatus),
+                userInfo: [
+                    NSLocalizedDescriptionKey: String(
+                        data: errorData,
+                        encoding: .utf8
+                    ) ?? "Command failed"
+                ]
+            )
+        }
+        return String(data: outputData, encoding: .utf8) ?? ""
+    }
+}

--- a/Tests/PhiBrowserTests/SentinelAccountDeletedEventTests.swift
+++ b/Tests/PhiBrowserTests/SentinelAccountDeletedEventTests.swift
@@ -7,12 +7,16 @@ import XCTest
 @testable import Phi
 
 final class SentinelAccountDeletedEventTests: XCTestCase {
-    func testBuildsAccountDeletedEventWithAuth0Sub() {
-        let event = SentinelAccountDeletedEvent.make(
+    private let signingKey = Data((0..<32).map(UInt8.init))
+
+    func testMatchesPublishedCompatibilityVector() throws {
+        let event = try SentinelAccountDeletedEvent.make(
             sentinelBundleID: "com.phibrowser.Sentinel",
             browserBundleID: "com.phibrowser.Mac",
             auth0Sub: "auth0|user-1",
-            requestID: "request-1"
+            signingKey: signingKey,
+            requestID: "request-1",
+            issuedAt: "1784800000"
         )
 
         XCTAssertEqual(
@@ -20,31 +24,238 @@ final class SentinelAccountDeletedEventTests: XCTestCase {
             "com.phibrowser.sentinel.accountDeleted"
         )
         XCTAssertEqual(event.sentinelBundleID, "com.phibrowser.Sentinel")
+        XCTAssertEqual(event.signature, "YU0BmgiXGqCSVOqdghK1/rsVOxE1KWKwpd0l6o9ipgY=")
         XCTAssertEqual(
             event.userInfo,
             [
+                "signatureVersion": "1",
                 "requestID": "request-1",
                 "browserBundleID": "com.phibrowser.Mac",
-                "auth0Sub": "auth0|user-1"
+                "auth0Sub": "auth0|user-1",
+                "issuedAt": "1784800000",
+                "signature": "YU0BmgiXGqCSVOqdghK1/rsVOxE1KWKwpd0l6o9ipgY="
             ]
         )
     }
 
-    func testOmitsAuth0SubWhenTokenUnreadable() {
-        let event = SentinelAccountDeletedEvent.make(
+    func testSignedContentIncludesStableAndCanaryBundlePairs() throws {
+        let stable = try SentinelAccountDeletedEvent.make(
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            auth0Sub: "auth0|user-1",
+            signingKey: signingKey,
+            requestID: "stable-request",
+            issuedAt: "1784800000"
+        )
+        let canary = try SentinelAccountDeletedEvent.make(
             sentinelBundleID: "com.phibrowser.canary.Sentinel",
             browserBundleID: "com.phibrowser.canary.Mac",
-            auth0Sub: nil,
-            requestID: "request-2"
+            auth0Sub: "auth0|user-1",
+            signingKey: signingKey,
+            requestID: "canary-request",
+            issuedAt: "1784800000"
         )
 
         XCTAssertEqual(
-            event.userInfo,
-            [
-                "requestID": "request-2",
-                "browserBundleID": "com.phibrowser.canary.Mac"
-            ],
-            "A missing sub must be omitted, not sent as an empty string"
+            stable.signedContent,
+            AccountDeletedSignedContent(
+                signatureVersion: "1",
+                notificationName: "com.phibrowser.sentinel.accountDeleted",
+                sentinelBundleID: "com.phibrowser.Sentinel",
+                browserBundleID: "com.phibrowser.Mac",
+                requestID: "stable-request",
+                auth0Sub: "auth0|user-1",
+                issuedAt: "1784800000"
+            )
         )
+        XCTAssertEqual(
+            canary.signedContent,
+            AccountDeletedSignedContent(
+                signatureVersion: "1",
+                notificationName: "com.phibrowser.sentinel.accountDeleted",
+                sentinelBundleID: "com.phibrowser.canary.Sentinel",
+                browserBundleID: "com.phibrowser.canary.Mac",
+                requestID: "canary-request",
+                auth0Sub: "auth0|user-1",
+                issuedAt: "1784800000"
+            )
+        )
+    }
+
+    func testRejectsMissingOrEmptyAuth0Sub() {
+        for auth0Sub in [nil, ""] {
+            XCTAssertThrowsError(
+                try SentinelAccountDeletedEvent.make(
+                    sentinelBundleID: "com.phibrowser.Sentinel",
+                    browserBundleID: "com.phibrowser.Mac",
+                    auth0Sub: auth0Sub,
+                    signingKey: signingKey,
+                    requestID: "request-1",
+                    issuedAt: "1784800000"
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? SentinelAccountDeletedEventError,
+                    .missingField("auth0Sub")
+                )
+            }
+        }
+    }
+
+    func testRejectsMissingOrMalformedSigningKey() {
+        let keys: [Data?] = [nil, Data(), Data(repeating: 0, count: 31), Data(repeating: 0, count: 33)]
+
+        for key in keys {
+            XCTAssertThrowsError(
+                try SentinelAccountDeletedEvent.make(
+                    sentinelBundleID: "com.phibrowser.Sentinel",
+                    browserBundleID: "com.phibrowser.Mac",
+                    auth0Sub: "auth0|user-1",
+                    signingKey: key,
+                    requestID: "request-1",
+                    issuedAt: "1784800000"
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? SentinelAccountDeletedEventError,
+                    .signingKeyUnavailable
+                )
+            }
+        }
+    }
+
+    func testEverySignedFieldChangesTheSignature() throws {
+        let content = AccountDeletedSignedContent(
+            signatureVersion: "1",
+            notificationName: "com.phibrowser.sentinel.accountDeleted",
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            requestID: "request-1",
+            auth0Sub: "auth0|user-1",
+            issuedAt: "1784800000"
+        )
+        let original = try AccountDeletedEventAuthentication.signature(
+            for: content,
+            key: signingKey
+        )
+        let changedContents = [
+            AccountDeletedSignedContent(
+                signatureVersion: "2",
+                notificationName: content.notificationName,
+                sentinelBundleID: content.sentinelBundleID,
+                browserBundleID: content.browserBundleID,
+                requestID: content.requestID,
+                auth0Sub: content.auth0Sub,
+                issuedAt: content.issuedAt
+            ),
+            AccountDeletedSignedContent(
+                signatureVersion: content.signatureVersion,
+                notificationName: "com.phibrowser.sentinel.other",
+                sentinelBundleID: content.sentinelBundleID,
+                browserBundleID: content.browserBundleID,
+                requestID: content.requestID,
+                auth0Sub: content.auth0Sub,
+                issuedAt: content.issuedAt
+            ),
+            AccountDeletedSignedContent(
+                signatureVersion: content.signatureVersion,
+                notificationName: content.notificationName,
+                sentinelBundleID: "com.phibrowser.canary.Sentinel",
+                browserBundleID: content.browserBundleID,
+                requestID: content.requestID,
+                auth0Sub: content.auth0Sub,
+                issuedAt: content.issuedAt
+            ),
+            AccountDeletedSignedContent(
+                signatureVersion: content.signatureVersion,
+                notificationName: content.notificationName,
+                sentinelBundleID: content.sentinelBundleID,
+                browserBundleID: "com.phibrowser.canary.Mac",
+                requestID: content.requestID,
+                auth0Sub: content.auth0Sub,
+                issuedAt: content.issuedAt
+            ),
+            AccountDeletedSignedContent(
+                signatureVersion: content.signatureVersion,
+                notificationName: content.notificationName,
+                sentinelBundleID: content.sentinelBundleID,
+                browserBundleID: content.browserBundleID,
+                requestID: "request-2",
+                auth0Sub: content.auth0Sub,
+                issuedAt: content.issuedAt
+            ),
+            AccountDeletedSignedContent(
+                signatureVersion: content.signatureVersion,
+                notificationName: content.notificationName,
+                sentinelBundleID: content.sentinelBundleID,
+                browserBundleID: content.browserBundleID,
+                requestID: content.requestID,
+                auth0Sub: "auth0|user-2",
+                issuedAt: content.issuedAt
+            ),
+            AccountDeletedSignedContent(
+                signatureVersion: content.signatureVersion,
+                notificationName: content.notificationName,
+                sentinelBundleID: content.sentinelBundleID,
+                browserBundleID: content.browserBundleID,
+                requestID: content.requestID,
+                auth0Sub: content.auth0Sub,
+                issuedAt: "1784800001"
+            )
+        ]
+
+        for changedContent in changedContents {
+            XCTAssertNotEqual(
+                try AccountDeletedEventAuthentication.signature(
+                    for: changedContent,
+                    key: signingKey
+                ),
+                original
+            )
+        }
+    }
+
+    func testRejectsNonIntegerIssuedAt() {
+        XCTAssertThrowsError(
+            try SentinelAccountDeletedEvent.make(
+                sentinelBundleID: "com.phibrowser.Sentinel",
+                browserBundleID: "com.phibrowser.Mac",
+                auth0Sub: "auth0|user-1",
+                signingKey: signingKey,
+                requestID: "request-1",
+                issuedAt: "1784800000.5"
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SentinelAccountDeletedEventError,
+                .invalidIssuedAt
+            )
+        }
+    }
+
+    func testRejectsEmptyBundleAndRequestIdentifiers() {
+        let cases = [
+            ("", "com.phibrowser.Mac", "request-1", "sentinelBundleID"),
+            ("com.phibrowser.Sentinel", "", "request-1", "browserBundleID"),
+            ("com.phibrowser.Sentinel", "com.phibrowser.Mac", "", "requestID")
+        ]
+
+        for (sentinelBundleID, browserBundleID, requestID, missingField) in cases {
+            XCTAssertThrowsError(
+                try SentinelAccountDeletedEvent.make(
+                    sentinelBundleID: sentinelBundleID,
+                    browserBundleID: browserBundleID,
+                    auth0Sub: "auth0|user-1",
+                    signingKey: signingKey,
+                    requestID: requestID,
+                    issuedAt: "1784800000"
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? SentinelAccountDeletedEventError,
+                    .missingField(missingField)
+                )
+            }
+        }
     }
 }

--- a/Tests/PhiBrowserTests/SentinelBackupCoordinationTests.swift
+++ b/Tests/PhiBrowserTests/SentinelBackupCoordinationTests.swift
@@ -1,0 +1,432 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import XCTest
+@testable import Phi
+
+final class SentinelBackupCoordinationTests: XCTestCase {
+    func testExportContractNamesAndPayload() {
+        XCTAssertEqual(
+            SentinelAIDataExport.requestName.rawValue,
+            "com.phibrowser.sentinel.exportAIData.request"
+        )
+        XCTAssertEqual(
+            SentinelAIDataExport.responseName.rawValue,
+            "com.phibrowser.sentinel.exportAIData.response"
+        )
+
+        XCTAssertEqual(
+            SentinelAIDataExport.requestUserInfo(
+                requestID: "request-1",
+                destinationPath: "/tmp/ai-data.tar.gz"
+            ),
+            [
+                "requestID": "request-1",
+                "destinationPath": "/tmp/ai-data.tar.gz"
+            ]
+        )
+
+        XCTAssertEqual(
+            SentinelAIDataExport.parseResponse([
+                "status": "completed",
+                "path": "/tmp/ai-data.tar.gz"
+            ]),
+            .init(
+                status: .completed,
+                path: "/tmp/ai-data.tar.gz",
+                error: nil
+            )
+        )
+        XCTAssertNil(SentinelAIDataExport.parseResponse(["status": "unknown"]))
+    }
+
+    func testClientRoutesRequestAndInjectsBrowserBundleID() async {
+        let transport = TestSentinelNotificationTransport()
+        transport.onPost = { posted in
+            transport.deliver(
+                name: SentinelAIDataExport.responseName,
+                object: posted.object,
+                userInfo: [
+                    "requestID": posted.userInfo["requestID"] ?? "",
+                    "status": "completed",
+                    "path": posted.userInfo["destinationPath"] ?? ""
+                ]
+            )
+        }
+        let client = SentinelBackupCoordinationClient(
+            transport: transport,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            retryDelays: [0]
+        )
+
+        let result = await client.requestExportAIData(
+            requestID: "request-1",
+            destinationPath: "/tmp/ai-data.tar.gz",
+            timeout: 1
+        )
+
+        guard case .response(let response) = result else {
+            return XCTFail("Expected completed response")
+        }
+        XCTAssertEqual(response.status, .completed)
+        XCTAssertEqual(transport.posts.count, 1)
+        XCTAssertEqual(
+            transport.posts.first?.userInfo["browserBundleID"],
+            "com.phibrowser.Mac"
+        )
+        XCTAssertEqual(
+            transport.observedObjects,
+            ["com.phibrowser.Sentinel"]
+        )
+        XCTAssertEqual(transport.activeSubscriptionCount, 0)
+    }
+
+    func testClientIgnoresMismatchedRequestID() async {
+        let transport = TestSentinelNotificationTransport()
+        transport.onPost = { posted in
+            transport.deliver(
+                name: SentinelAIDataExport.responseName,
+                object: posted.object,
+                userInfo: [
+                    "requestID": "another-request",
+                    "status": "completed",
+                    "path": "/tmp/ai-data.tar.gz"
+                ]
+            )
+        }
+        let client = SentinelBackupCoordinationClient(
+            transport: transport,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            retryDelays: [0]
+        )
+
+        let result = await client.requestExportAIData(
+            requestID: "request-1",
+            destinationPath: "/tmp/ai-data.tar.gz",
+            timeout: 0.01
+        )
+
+        guard case .timedOut = result else {
+            return XCTFail("Expected timeout")
+        }
+        XCTAssertEqual(transport.activeSubscriptionCount, 0)
+    }
+
+    func testClientRetriesUntilSentinelResponds() async {
+        let transport = TestSentinelNotificationTransport()
+        transport.onPost = { posted in
+            guard transport.posts.count == 3 else {
+                return
+            }
+            transport.deliver(
+                name: SentinelAIDataExport.responseName,
+                object: posted.object,
+                userInfo: [
+                    "requestID": posted.userInfo["requestID"] ?? "",
+                    "status": "completed",
+                    "path": posted.userInfo["destinationPath"] ?? ""
+                ]
+            )
+        }
+        let client = SentinelBackupCoordinationClient(
+            transport: transport,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            retryDelays: [0, 0.01, 0.02]
+        )
+
+        let result = await client.requestExportAIData(
+            requestID: "request-1",
+            destinationPath: "/tmp/ai-data.tar.gz",
+            timeout: 1
+        )
+
+        guard case .response(let response) = result else {
+            return XCTFail("Expected completed response after retries")
+        }
+        XCTAssertEqual(response.status, .completed)
+        XCTAssertEqual(transport.posts.count, 3)
+        XCTAssertEqual(transport.activeSubscriptionCount, 0)
+    }
+
+    func testClientCancellationStopsWaitingAndRetries() async {
+        let transport = TestSentinelNotificationTransport()
+        let client = SentinelBackupCoordinationClient(
+            transport: transport,
+            sentinelBundleID: "com.phibrowser.Sentinel",
+            browserBundleID: "com.phibrowser.Mac",
+            retryDelays: [0, 1]
+        )
+
+        let requestTask = Task {
+            await client.requestExportAIData(
+                requestID: "request-1",
+                destinationPath: "/tmp/ai-data.tar.gz",
+                timeout: 60
+            )
+        }
+        for _ in 0..<100 where transport.posts.isEmpty {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(transport.posts.count, 1)
+        XCTAssertEqual(transport.activeSubscriptionCount, 1)
+
+        requestTask.cancel()
+        let result = await requestTask.value
+        guard case .cancelled = result else {
+            return XCTFail("Expected cancellation")
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        XCTAssertEqual(transport.posts.count, 1)
+        XCTAssertEqual(transport.activeSubscriptionCount, 0)
+    }
+}
+
+final class AIDataExportCoordinatorTests: XCTestCase {
+    func testUnavailableSentinelSkipsExport() async {
+        let coordinator = makeCoordinator(
+            ensureSentinelRunning: { false },
+            response: .timedOut,
+            isRegularFile: { _ in true }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .sentinelUnavailable))
+    }
+
+    func testCompletedExportRequiresExactExpectedPath() async {
+        let coordinator = makeCoordinator(
+            response: .response(.init(
+                status: .completed,
+                path: "/tmp/unexpected.tar.gz",
+                error: nil
+            )),
+            isRegularFile: { _ in true }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .invalidResponsePath))
+    }
+
+    func testCompletedExportRejectsNormalizedEquivalentPath() async {
+        let coordinator = makeCoordinator(
+            response: .response(.init(
+                status: .completed,
+                path: "/tmp/subdirectory/../ai-data.tar.gz",
+                error: nil
+            )),
+            isRegularFile: { _ in true }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .invalidResponsePath))
+    }
+
+    func testCompletedExportRequiresRegularFile() async {
+        let coordinator = makeCoordinator(
+            response: .response(.init(
+                status: .completed,
+                path: "/tmp/ai-data.tar.gz",
+                error: nil
+            )),
+            isRegularFile: { _ in false }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .exportFailed))
+    }
+
+    func testCompletedExportReturnsExpectedArchive() async {
+        let expectedURL = URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        let coordinator = makeCoordinator(
+            response: .response(.init(
+                status: .completed,
+                path: expectedURL.path,
+                error: nil
+            )),
+            isRegularFile: { $0 == expectedURL }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: expectedURL
+        )
+
+        XCTAssertEqual(result, .packed(tarURL: expectedURL))
+    }
+
+    func testCancelledRequestSkipsExport() async {
+        let coordinator = makeCoordinator(
+            response: .cancelled,
+            isRegularFile: { _ in true }
+        )
+
+        let result = await coordinator.coordinate(
+            requestID: "request-1",
+            destinationTarURL: URL(fileURLWithPath: "/tmp/ai-data.tar.gz")
+        )
+
+        XCTAssertEqual(result, .skipped(reason: .cancelled))
+    }
+
+    private func makeCoordinator(
+        ensureSentinelRunning: @escaping () async -> Bool = { true },
+        response: SentinelCoordinationResult<SentinelAIDataExport.Response>,
+        isRegularFile: @escaping (URL) -> Bool
+    ) -> AIDataExportCoordinator {
+        AIDataExportCoordinator(
+            ensureSentinelRunning: ensureSentinelRunning,
+            requestExport: { _, _ in response },
+            isRegularFile: isRegularFile,
+            isCancelled: { false }
+        )
+    }
+}
+
+private final class TestSentinelNotificationTransport:
+    SentinelNotificationTransport
+{
+    struct Posted {
+        let name: Notification.Name
+        let object: String
+        let userInfo: [String: String]
+    }
+
+    private final class Registration {
+        let name: Notification.Name
+        let object: String
+        let handler: ([String: String]) -> Void
+        var isCancelled = false
+
+        init(
+            name: Notification.Name,
+            object: String,
+            handler: @escaping ([String: String]) -> Void
+        ) {
+            self.name = name
+            self.object = object
+            self.handler = handler
+        }
+    }
+
+    private final class Subscription: SentinelNotificationSubscription {
+        private let onCancel: () -> Void
+
+        init(onCancel: @escaping () -> Void) {
+            self.onCancel = onCancel
+        }
+
+        func cancel() {
+            onCancel()
+        }
+    }
+
+    private let lock = NSLock()
+    private var storedPosts: [Posted] = []
+    private var storedObservedObjects: [String] = []
+    private var registrations: [Registration] = []
+    var onPost: ((Posted) -> Void)?
+
+    var posts: [Posted] {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return storedPosts
+    }
+
+    var observedObjects: [String] {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return storedObservedObjects
+    }
+
+    var activeSubscriptionCount: Int {
+        lock.lock()
+        defer {
+            lock.unlock()
+        }
+        return registrations.filter { !$0.isCancelled }.count
+    }
+
+    func post(
+        name: Notification.Name,
+        object: String,
+        userInfo: [String: String]
+    ) {
+        let posted = Posted(
+            name: name,
+            object: object,
+            userInfo: userInfo
+        )
+        lock.lock()
+        storedPosts.append(posted)
+        let onPost = onPost
+        lock.unlock()
+        onPost?(posted)
+    }
+
+    func observe(
+        name: Notification.Name,
+        object: String,
+        handler: @escaping ([String: String]) -> Void
+    ) -> SentinelNotificationSubscription {
+        let registration = Registration(
+            name: name,
+            object: object,
+            handler: handler
+        )
+        lock.lock()
+        registrations.append(registration)
+        storedObservedObjects.append(object)
+        lock.unlock()
+        return Subscription {
+            self.lock.lock()
+            registration.isCancelled = true
+            self.lock.unlock()
+        }
+    }
+
+    func deliver(
+        name: Notification.Name,
+        object: String,
+        userInfo: [String: String]
+    ) {
+        lock.lock()
+        let handlers: [([String: String]) -> Void] =
+            registrations.compactMap { registration in
+                guard !registration.isCancelled,
+                      registration.name == name,
+                      registration.object == object else {
+                    return nil
+                }
+                return registration.handler
+            }
+        lock.unlock()
+        for handler in handlers {
+            handler(userInfo)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- authenticate Sentinel account-deleted events and fence credential cleanup against stale account state
- clear local account data and shared credentials safely during account deletion
- coordinate Sentinel AI data export as part of browser user-data backups
- include focused account-deletion and export coordination tests

## Included work

- `40829127` Fix account deletion credential fencing
- #77 Sentinel AI data export

## Verification

- Canary build succeeded
- focused account-deletion and export tests passed