### PR TITLE
test: restore ExtensionMessageRouter coverage

### DIFF
--- a/Tests/PhiBrowserTests/ExtensionMessagingTests.swift
+++ b/Tests/PhiBrowserTests/ExtensionMessagingTests.swift
@@ -3,95 +3,59 @@
 // Use of this source code is governed by an Apache license that can be
 // found in the LICENSE file.
 
-// TODO: Rewrite against the current ExtensionMessageRouter API.
-//
-// Original tests (commented out below) targeted an older API that has
-// since been refactored:
-//   - `ExtensionMessageEnvelope` (struct with action/version/correlationId/payload)
-//     was replaced by `ExtensionMessageContext`.
-//   - `router.register(action:)` / `register(actions:)` was replaced by
-//     `register(type:handler:)`.
-//   - `router.handle(message:requestId:)` (taking a JSON-encoded envelope
-//     string) was replaced by `handle(type:payload:requestId:)`.
-//
-// The change landed in `1a42a268 merge: sync code from 1.1.0 branch` but
-// this test file was never updated, leaving the PhiBrowserTests target
-// uncompilable on `dev` and feature branches alike. Stubbed out so unit
-// tests can run; rewrite when the router behaviour is being touched
-// again.
-
-import XCTest
-
-final class ExtensionMessagingTests: XCTestCase {
-    func testPlaceholder() {
-        // Stubbed; see file header.
-    }
-}
-
-/*
 import XCTest
 @testable import Phi
 
 final class ExtensionMessagingTests: XCTestCase {
-    func testEnvelopeEncodeDecodeRoundTrip() throws {
-        let payload: [String: AnyCodable] = ["k": .string("v")]
-        let envelope = ExtensionMessageEnvelope(
-            action: "notification.card.request",
-            version: "1",
-            correlationId: "req-1",
-            payload: payload
-        )
-        let data = try envelope.encode()
-        let decoded = try ExtensionMessageEnvelope.decode(from: data)
-        XCTAssertEqual(decoded.action, "notification.card.request")
-        XCTAssertEqual(decoded.version, "1")
-        XCTAssertEqual(decoded.correlationId, "req-1")
-        XCTAssertEqual(decoded.payload?["k"]?.stringValue, "v")
-    }
-
-    func testRouterDispatchesByAction() throws {
+    func testRegisteredHandlerReceivesContextAndReturnsResponse() {
         let router = ExtensionMessageRouter()
-        var handled = false
-        router.register(action: "notification.card.request") { _ in
-            handled = true
-            return nil
-        }
-        let envelope = ExtensionMessageEnvelope(
-            action: "notification.card.request",
-            version: "1",
-            correlationId: "req-2",
-            payload: [:]
-        )
-        let data = try envelope.encode()
-        _ = router.handle(message: String(data: data, encoding: .utf8)!, requestId: "req-2")
-        XCTAssertTrue(handled)
-    }
-
-    func testRouterRegistersMultipleActions() throws {
-        let router = ExtensionMessageRouter()
-        var handled: [String] = []
-        router.register(actions: "notification.card.request", "notification.card.response") { envelope in
-            handled.append(envelope.action)
-            return nil
+        var receivedContext: ExtensionMessageContext?
+        router.register(type: "test.echo") { context in
+            receivedContext = context
+            return #"{"ok":true}"#
         }
 
-        let request = ExtensionMessageEnvelope(
-            action: "notification.card.request",
-            version: "1",
-            correlationId: "req-3",
-            payload: [:]
-        )
-        let response = ExtensionMessageEnvelope(
-            action: "notification.card.response",
-            version: "1",
-            correlationId: "req-4",
-            payload: [:]
+        let response = router.handle(
+            type: "test.echo",
+            payload: #"{"message":"hello"}"#,
+            requestId: "request-123",
+            senderId: "extension-456",
+            agentName: "test-agent"
         )
 
-        _ = router.handle(message: String(data: try request.encode(), encoding: .utf8)!, requestId: "req-3")
-        _ = router.handle(message: String(data: try response.encode(), encoding: .utf8)!, requestId: "req-4")
+        XCTAssertEqual(response, #"{"ok":true}"#)
+        XCTAssertEqual(receivedContext?.type, "test.echo")
+        XCTAssertEqual(receivedContext?.payload, #"{"message":"hello"}"#)
+        XCTAssertEqual(receivedContext?.requestId, "request-123")
+        XCTAssertEqual(receivedContext?.senderId, "extension-456")
+        XCTAssertEqual(receivedContext?.agentName, "test-agent")
+    }
 
-        XCTAssertEqual(handled.sorted(), ["notification.card.request", "notification.card.response"])
+    func testSeparatelyRegisteredTypesDispatchIndependently() {
+        let router = ExtensionMessageRouter()
+        var handledTypes: [String] = []
+        router.register(type: "test.first") { context in
+            handledTypes.append(context.type)
+            return "first-response"
+        }
+        router.register(type: "test.second") { context in
+            handledTypes.append(context.type)
+            return "second-response"
+        }
+
+        let firstResponse = router.handle(
+            type: "test.first",
+            payload: "",
+            requestId: "request-first"
+        )
+        let secondResponse = router.handle(
+            type: "test.second",
+            payload: "",
+            requestId: "request-second"
+        )
+
+        XCTAssertEqual(firstResponse, "first-response")
+        XCTAssertEqual(secondResponse, "second-response")
+        XCTAssertEqual(handledTypes, ["test.first", "test.second"])
     }
 }
-*/


### PR DESCRIPTION
## Summary

- replace the placeholder `ExtensionMessagingTests` suite with coverage for the current
  `ExtensionMessageRouter` API
- verify complete context forwarding and synchronous response propagation
- verify separately registered message types dispatch independently
- remove the obsolete tests for the deleted envelope-based API

Closes #80.

## Motivation

`ExtensionMessagingTests.swift` was left as a placeholder after
`ExtensionMessageEnvelope`, `register(action:)`, and `handle(message:requestId:)` were
removed. The current type-based router therefore had no focused unit coverage.

## Design

The tests register unique message types on a fresh router instance. This exercises the
router's public-internal registration and dispatch boundary without invoking built-in
handlers or their global UI and framework dependencies.

No production code or API changes are included.

## Testing

- `swiftc -parse $(rg --files Tests -g '*.swift')` — passed
- `swiftc -parse Sources/Notifications/MessageCard/ExtensionMessageRouter.swift` —
  passed
- `plutil -lint Phi.xcodeproj/project.pbxproj` — passed
- the two test methods were type-checked and executed successfully against a temporary
  API-faithful router seam outside the repository

Native `xcodebuild test` was unavailable in the local environment because it only has
Command Line Tools selected, not Xcode 26+, and the required local
`Phi Framework.framework` is not present. The temporary seam is a degraded check and is
not presented as a substitute for the project's native XCTest run.

## Compatibility and scope

- test-only change
- no framework, UI, routing, or application behavior changes
- no new dependencies
