### PR TITLE
fix: enforce Stable privacy controls

### DIFF
--- a/Sources/AccountController/Account.swift
+++ b/Sources/AccountController/Account.swift
@@ -75,14 +75,14 @@ class AccountController {
     private func syncTelemetryIdentity(for account: Account?) {
         SentryService.configureUser(account)
 
-        guard let bridge = ChromiumLauncher.sharedInstance().bridge,
-              bridge.isMetricsReportingEnabled(),
+        let metricsReportingSnapshot = PhiChromiumCoordinator.shared.metricsReportingSnapshot
+        guard metricsReportingSnapshot.isEnabled,
               let sub = account?.userInfo?.sub else {
             PostHogSDK.shared.reset()
             return
         }
 
-        let properties = bridge.getMetricsClientId().map {
+        let properties = metricsReportingSnapshot.clientID.map {
             ["chromium_metrics_client_id": $0] as [String: Any]
         }
         PostHogSDK.shared.identify(sub, userProperties: properties)
@@ -90,12 +90,13 @@ class AccountController {
 
     /// Re-apply identity persistence when Chromium's measurement preference
     /// changes without an account transition.
-    func refreshTelemetryPrivacy() {
-        if ChromiumLauncher.sharedInstance().bridge?.isMetricsReportingEnabled() == true {
+    func refreshTelemetryPrivacy(metricsReportingEnabled: Bool) {
+        if metricsReportingEnabled {
             PostHogSDK.shared.optIn()
         } else {
             PostHogSDK.shared.optOut()
         }
+        SentryService.refreshTelemetryPrivacy(enabled: metricsReportingEnabled)
         syncTelemetryIdentity(for: account)
     }
 

--- a/Sources/AccountController/Account.swift
+++ b/Sources/AccountController/Account.swift
@@ -62,6 +62,7 @@ class AccountController {
     var account: Account? {
         didSet {
             syncTelemetryIdentity(for: account)
+            PhiChromiumCoordinator.shared.publishNativeSettingsChanged()
             NotificationCenter.default.post(name: .mainAccountChanged, object: account)
             /// FIXME: Chromium builds the main menu before the account exists, but shortcut overrides
             /// are account-scoped. Reloading here works, but this probably deserves a cleaner hook.
@@ -85,6 +86,17 @@ class AccountController {
             ["chromium_metrics_client_id": $0] as [String: Any]
         }
         PostHogSDK.shared.identify(sub, userProperties: properties)
+    }
+
+    /// Re-apply identity persistence when Chromium's measurement preference
+    /// changes without an account transition.
+    func refreshTelemetryPrivacy() {
+        if ChromiumLauncher.sharedInstance().bridge?.isMetricsReportingEnabled() == true {
+            PostHogSDK.shared.optIn()
+        } else {
+            PostHogSDK.shared.optOut()
+        }
+        syncTelemetryIdentity(for: account)
     }
 
     /// Best-effort refresh of the existing per-account profile cache. The

--- a/Sources/Application/AppController.swift
+++ b/Sources/Application/AppController.swift
@@ -156,20 +156,26 @@ import PostHog
         // Set up PostHog before `didFinishLaunchingNotification` fires so the
         // SDK can observe the app-opened lifecycle event. If either value is
         // missing the app runs without analytics.
+        let metricsReportingEnabled = chromiumBridge?.isMetricsReportingEnabled() ?? false
+        let metricsClientID = metricsReportingEnabled ? chromiumBridge?.getMetricsClientId() : nil
+        lastMetricsReportingEnabled = metricsReportingEnabled
+        PhiChromiumCoordinator.shared.updateMetricsReportingSnapshot(
+            isEnabled: metricsReportingEnabled,
+            clientID: metricsClientID
+        )
         if let token = PostHogEnv.projectToken.value,
            let host = PostHogEnv.host.value {
             let postHogConfig = PostHogConfig(apiKey: token, host: host)
             // The Chromium-owned measurement setting is the sole opt-in
             // source. Starting opted out prevents remote-config, lifecycle,
             // identity, and queue activity from racing launch.
-            postHogConfig.optOut = !(chromiumBridge?.isMetricsReportingEnabled() ?? false)
+            postHogConfig.optOut = !metricsReportingEnabled
             postHogConfig.captureApplicationLifecycleEvents = true
             #if DEBUG
             postHogConfig.debug = true
             #endif
             postHogConfig.setBeforeSend { event in
-                guard ChromiumLauncher.sharedInstance().bridge?
-                    .isMetricsReportingEnabled() == true else { return nil }
+                guard PhiChromiumCoordinator.shared.metricsReportingEnabledSnapshot else { return nil }
                 guard event.event == "Application Opened" else { return event }
                 event.properties["layout_mode"] = PhiPreferences.GeneralSettings.loadLayoutMode().rawValue
                 event.properties["ai_enabled"] = PhiPreferences.AISettings.phiAIEnabled.loadValue()
@@ -199,9 +205,9 @@ import PostHog
         }
     }
 
-    /// Chromium owns the user-facing measurement toggle and exposes a live
-    /// getter but no change callback. Polling this one boolean lets native and
-    /// extension telemetry react promptly without duplicating the preference.
+    /// Chromium owns the user-facing measurement toggle and exposes live
+    /// getters but no change callback. Polling consent, and lazily filling its
+    /// client ID, lets telemetry react promptly without duplicating ownership.
     private func startMetricsReportingObservation() {
         refreshMetricsReportingState()
         let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
@@ -212,10 +218,17 @@ import PostHog
     }
 
     private func refreshMetricsReportingState() {
-        guard let enabled = ChromiumLauncher.sharedInstance().bridge?
-            .isMetricsReportingEnabled(), enabled != lastMetricsReportingEnabled else { return }
+        guard let bridge = ChromiumLauncher.sharedInstance().bridge else { return }
+        let enabled = bridge.isMetricsReportingEnabled()
+        let currentSnapshot = PhiChromiumCoordinator.shared.metricsReportingSnapshot
+        let clientID = enabled ? currentSnapshot.clientID ?? bridge.getMetricsClientId() : nil
+        guard enabled != lastMetricsReportingEnabled || clientID != currentSnapshot.clientID else { return }
         lastMetricsReportingEnabled = enabled
-        AccountController.shared.refreshTelemetryPrivacy()
+        PhiChromiumCoordinator.shared.updateMetricsReportingSnapshot(
+            isEnabled: enabled,
+            clientID: clientID
+        )
+        AccountController.shared.refreshTelemetryPrivacy(metricsReportingEnabled: enabled)
         PhiChromiumCoordinator.shared.publishNativeSettingsChanged()
     }
     

--- a/Sources/Application/AppController.swift
+++ b/Sources/Application/AppController.swift
@@ -55,6 +55,8 @@ import PostHog
     private var pendingOpenURLsAwaitingLoginStatus: [URL] = []
     /// Cached in `applicationWillFinishLaunching`; weak — owned by `ChromiumLauncher`, not AppController.
     private weak var chromiumBridge: (any PhiChromiumBridgeProtocol)?
+    private var metricsReportingObservationTimer: Timer?
+    private var lastMetricsReportingEnabled: Bool?
 
     override init() {
         super.init()
@@ -79,6 +81,7 @@ import PostHog
         //        ASWebAuthenticationSessionWebBrowserSessionManager.shared.sessionHandler = self
         
         ChromiumLauncher.sharedInstance().bridge?.applicationDidFinishLaunching(notification)
+        startMetricsReportingObservation()
         
         //        ASWebAuthenticationSessionWebBrowserSessionManager.shared.sessionHandler = self
         
@@ -156,11 +159,17 @@ import PostHog
         if let token = PostHogEnv.projectToken.value,
            let host = PostHogEnv.host.value {
             let postHogConfig = PostHogConfig(apiKey: token, host: host)
+            // The Chromium-owned measurement setting is the sole opt-in
+            // source. Starting opted out prevents remote-config, lifecycle,
+            // identity, and queue activity from racing launch.
+            postHogConfig.optOut = !(chromiumBridge?.isMetricsReportingEnabled() ?? false)
             postHogConfig.captureApplicationLifecycleEvents = true
             #if DEBUG
             postHogConfig.debug = true
             #endif
             postHogConfig.setBeforeSend { event in
+                guard ChromiumLauncher.sharedInstance().bridge?
+                    .isMetricsReportingEnabled() == true else { return nil }
                 guard event.event == "Application Opened" else { return event }
                 event.properties["layout_mode"] = PhiPreferences.GeneralSettings.loadLayoutMode().rawValue
                 event.properties["ai_enabled"] = PhiPreferences.AISettings.phiAIEnabled.loadValue()
@@ -177,6 +186,8 @@ import PostHog
     func applicationWillTerminate(_ notification: Notification) {
         coldOpenURLForwardWorkItem?.cancel()
         coldOpenURLForwardWorkItem = nil
+        metricsReportingObservationTimer?.invalidate()
+        metricsReportingObservationTimer = nil
         AppLogInfo("-------applicationWillTerminate----")
         MemoryUsageMonitor.shared.stop()
         AgentCDPListener.shared.stop()
@@ -186,6 +197,26 @@ import PostHog
             AppLogWarn("[AppController] applicationWillTerminate: chromium bridge not cached; using launcher fallback")
             ChromiumLauncher.sharedInstance().bridge?.applicationWillTerminate(notification)
         }
+    }
+
+    /// Chromium owns the user-facing measurement toggle and exposes a live
+    /// getter but no change callback. Polling this one boolean lets native and
+    /// extension telemetry react promptly without duplicating the preference.
+    private func startMetricsReportingObservation() {
+        refreshMetricsReportingState()
+        let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
+            self?.refreshMetricsReportingState()
+        }
+        metricsReportingObservationTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func refreshMetricsReportingState() {
+        guard let enabled = ChromiumLauncher.sharedInstance().bridge?
+            .isMetricsReportingEnabled(), enabled != lastMetricsReportingEnabled else { return }
+        lastMetricsReportingEnabled = enabled
+        AccountController.shared.refreshTelemetryPrivacy()
+        PhiChromiumCoordinator.shared.publishNativeSettingsChanged()
     }
     
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {

--- a/Sources/ChromiumBridge/PhiChromiumCoordinator.swift
+++ b/Sources/ChromiumBridge/PhiChromiumCoordinator.swift
@@ -9,6 +9,36 @@ import SwiftUI
 @objc class PhiChromiumCoordinator: NSObject {
     @objc static var shared = PhiChromiumCoordinator()
 
+    struct MetricsReportingSnapshot {
+        let isEnabled: Bool
+        let clientID: String?
+    }
+
+    private let metricsReportingStateLock = NSLock()
+    private var _metricsReportingSnapshot = MetricsReportingSnapshot(isEnabled: false, clientID: nil)
+
+    /// Thread-safe telemetry consent snapshot. Only the main-thread Chromium
+    /// integration updates it; telemetry SDK callbacks may read it from their
+    /// worker queues without crossing into Chromium.
+    var metricsReportingEnabledSnapshot: Bool {
+        metricsReportingSnapshot.isEnabled
+    }
+
+    var metricsReportingSnapshot: MetricsReportingSnapshot {
+        metricsReportingStateLock.lock()
+        defer { metricsReportingStateLock.unlock() }
+        return _metricsReportingSnapshot
+    }
+
+    func updateMetricsReportingSnapshot(isEnabled: Bool, clientID: String?) {
+        metricsReportingStateLock.lock()
+        _metricsReportingSnapshot = MetricsReportingSnapshot(
+            isEnabled: isEnabled,
+            clientID: isEnabled ? clientID : nil
+        )
+        metricsReportingStateLock.unlock()
+    }
+
     /// Live ask-Space overlays keyed by the source windowId, so a second
     /// match for the same window replaces (rather than stacks) the prompt and
     /// dismissal can tear the right one down.
@@ -131,10 +161,8 @@ extension PhiChromiumCoordinator: PhiChromiumBridgeDelegate {
     /// One source of truth for preinstalled extensions' privacy-sensitive
     /// runtime state. Missing bridge state fails closed for measurement.
     func currentNativeSettings() -> String {
-        let metricsReportingEnabled = ChromiumLauncher.sharedInstance().bridge?
-            .isMetricsReportingEnabled() ?? false
         return PhiPreferences.AISettings.buildConfig(additional: [
-            "metricsReportingEnabled": metricsReportingEnabled,
+            "metricsReportingEnabled": metricsReportingEnabledSnapshot,
             "signedIn": AccountController.shared.account != nil,
         ])
     }

--- a/Sources/ChromiumBridge/PhiChromiumCoordinator.swift
+++ b/Sources/ChromiumBridge/PhiChromiumCoordinator.swift
@@ -125,7 +125,26 @@ extension PhiChromiumCoordinator: PhiChromiumBridgeDelegate {
     }
     
     func getNativeSettings() -> String {
-        return PhiPreferences.AISettings.buildConfig()
+        return currentNativeSettings()
+    }
+
+    /// One source of truth for preinstalled extensions' privacy-sensitive
+    /// runtime state. Missing bridge state fails closed for measurement.
+    func currentNativeSettings() -> String {
+        let metricsReportingEnabled = ChromiumLauncher.sharedInstance().bridge?
+            .isMetricsReportingEnabled() ?? false
+        return PhiPreferences.AISettings.buildConfig(additional: [
+            "metricsReportingEnabled": metricsReportingEnabled,
+            "signedIn": AccountController.shared.account != nil,
+        ])
+    }
+
+    /// Push a complete snapshot so extension realms can apply account, AI,
+    /// browser-memory, and measurement changes without a relaunch.
+    func publishNativeSettingsChanged() {
+        let settings = currentNativeSettings()
+        ChromiumLauncher.sharedInstance().bridge?.nativeSettingsChanged(settings)
+        AppLogDebug("[NativeSettings] Changed notification sent: \(settings)")
     }
     
     func handleDeeplink(withUrlString urlString: String, windowId: Int64) -> Bool {

--- a/Sources/UserInterface/Preferences/AISettings/AISettingView.swift
+++ b/Sources/UserInterface/Preferences/AISettings/AISettingView.swift
@@ -563,9 +563,7 @@ private struct AINavigationRow: View {
 // MARK: - Helpers
 
 private func notifyNativeSettingsChanged() {
-    let settings = PhiPreferences.AISettings.buildConfig()
-    ChromiumLauncher.sharedInstance().bridge?.nativeSettingsChanged(settings)
-    AppLogDebug("[AISettings] Native settings changed notification sent: \(settings)")
+    PhiChromiumCoordinator.shared.publishNativeSettingsChanged()
 }
 
 #Preview {

--- a/Sources/UserInterface/Preferences/PhiPreferences.swift
+++ b/Sources/UserInterface/Preferences/PhiPreferences.swift
@@ -219,13 +219,13 @@ extension PhiPreferences {
             UserDefaults.standard.bool(forKey: rawValue, default: defaultValue)
         }
 
-        static func buildConfig() -> String {
+        static func buildConfig(additional: [String: Any] = [:]) -> String {
             var result = [String: Any]()
             allCases
-                .filter { $0 != .enableBrowserMemories}
                 .forEach {
-                result[$0.rawValue] = UserDefaults.standard.bool(forKey: $0.rawValue)
+                result[$0.rawValue] = $0.loadValue()
             }
+            additional.forEach { result[$0.key] = $0.value }
             let data = try? JSONSerialization.data(withJSONObject: result, options: [])
             return String(data: data ?? Data(), encoding: .utf8) ?? "{}"
         }

--- a/Sources/Utilities/Sentry/Sentry.swift
+++ b/Sources/Utilities/Sentry/Sentry.swift
@@ -134,6 +134,11 @@ struct TimeMachineSentryTraceStore {
         SentrySDK.start { options in
             options.dsn = ""
             options.experimental.enableLogs = true
+            options.beforeSendLog = { log in
+                guard ChromiumLauncher.sharedInstance().bridge?
+                    .isMetricsReportingEnabled() == true else { return nil }
+                return log
+            }
             
             if let basePath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first,
                let appName = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String {
@@ -149,7 +154,7 @@ struct TimeMachineSentryTraceStore {
             options.enableCoreDataTracing = false
             options.enableFileIOTracing = false
             options.enableNetworkTracking = false
-            options.enableAutoSessionTracking = true
+            options.enableAutoSessionTracking = false
             options.enableCaptureFailedRequests = false
             options.enableAutoPerformanceTracing = false
             options.enableAppHangTracking = false
@@ -157,6 +162,8 @@ struct TimeMachineSentryTraceStore {
             options.enableMetricKitRawPayload = true
             
             options.beforeSend = { event in
+                guard ChromiumLauncher.sharedInstance().bridge?
+                    .isMetricsReportingEnabled() == true else { return nil }
                 let isMetricKitDiskWrite =
                 event.exceptions?.contains {
                     $0.type == "MXDiskWriteException" ||
@@ -171,9 +178,12 @@ struct TimeMachineSentryTraceStore {
             }
             
             options.initialScope = { scope in
-                // Attach recent logs up front because startup may immediately report a previous crash.
                 scope.clearAttachments()
-                if let stringData = PhiLogging.applicationLog(maxLength: Int(maxSentryLogSize))?.data(using: .utf8) {
+                // Do not retain logs collected while measurement is disabled:
+                // a later opt-in must not attach prior off-period activity.
+                if ChromiumLauncher.sharedInstance().bridge?
+                    .isMetricsReportingEnabled() == true,
+                   let stringData = PhiLogging.applicationLog(maxLength: Int(maxSentryLogSize))?.data(using: .utf8) {
                     let attachment = Attachment(data: stringData, filename: "logs.txt")
                     scope.addAttachment(attachment)
                 }

--- a/Sources/Utilities/Sentry/Sentry.swift
+++ b/Sources/Utilities/Sentry/Sentry.swift
@@ -90,6 +90,11 @@ struct TimeMachineSentryTraceStore {
         return try load()
     }
 
+    func clear() throws {
+        guard fileManager.fileExists(atPath: queueURL.path) else { return }
+        try fileManager.removeItem(at: queueURL)
+    }
+
     private func load() throws -> [TimeMachineSentryTrace] {
         let data = try Data(contentsOf: queueURL)
         return try Self.decoder.decode([TimeMachineSentryTrace].self, from: data)
@@ -121,8 +126,25 @@ struct TimeMachineSentryTraceStore {
     private static let pendingTimeMachineTraceLock = NSLock()
     private static var pendingTimeMachineTraces: [TimeMachineSentryTrace] = []
     private static var timeMachineTraceStore = TimeMachineSentryTraceStore()
+    private static var sentryURLSession: URLSession?
+
+    private static var cacheDirectoryURL: URL? {
+        guard let basePath = NSSearchPathForDirectoriesInDomains(
+            .applicationSupportDirectory,
+            .userDomainMask,
+            true
+        ).first,
+        let appName = Bundle.main.bundleIdentifier else { return nil }
+        return URL(fileURLWithPath: basePath, isDirectory: true)
+            .appendingPathComponent(appName, isDirectory: true)
+    }
 
     @objc static func setup() {
+        guard PhiChromiumCoordinator.shared.metricsReportingEnabledSnapshot else {
+            stopAndPurge()
+            return
+        }
+
         pendingTimeMachineTraceLock.lock()
         guard !hasStarted, !isStarting else {
             pendingTimeMachineTraceLock.unlock()
@@ -131,18 +153,21 @@ struct TimeMachineSentryTraceStore {
         isStarting = true
         pendingTimeMachineTraceLock.unlock()
 
+        let urlSession = URLSession(configuration: .ephemeral)
+        sentryURLSession = urlSession
+
         SentrySDK.start { options in
             options.dsn = ""
+            options.shutdownTimeInterval = 0
+            options.urlSession = urlSession
             options.experimental.enableLogs = true
             options.beforeSendLog = { log in
-                guard ChromiumLauncher.sharedInstance().bridge?
-                    .isMetricsReportingEnabled() == true else { return nil }
+                guard PhiChromiumCoordinator.shared.metricsReportingEnabledSnapshot else { return nil }
                 return log
             }
             
-            if let basePath = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first,
-               let appName = Bundle.main.infoDictionary?["CFBundleIdentifier"] as? String {
-                options.cacheDirectoryPath = (basePath as NSString).appendingPathComponent(appName)
+            if let cacheDirectoryURL {
+                options.cacheDirectoryPath = cacheDirectoryURL.path
             }
             
             // https://docs.sentry.io/platforms/apple/guides/macos/usage/#capturing-uncaught-exceptions-in-macos
@@ -154,7 +179,7 @@ struct TimeMachineSentryTraceStore {
             options.enableCoreDataTracing = false
             options.enableFileIOTracing = false
             options.enableNetworkTracking = false
-            options.enableAutoSessionTracking = false
+            options.enableAutoSessionTracking = true
             options.enableCaptureFailedRequests = false
             options.enableAutoPerformanceTracing = false
             options.enableAppHangTracking = false
@@ -162,8 +187,7 @@ struct TimeMachineSentryTraceStore {
             options.enableMetricKitRawPayload = true
             
             options.beforeSend = { event in
-                guard ChromiumLauncher.sharedInstance().bridge?
-                    .isMetricsReportingEnabled() == true else { return nil }
+                guard PhiChromiumCoordinator.shared.metricsReportingEnabledSnapshot else { return nil }
                 let isMetricKitDiskWrite =
                 event.exceptions?.contains {
                     $0.type == "MXDiskWriteException" ||
@@ -181,8 +205,7 @@ struct TimeMachineSentryTraceStore {
                 scope.clearAttachments()
                 // Do not retain logs collected while measurement is disabled:
                 // a later opt-in must not attach prior off-period activity.
-                if ChromiumLauncher.sharedInstance().bridge?
-                    .isMetricsReportingEnabled() == true,
+                if PhiChromiumCoordinator.shared.metricsReportingEnabledSnapshot,
                    let stringData = PhiLogging.applicationLog(maxLength: Int(maxSentryLogSize))?.data(using: .utf8) {
                     let attachment = Attachment(data: stringData, filename: "logs.txt")
                     scope.addAttachment(attachment)
@@ -233,10 +256,22 @@ struct TimeMachineSentryTraceStore {
         configureUser(AccountController.shared.account)
         flushPendingTimeMachineTraces(pendingTimeMachineTraces)
     }
+
+    static func refreshTelemetryPrivacy(enabled: Bool) {
+        if enabled {
+            setup()
+            configureUser(AccountController.shared.account)
+        } else {
+            stopAndPurge()
+        }
+    }
     
     static func configureUser(_ account: Account?) {
-        guard hasStarted else { return }
-        guard ChromiumLauncher.sharedInstance().bridge?.isMetricsReportingEnabled() ?? false,
+        pendingTimeMachineTraceLock.lock()
+        let started = hasStarted
+        pendingTimeMachineTraceLock.unlock()
+        guard started else { return }
+        guard PhiChromiumCoordinator.shared.metricsReportingEnabledSnapshot,
               let userInfo = account?.userInfo,
               let sub = userInfo.sub else {
             SentrySDK.setUser(nil)
@@ -472,6 +507,9 @@ struct TimeMachineSentryTraceStore {
             pendingTimeMachineTraceLock.unlock()
         }
 
+        guard PhiChromiumCoordinator.shared.metricsReportingEnabledSnapshot else {
+            return true
+        }
         guard !hasStarted else {
             return false
         }
@@ -483,6 +521,50 @@ struct TimeMachineSentryTraceStore {
             AppLogError("[TimeMachine] Failed to persist pending Sentry trace: \(error.localizedDescription)")
         }
         return true
+    }
+
+    private static func stopAndPurge() {
+        pendingTimeMachineTraceLock.lock()
+        let shouldClose = hasStarted || isStarting
+        hasStarted = false
+        isStarting = false
+        pendingTimeMachineTraces.removeAll()
+        let urlSession = sentryURLSession
+        sentryURLSession = nil
+        do {
+            try timeMachineTraceStore.clear()
+        } catch {
+            AppLogError("[Sentry] Failed to clear pending Time Machine traces: \(error.localizedDescription)")
+        }
+        pendingTimeMachineTraceLock.unlock()
+
+        if shouldClose {
+            urlSession?.invalidateAndCancel()
+            SentrySDK.setUser(nil)
+            SentrySDK.close()
+        }
+        purgeCachedTelemetry()
+    }
+
+    private static func purgeCachedTelemetry() {
+        guard let cacheDirectoryURL else { return }
+        do {
+            try purgeCachedTelemetry(at: cacheDirectoryURL)
+        } catch {
+            AppLogError("[Sentry] Failed to purge cached telemetry: \(error.localizedDescription)")
+        }
+    }
+
+    static func purgeCachedTelemetry(
+        at cacheDirectoryURL: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        for url in [
+            cacheDirectoryURL.appendingPathComponent("io.sentry", isDirectory: true),
+            cacheDirectoryURL.appendingPathComponent("INSTALLATION", isDirectory: false),
+        ] where fileManager.fileExists(atPath: url.path) {
+            try fileManager.removeItem(at: url)
+        }
     }
 
     private static func flushPendingTimeMachineTraces(_ traces: [TimeMachineSentryTrace]) {

--- a/Tests/PhiBrowserTests/TelemetryPrivacyTests.swift
+++ b/Tests/PhiBrowserTests/TelemetryPrivacyTests.swift
@@ -1,0 +1,62 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import XCTest
+@testable import Phi
+
+final class TelemetryPrivacyTests: XCTestCase {
+    private var temporaryDirectories: [URL] = []
+
+    override func tearDownWithError() throws {
+        for directory in temporaryDirectories {
+            try? FileManager.default.removeItem(at: directory)
+        }
+        temporaryDirectories.removeAll()
+    }
+
+    func testMetricsReportingSnapshotDefaultsToDeniedAndClearsIdentityWhenDisabled() {
+        let coordinator = PhiChromiumCoordinator()
+
+        XCTAssertFalse(coordinator.metricsReportingEnabledSnapshot)
+        XCTAssertNil(coordinator.metricsReportingSnapshot.clientID)
+
+        coordinator.updateMetricsReportingSnapshot(isEnabled: true, clientID: "client-id")
+
+        XCTAssertTrue(coordinator.metricsReportingEnabledSnapshot)
+        XCTAssertEqual(coordinator.metricsReportingSnapshot.clientID, "client-id")
+
+        coordinator.updateMetricsReportingSnapshot(isEnabled: false, clientID: "must-not-persist")
+
+        XCTAssertFalse(coordinator.metricsReportingEnabledSnapshot)
+        XCTAssertNil(coordinator.metricsReportingSnapshot.clientID)
+    }
+
+    func testSentryCachePurgeRemovesOnlyTelemetryState() throws {
+        let root = try makeTemporaryDirectory()
+        let sentryDirectory = root.appendingPathComponent("io.sentry", isDirectory: true)
+        let installationFile = root.appendingPathComponent("INSTALLATION", isDirectory: false)
+        let unrelatedFile = root.appendingPathComponent("account.json", isDirectory: false)
+        try FileManager.default.createDirectory(at: sentryDirectory, withIntermediateDirectories: true)
+        try Data("envelope".utf8).write(
+            to: sentryDirectory.appendingPathComponent("queued-envelope.json")
+        )
+        try Data("installation-id".utf8).write(to: installationFile)
+        try Data("keep".utf8).write(to: unrelatedFile)
+
+        try SentryService.purgeCachedTelemetry(at: root)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sentryDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: installationFile.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unrelatedFile.path))
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TelemetryPrivacyTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        temporaryDirectories.append(url)
+        return url
+    }
+}

--- a/Tests/PhiBrowserTests/TimeMachineCoreTests.swift
+++ b/Tests/PhiBrowserTests/TimeMachineCoreTests.swift
@@ -219,6 +219,27 @@ final class TimeMachineCoreTests: XCTestCase {
         XCTAssertEqual(try TimeMachineSentryTraceStore(paths: paths).drain(), [])
     }
 
+    func testSentryTraceStoreClearDropsPersistedRecoveryTrace() throws {
+        let root = try makeTemporaryDirectory()
+        let paths = TimeMachinePaths(rootURL: root, bundleIdentifier: "com.phibrowser.Mac")
+        let trace = TimeMachineRestoreRecoveryTrace(
+            status: .blocked,
+            operationID: nil,
+            bundleIdentifier: "com.phibrowser.Mac",
+            phase: .dataSwapped,
+            hasStartedDestructiveSwap: true,
+            reason: "measurement disabled",
+            errorDescription: nil,
+            errorType: nil
+        )
+        let store = TimeMachineSentryTraceStore(paths: paths)
+
+        try store.append(.restoreRecovery(trace))
+        try store.clear()
+
+        XCTAssertEqual(try store.drain(), [])
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("TimeMachineCoreTests-\(UUID().uuidString)", isDirectory: true)

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -5,7 +5,8 @@ Last updated: 2026-08-03
 Phi Browser uses PostHog for product analytics and Sentry for crash/error reporting. Both
 pipelines are controlled by Chromium's **Help improve Phi's features and performance**
 setting. When that setting is off, outbound events are rejected and persisted analytics
-identity is reset.
+identity is reset. Sentry is stopped, its transport is cancelled, and its queued cache is
+deleted so previously accepted offline envelopes cannot upload after opt-out.
 
 ## Initialization
 
@@ -21,8 +22,16 @@ If the project token or host is empty, `AppController` logs a warning and skips 
 `PhiChromiumCoordinator.currentNativeSettings()` publishes the same live measurement state,
 account presence, Phi AI master switch, and Browser Memories switch to preinstalled
 extensions. `AppController` observes the Chromium-owned measurement setting and republishes
-changes; account and AI-setting changes publish through the same snapshot. Missing bridge
-state fails closed.
+changes; account and AI-setting changes publish through the same snapshot. The main-thread
+observer caches measurement consent and Chromium's metrics client ID in
+`PhiChromiumCoordinator`; account and telemetry SDK worker callbacks read that locked snapshot
+rather than calling Chromium off-thread. Missing bridge state fails closed.
+
+Sentry starts only while measurement consent is enabled. Opt-out cancels its URL session, closes
+the SDK with a zero-second shutdown window, and removes both cached envelopes and its persisted
+installation identifier. Opt-in starts a fresh SDK transport. Automatic session tracking remains
+enabled for opted-in periods so release-health metrics remain complete without crossing an
+opted-out period.
 
 ### PostHog config pipeline
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,19 +1,28 @@
 # Analytics
 
-Last updated: 2026-05-21
+Last updated: 2026-08-03
 
-Phi Browser emits product analytics to both [Countly](https://phi-browser-eaade70cfd902.flex.countly.com) (legacy) and [PostHog](https://us.posthog.com/project/385742) (current). Both pipelines run side-by-side; PostHog is the forward-looking source of truth.
+Phi Browser uses PostHog for product analytics and Sentry for crash/error reporting. Both
+pipelines are controlled by Chromium's **Help improve Phi's features and performance**
+setting. When that setting is off, outbound events are rejected and persisted analytics
+identity is reset.
 
 ## Initialization
 
 | Pipeline | Init site | Config source |
 | --- | --- | --- |
 | PostHog | `AppController.applicationWillFinishLaunching` (`Sources/Application/AppController.swift`) | `PostHogEnv` → `PostHogGeneratedConfig` (compiled-in constants from `Sources/Utilities/PostHogConfig.generated.swift`) |
-| Countly | `EventTracker.initTracker()` (`Sources/Utilities/EventTrack/EventTracker.swift`) | Hardcoded in source, split by `NIGHTLY_BUILD || DEBUG` |
+| Sentry | `SentryService.setup()` (`Sources/Utilities/Sentry/Sentry.swift`) | Native Sentry configuration |
 
 PostHog SDK config uses `captureApplicationLifecycleEvents = true`, so `$app_installed`, `$app_updated`, `$app_opened`, `$app_backgrounded` are auto-captured — these power DAU and retention.
 
 If the project token or host is empty, `AppController` logs a warning and skips PostHog init; the app runs without analytics rather than crashing.
+
+`PhiChromiumCoordinator.currentNativeSettings()` publishes the same live measurement state,
+account presence, Phi AI master switch, and Browser Memories switch to preinstalled
+extensions. `AppController` observes the Chromium-owned measurement setting and republishes
+changes; account and AI-setting changes publish through the same snapshot. Missing bridge
+state fails closed.
 
 ### PostHog config pipeline
 
@@ -40,7 +49,7 @@ A plain Xcode Run/Debug compiles the empty-value default and runs without PostHo
 | Active account changed | `identify(auth0.sub, userProperties)` | `AccountController/Account.swift` |
 | Logout | `capture("user_logged_out")` then `reset()` | `Onboarding/AuthManager.swift` |
 
-Distinct ID == Auth0 `sub`. When Chromium metrics reporting is enabled, identify also sets `chromium_metrics_client_id` to Chromium's UMA client ID. A temporarily unavailable client ID does not prevent identification.
+Distinct ID == Auth0 `sub`. When Chromium metrics reporting is enabled, identify also sets `chromium_metrics_client_id` to Chromium's UMA client ID. A temporarily unavailable client ID does not prevent identification. Turning measurement off resets PostHog identity and clears the Sentry user.
 
 ## Super properties
 
@@ -77,5 +86,6 @@ Naming rule: **don't reuse PostHog-reserved names** (anything starting with `$`,
 ## Adding a new event
 
 1. Call `PostHogSDK.shared.capture("snake_case_name", properties: [...])` at the action site. Import `PostHog` in the file.
-2. If a matching Countly event already exists, keep both calls side-by-side during migration.
+2. Do not add a second telemetry transport; the global PostHog consent hook is the required
+   enforcement boundary.
 3. Add a row to the Events table above.


### PR DESCRIPTION
## Summary

- make Chromium's existing **Help improve Phi's features and performance** setting the sole native telemetry-consent source
- start PostHog opted out when consent is unavailable, reject events globally while disabled, and reset persisted identity
- gate Sentry events, logs, user identity, startup attachments, and automatic sessions on the same setting
- publish a complete live privacy snapshot to preinstalled extensions, including sign-in, Phi AI, Browser Memories, and metrics state
- republish that snapshot when account, AI settings, or metrics consent changes

## Why

The current switch existed, but it was not wired as a global enforcement boundary. PostHog lifecycle events could initialize independently, Sentry and MetricKit paths did not follow the switch, and extensions did not receive enough state to enable Lexington safely.

## Impact

No new user-facing switch is added. The current control becomes authoritative across native telemetry and the companion extensions. Missing bridge state fails closed.

Companion phi-ai PR: https://github.com/phibrowser/phi-ai/pull/252

## Validation

- rebased onto current `dev`
- signed commit
- `PhiBrowser-release` Release build succeeded with Xcode, code signing disabled
