### PR TITLE
README: Weblate is live at i18n.phibrowser.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ We welcome bug reports, feature requests, documentation improvements, and pull r
 
 ### Translations
 
-Phi ships in 8 languages, currently machine-seeded and waiting for native speakers to make them feel right. If you can read a JSON file, you can help: every user-visible string in the Phi product family lives in [phibrowser/phi-i18n](https://github.com/phibrowser/phi-i18n), each with context on where it appears and what it does. Translations merged there flow into the next Phi build automatically, credited to you. A web UI (Weblate) is on the way for contributors who would rather never see a git command.
+Phi ships in 8 languages, currently machine-seeded and waiting for native speakers to make them feel right. If you can read a JSON file, you can help: every user-visible string in the Phi product family lives in [phibrowser/phi-i18n](https://github.com/phibrowser/phi-i18n), each with context on where it appears and what it does. Translations merged there flow into the next Phi build automatically, credited to you. Prefer a web UI over git? Our Weblate is live at [i18n.phibrowser.com](https://i18n.phibrowser.com): browse every string without an account, sign in to translate, with a shared glossary and context for each one.
 
 ## License
 


### PR DESCRIPTION
Updates the Translations subsection: the Weblate web UI is no longer "on the way", it is fully operational at [i18n.phibrowser.com](https://i18n.phibrowser.com) with anonymous browsing, Phi Account or e-mail sign-in, the full catalog, and a shared glossary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)