### PR TITLE
i18n: CJK spacing consistency sync

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -66,7 +66,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chromiumエンジンバージョン %@"
+            "value" : "Chromiumエンジンバージョン%@"
           }
         },
         "ko" : {
@@ -186,7 +186,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "バージョン %1$@ (%2$@)"
+            "value" : "バージョン%1$@ (%2$@)"
           }
         },
         "ko" : {
@@ -43337,7 +43337,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "批准智能体请求（10分钟或始终）后，相应授权会显示在这里。"
+            "value" : "批准智能体请求（10 分钟或始终）后，相应授权会显示在这里。"
           }
         },
         "zh-Hant" : {
@@ -45617,7 +45617,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "4小时"
+            "value" : "4 小时"
           }
         },
         "zh-Hant" : {
@@ -45737,7 +45737,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "1小时"
+            "value" : "1 小时"
           }
         },
         "zh-Hant" : {
@@ -68339,7 +68339,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "シークレット %d"
+            "value" : "シークレット%d"
           }
         },
         "ko" : {


### PR DESCRIPTION
Applies the CJK spacing ruling from the translation catalog: Japanese strings no longer carry literal spaces at Japanese/Latin/digit boundaries (rendering engines insert optical spacing; macOS has done so automatically since Monterey), and three Simplified Chinese strings gain the space between digit and Chinese unit word required by the ratified zh style rule.

Sync from [phibrowser/phi-i18n](https://github.com/phibrowser/phi-i18n) per the localization guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)