### PR TITLE
Chore/terms compliant open source build

### DIFF
--- a/Configs/OpenSource.xcconfig
+++ b/Configs/OpenSource.xcconfig
@@ -9,9 +9,9 @@ APP_ENTITLEMENTS = Resources/PhiBrowser-OpenSource.entitlements
 // Asset Catalog
 ASSETCATALOG_COMPILER_APPICON_NAME = PhiIcon
 
-// Sparkle Update Feed
-APPCAST_PATH = 
-
 // Build Settings
+PHI_OSS_BUILD = YES
 ONLY_ACTIVE_ARCH = YES
 SWIFT_OPTIMIZATION_LEVEL = -Onone
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) PHI_OSS_BUILD
+EXCLUDED_SOURCE_FILE_NAMES = $(inherited) Sparkle.framework

--- a/Configs/OpenSource.xcconfig
+++ b/Configs/OpenSource.xcconfig
@@ -3,7 +3,7 @@
 
 // Product Settings
 PRODUCT_NAME = Phi
-PRODUCT_BUNDLE_IDENTIFIER = com.phibrowser.canary.Mac
+PRODUCT_BUNDLE_IDENTIFIER = com.phibrowser.opensource.Mac
 APP_ENTITLEMENTS = Resources/PhiBrowser-OpenSource.entitlements
 
 // Asset Catalog
@@ -14,4 +14,5 @@ PHI_OSS_BUILD = YES
 ONLY_ACTIVE_ARCH = YES
 SWIFT_OPTIMIZATION_LEVEL = -Onone
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) PHI_OSS_BUILD
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) PHI_OSS_BUILD=1
 EXCLUDED_SOURCE_FILE_NAMES = $(inherited) Sparkle.framework

--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -2537,6 +2537,7 @@
 				A8F100312FF0000000000031 /* Copy Uninstall Helper */,
 				B17DE00000000000000000E2 /* Copy Bitwarden Helper */,
 				B17DE00000000000000000E7 /* Copy Bitwarden GPL Notices */,
+				E10000000000000000000010 /* Prune OpenSource Build */,
 			);
 			buildRules = (
 			);
@@ -2699,6 +2700,31 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		E10000000000000000000010 /* Prune OpenSource Build */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Prune OpenSource Build";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"$PHI_OSS_BUILD\" != \"YES\" ]; then\n    exit 0\nfi\n\n/bin/sh \"$SRCROOT/scripts/prune_open_source_build.sh\" \"$TARGET_BUILD_DIR/$WRAPPER_NAME\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		54A200332FE1000000000033 /* Sources */ = {
@@ -4087,10 +4113,16 @@
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 4;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_HARDENED_RUNTIME = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Frameworks",
+				);
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-Wl,-dead_strip_dylibs",
+					"-Wl,-needed_framework,Phi\\ Framework",
 				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",

--- a/Sources/AccountController/Account.swift
+++ b/Sources/AccountController/Account.swift
@@ -131,6 +131,7 @@ class AccountController {
     }
 
     private func syncTelemetryIdentity(for account: Account?) {
+        #if !PHI_OSS_BUILD
         SentryService.configureUser(account)
 
         guard let bridge = ChromiumLauncher.sharedInstance().bridge,
@@ -144,6 +145,7 @@ class AccountController {
             ["chromium_metrics_client_id": $0] as [String: Any]
         }
         PostHogSDK.shared.identify(sub, userProperties: properties)
+        #endif
     }
 
     /// Best-effort refresh of the existing per-account profile cache. The

--- a/Sources/Application/AppController+Menu.swift
+++ b/Sources/Application/AppController+Menu.swift
@@ -449,6 +449,7 @@ extension AppController {
             } else
             
             if menuRole == .app, let subMenu = menuItem.submenu {
+                #if !PHI_OSS_BUILD
                 subMenu.items.removeAll { $0.tag == AppController.checkForUpdateItemTag }
 
                 for (index, item) in subMenu.items.enumerated() {
@@ -462,7 +463,7 @@ extension AppController {
                         break
                     }
                 }
-
+                #endif
             } else
             
             if menuRole == .edit, let subMenu = menuItem.submenu {
@@ -2150,6 +2151,7 @@ extension AppController {
             return ApplicationState.shared.canUseBrowser
         }
         
+        #if !PHI_OSS_BUILD
         if item.action == #selector(checkForUpdate(_:)) {
             guard updater?.canCheckForUpdates == true else { return false }
 
@@ -2160,6 +2162,7 @@ extension AppController {
                 return true
             }
         }
+        #endif
 
         if item.action == #selector(selectLayoutMode(_:)) {
             if let menuItem = item as? NSMenuItem {

--- a/Sources/Application/AppController+Sparkle.swift
+++ b/Sources/Application/AppController+Sparkle.swift
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an Apache license that can be
 // found in the LICENSE file.
 
+#if !PHI_OSS_BUILD
 import Foundation
 import Sparkle
 
@@ -163,3 +164,4 @@ extension AppController {
         }
     }
 }
+#endif

--- a/Sources/Application/AppController.swift
+++ b/Sources/Application/AppController.swift
@@ -81,23 +81,27 @@ import PostHog
         // whether its windows may be shown. The async refresh below can still
         // recover a fresher shared credential snapshot afterwards.
         resolveBrowserAccessFromAuthentication(checkChromiumLaunchStatus: true)
-        if ApplicationState.shared.isGuest {
+        if ApplicationState.shared.isGuest || !PhiBuildCapabilities.supportsAI {
             GuestModePreferences.disableAI()
         }
-        LoginController.shared.prepareGuestMigrationRecoveryBeforeChromiumLaunch()
         let permitsSentinelLaunch: Bool
-        if ApplicationState.shared.isGuest {
-            permitsSentinelLaunch =
-                AuthManager.shared
-                    .prepareGuestSessionBoundaryBeforeServiceLaunch(
-                        preserveLocalRecoveryCredentials:
-                            ApplicationState.shared
-                                .isGuestMigrationRecoveryInProgress
-                    )
+        if PhiBuildCapabilities.supportsAuthentication {
+            LoginController.shared.prepareGuestMigrationRecoveryBeforeChromiumLaunch()
+            if ApplicationState.shared.isGuest {
+                permitsSentinelLaunch =
+                    AuthManager.shared
+                        .prepareGuestSessionBoundaryBeforeServiceLaunch(
+                            preserveLocalRecoveryCredentials:
+                                ApplicationState.shared
+                                    .isGuestMigrationRecoveryInProgress
+                        )
+            } else {
+                permitsSentinelLaunch = true
+            }
+            LoginController.shared.refreshLoginStatusOnLaunching()
         } else {
             permitsSentinelLaunch = true
         }
-        LoginController.shared.refreshLoginStatusOnLaunching()
         
         //        ASWebAuthenticationSessionWebBrowserSessionManager.shared.sessionHandler = self
         
@@ -264,7 +268,9 @@ import PostHog
     }
     
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
-        if !ApplicationState.shared.canUseBrowser {
+        let canUseBrowser = !PhiBuildCapabilities.supportsAuthentication
+            || ApplicationState.shared.canUseBrowser
+        if !canUseBrowser {
             if !ApplicationState.shared.isGuestMigrationRecoveryInProgress {
                 LoginController.shared.showLoginWindow()
             }
@@ -312,8 +318,10 @@ import PostHog
     }
     
     func application(_ application: NSApplication, open urls: [URL]) {
-        for url in urls where AuthManager.shared.resumeExternalBrowserAuthentication(with: url) {
-            return
+        if PhiBuildCapabilities.supportsAuthentication {
+            for url in urls where AuthManager.shared.resumeExternalBrowserAuthentication(with: url) {
+                return
+            }
         }
 
         if !ApplicationState.shared.canUseBrowser {
@@ -422,7 +430,9 @@ import PostHog
     }
 
     @objc private func loginCompleted(_ notification: Notification) {
-        if LoginController.shared.isLoggedin() {
+        if !PhiBuildCapabilities.supportsAuthentication {
+            ApplicationState.shared.enterGuestMode()
+        } else if LoginController.shared.isLoggedin() {
             ApplicationState.shared.markSignedIn()
         } else {
             resolveBrowserAccessFromAuthentication(checkChromiumLaunchStatus: false)
@@ -485,6 +495,11 @@ import PostHog
     private func resolveBrowserAccessFromAuthentication(
         checkChromiumLaunchStatus: Bool
     ) {
+        guard PhiBuildCapabilities.supportsAuthentication else {
+            ApplicationState.shared.enterGuestMode()
+            return
+        }
+
         // A persisted Guest choice deliberately outranks credentials that were
         // staged but never committed. LoginController performs the one
         // identity-bound recovery when a migration journal exists; ordinary

--- a/Sources/Application/AppController.swift
+++ b/Sources/Application/AppController.swift
@@ -9,7 +9,9 @@ import SwiftData
 import CocoaLumberjackSwift
 import Kingfisher
 import Auth0
+#if !PHI_OSS_BUILD
 import Sparkle
+#endif
 import WebKit
 import Settings
 import PostHog
@@ -26,6 +28,7 @@ import PostHog
     var settingsPanesIncludeDeveloper = false
 
     var container: ModelContainer?
+    #if !PHI_OSS_BUILD
     var updater: SPUUpdater?
     var sparkleUserDriver: PhiSparkleUserDriver?
     /// Sparkle update state
@@ -36,6 +39,7 @@ import PostHog
             }
         }
     }
+    #endif
     
     var menuObservation: NSKeyValueObservation?
 
@@ -102,7 +106,9 @@ import PostHog
         
         //        ASWebAuthenticationSessionWebBrowserSessionManager.shared.sessionHandler = self
         
+        #if !PHI_OSS_BUILD
         setupSparkle()
+        #endif
         setupKinfisherCache()
         
         SentryService.setup()

--- a/Sources/Application/AppController.swift
+++ b/Sources/Application/AppController.swift
@@ -106,7 +106,9 @@ import PostHog
         //        ASWebAuthenticationSessionWebBrowserSessionManager.shared.sessionHandler = self
         
         ChromiumLauncher.sharedInstance().bridge?.applicationDidFinishLaunching(notification)
+        #if !PHI_OSS_BUILD
         SentinelTelemetryConsentPublisher.shared.start()
+        #endif
         
         //        ASWebAuthenticationSessionWebBrowserSessionManager.shared.sessionHandler = self
         

--- a/Sources/Application/AppController.swift
+++ b/Sources/Application/AppController.swift
@@ -106,6 +106,14 @@ import PostHog
         //        ASWebAuthenticationSessionWebBrowserSessionManager.shared.sessionHandler = self
         
         ChromiumLauncher.sharedInstance().bridge?.applicationDidFinishLaunching(notification)
+        #if PHI_OSS_BUILD
+        ChromiumLauncher.sharedInstance().bridge?.setMetricsReportingEnabled(false) { effectiveEnabled in
+            if effectiveEnabled {
+                AppLogWarn("[OSS] Failed to disable Chromium metrics reporting")
+            }
+        }
+        #endif
+        
         #if !PHI_OSS_BUILD
         SentinelTelemetryConsentPublisher.shared.start()
         #endif

--- a/Sources/Application/AppController.swift
+++ b/Sources/Application/AppController.swift
@@ -115,7 +115,9 @@ import PostHog
         #endif
         setupKinfisherCache()
         
+        #if !PHI_OSS_BUILD
         SentryService.setup()
+        #endif
         
         MemoryUsageMonitor.shared.start()
 
@@ -193,6 +195,7 @@ import PostHog
         // The startup takeover for the user-data removal mechanism runs in
         // main() (UserDataRemovalBootstrap), before Chromium reads any state.
 
+        #if !PHI_OSS_BUILD
         // Set up PostHog before `didFinishLaunchingNotification` fires so the
         // SDK can observe the app-opened lifecycle event. If either value is
         // missing the app runs without analytics.
@@ -215,6 +218,7 @@ import PostHog
         } else {
             AppLogInfo("PostHog: project token or host not set in PostHogConfig.generated.swift; skipping init")
         }
+        #endif
 
         chromiumBridge?.applicationWillFinishLaunching(notification)
     }

--- a/Sources/Application/SentinelHelper.swift
+++ b/Sources/Application/SentinelHelper.swift
@@ -229,6 +229,7 @@ enum AuthenticatedSentinelSessionLifecycle {
         launchOnLogin: Bool =
             PhiPreferences.AISettings.launchSentinelOnLogin.loadValue()
     ) {
+        guard PhiBuildCapabilities.supportsAI else { return }
         let browserAccessState =
             ApplicationState.shared.browserAccessState
         let isAuthenticated = ApplicationState.shared.isAuthenticated

--- a/Sources/ChromiumBridge/ChromiumLauncher.m
+++ b/Sources/ChromiumBridge/ChromiumLauncher.m
@@ -205,7 +205,13 @@
     if ([self.bridge conformsToProtocol:@protocol(PhiChromiumBridgeProtocol)]) {
         self.bridge.delegate = [PhiChromiumCoordinator shared];
     }
+#if PHI_OSS_BUILD
+    if ([self initializeChromiumWithLaunchArgc:argc launchArgv:argv]) {
+        [self.bridge setMetricsReportingEnabled:NO completion:^(__unused BOOL effectiveEnabled) {}];
+    }
+#else
     [self initializeChromiumWithLaunchArgc:argc launchArgv:argv];
+#endif
 
 }
 

--- a/Sources/ChromiumBridge/ChromiumLauncher.m
+++ b/Sources/ChromiumBridge/ChromiumLauncher.m
@@ -205,13 +205,7 @@
     if ([self.bridge conformsToProtocol:@protocol(PhiChromiumBridgeProtocol)]) {
         self.bridge.delegate = [PhiChromiumCoordinator shared];
     }
-#if PHI_OSS_BUILD
-    if ([self initializeChromiumWithLaunchArgc:argc launchArgv:argv]) {
-        [self.bridge setMetricsReportingEnabled:NO completion:^(__unused BOOL effectiveEnabled) {}];
-    }
-#else
     [self initializeChromiumWithLaunchArgc:argc launchArgv:argv];
-#endif
 
 }
 

--- a/Sources/ChromiumBridge/PhiChromiumCoordinator.swift
+++ b/Sources/ChromiumBridge/PhiChromiumCoordinator.swift
@@ -30,7 +30,10 @@ import SwiftUI
 }
 
 extension PhiChromiumCoordinator: PhiChromiumBridgeDelegate {
-    func shouldEnablePhiExtensions() -> Bool { PhiPreferences.AISettings.phiAIEnabled.loadValue() }
+    func shouldEnablePhiExtensions() -> Bool {
+        PhiBuildCapabilities.supportsAI
+            && PhiPreferences.AISettings.phiAIEnabled.loadValue()
+    }
 
     /// Source of truth for the browser-process DevTools gate that blocks
     /// remote-debugging clients from the user's own Spaces. Read live per gated
@@ -328,6 +331,10 @@ extension PhiChromiumCoordinator: PhiChromiumBridgeDelegate {
     }
     
     func canShowChromiumWindow() -> Bool {
+        guard PhiBuildCapabilities.supportsAuthentication else {
+            return true
+        }
+
         if ApplicationState.shared.isGuest {
             let canUseBrowser = ApplicationState.shared.canUseBrowser
             AppLogDebug(
@@ -352,13 +359,15 @@ extension PhiChromiumCoordinator: PhiChromiumBridgeDelegate {
     }
 
     func isPhiGuestMode() -> Bool {
-        ApplicationState.shared.isGuest
+        !PhiBuildCapabilities.supportsAuthentication
+            || ApplicationState.shared.isGuest
     }
 
     /// Returns the current Phi account identity from the same per-account
     /// profile cache used by the Mac account settings page. The ID-token
     /// identity covers the short window before the init prefetch completes.
     func getPhiAccountInfo() -> [String: Any]? {
+        guard PhiBuildCapabilities.supportsAuthentication else { return nil }
         guard ApplicationState.shared.isAuthenticated else { return nil }
         guard let account = AccountController.shared.account else { return nil }
         let profile: Profile? = account.userDefaults.codableValue(
@@ -380,6 +389,7 @@ extension PhiChromiumCoordinator: PhiChromiumBridgeDelegate {
     }
     
     func showLoginUI() {
+        guard PhiBuildCapabilities.supportsAuthentication else { return }
         AppLogInfo("🌐 [Chromium] showLoginUI called by Chromium")
         Task { @MainActor in
             LoginController.shared.showLoginWindow()
@@ -426,6 +436,7 @@ extension PhiChromiumCoordinator: PhiChromiumBridgeDelegate {
     }
 
     func getAuth0AccessTokenSyncly() -> String {
+        guard PhiBuildCapabilities.supportsAuthentication else { return "" }
         guard ApplicationState.shared.isAuthenticated else {
             AppLogDebug("🌐 [Chromium] getAuth0AccessTokenSyncly called without an authenticated browser session")
             return ""

--- a/Sources/States/ApplicationState.swift
+++ b/Sources/States/ApplicationState.swift
@@ -5,6 +5,16 @@
 
 import Foundation
 
+enum PhiBuildCapabilities {
+    #if PHI_OSS_BUILD
+    static let supportsAuthentication = false
+    static let supportsAI = false
+    #else
+    static let supportsAuthentication = true
+    static let supportsAI = true
+    #endif
+}
+
 enum BrowserAccessState: Equatable {
     case loginRequired
     case guest
@@ -26,6 +36,7 @@ final class ApplicationState {
 
     private let defaults: UserDefaults
     private let notificationCenter: NotificationCenter
+    private let supportsAuthentication: Bool
     private let stateLock = NSLock()
     private var storedBrowserAccessState: BrowserAccessState
     /// In-memory fence spanning authenticated-account publication and Native
@@ -77,13 +88,20 @@ final class ApplicationState {
 
     init(
         defaults: UserDefaults = .standard,
-        notificationCenter: NotificationCenter = .default
+        notificationCenter: NotificationCenter = .default,
+        supportsAuthentication: Bool = PhiBuildCapabilities.supportsAuthentication
     ) {
         self.defaults = defaults
         self.notificationCenter = notificationCenter
-        storedBrowserAccessState = defaults.bool(forKey: Self.guestModeEnabledKey)
-            ? .guest
-            : .loginRequired
+        self.supportsAuthentication = supportsAuthentication
+        if supportsAuthentication {
+            storedBrowserAccessState = defaults.bool(forKey: Self.guestModeEnabledKey)
+                ? .guest
+                : .loginRequired
+        } else {
+            storedBrowserAccessState = .guest
+            defaults.set(true, forKey: Self.guestModeEnabledKey)
+        }
     }
 
     /// Resolves the synchronous launch state before Chromium asks whether its
@@ -94,6 +112,16 @@ final class ApplicationState {
         hasRecoverableLoginSession: Bool,
         isAuthenticated: Bool
     ) {
+        guard supportsAuthentication else {
+            transition(
+                to: .guest,
+                persistedGuestChoice: true,
+                guestPromotionInProgress: false,
+                guestMigrationRecoveryInProgress: false
+            )
+            return
+        }
+
         let transitionSnapshot = guestTransitionSnapshot()
         if isAuthenticationBlocked && persistedGuestChoice {
             // The fence blocks authenticated access, not local browsing. A
@@ -166,6 +194,7 @@ final class ApplicationState {
     func beginGuestMigrationRecovery(
         notifyBrowserAccessChange: Bool = true
     ) -> Bool {
+        guard supportsAuthentication else { return false }
         stateLock.lock()
         guard storedBrowserAccessState == .guest,
               defaults.bool(forKey: Self.guestModeEnabledKey) else {
@@ -208,6 +237,7 @@ final class ApplicationState {
     /// regular login or account refresh.
     @discardableResult
     func beginGuestAccountPromotion() -> Bool {
+        guard supportsAuthentication else { return false }
         stateLock.lock()
         defer { stateLock.unlock() }
         guard storedBrowserAccessState == .guest,
@@ -232,6 +262,7 @@ final class ApplicationState {
     /// until `markSignedIn()` commits the transaction.
     @discardableResult
     func resumeBrowserAccessForGuestAccountPromotion() -> Bool {
+        guard supportsAuthentication else { return false }
         stateLock.lock()
         guard storedBrowserAccessState == .guest,
               guestAccountPromotionInProgress,
@@ -282,7 +313,7 @@ final class ApplicationState {
     /// removal drops the whole preferences domain.
     func clearPersistedGuestChoice() {
         stateLock.lock()
-        defaults.set(false, forKey: Self.guestModeEnabledKey)
+        defaults.set(!supportsAuthentication, forKey: Self.guestModeEnabledKey)
         stateLock.unlock()
     }
 
@@ -297,20 +328,28 @@ final class ApplicationState {
         guestMigrationRecoveryInProgress: Bool? = nil
     ) {
         stateLock.lock()
-        if let persistedGuestChoice {
-            defaults.set(persistedGuestChoice, forKey: Self.guestModeEnabledKey)
-        }
-        if let guestPromotionInProgress {
-            self.guestAccountPromotionInProgress = guestPromotionInProgress
+        let effectiveState = supportsAuthentication ? newState : .guest
+        if supportsAuthentication {
+            if let persistedGuestChoice {
+                defaults.set(persistedGuestChoice, forKey: Self.guestModeEnabledKey)
+            }
+            if let guestPromotionInProgress {
+                self.guestAccountPromotionInProgress = guestPromotionInProgress
+            }
+        } else {
+            defaults.set(true, forKey: Self.guestModeEnabledKey)
+            self.guestAccountPromotionInProgress = false
         }
         let oldRecoveryState = self.guestMigrationRecoveryInProgress
-        if let guestMigrationRecoveryInProgress {
+        if !supportsAuthentication {
+            self.guestMigrationRecoveryInProgress = false
+        } else if let guestMigrationRecoveryInProgress {
             self.guestMigrationRecoveryInProgress =
                 guestMigrationRecoveryInProgress
         }
-        let didChange = storedBrowserAccessState != newState
+        let didChange = storedBrowserAccessState != effectiveState
             || oldRecoveryState != self.guestMigrationRecoveryInProgress
-        storedBrowserAccessState = newState
+        storedBrowserAccessState = effectiveState
         stateLock.unlock()
 
         guard didChange else { return }

--- a/Sources/States/BrowserState+ToggleAI.swift
+++ b/Sources/States/BrowserState+ToggleAI.swift
@@ -8,12 +8,13 @@ import Cocoa
 
 extension BrowserState {
     func onAIEnabledChanged(_ enabled: Bool, sentinelOnLogin: Bool) {
-        if enabled {
+        let effectiveEnabled = enabled && PhiBuildCapabilities.supportsAI
+        if effectiveEnabled {
             ChromiumLauncher.sharedInstance().bridge?.enablePhiExtensions()
         } else {
             ChromiumLauncher.sharedInstance().bridge?.disablePhiExtensions(false)
         }
-        if enabled {
+        if effectiveEnabled {
             updateSentinelRegistration(sentinelOnLogin)
         } else {
             Task {

--- a/Sources/States/BrowserState.swift
+++ b/Sources/States/BrowserState.swift
@@ -995,6 +995,10 @@ class BrowserState {
     /// Toggle AI Chat for the currently focused tab
     /// The collapse state is now managed per-tab, not globally
     func toggleAIChat(_ collapse: Bool? = nil) {
+        guard collapse == true
+                || PhiPreferences.AISettings.phiAIEnabled.loadValue() else {
+            return
+        }
         // Defense in depth: any caller (extension, debug, etc.) hitting this
         // path during placeholder mode would operate on a stale focusingTab.
         // Primary entry points are gated upstream; this is the safety net.

--- a/Sources/UserInterface/Common/Tabs/Tab.swift
+++ b/Sources/UserInterface/Common/Tabs/Tab.swift
@@ -599,6 +599,11 @@ class Tab: WebContentRepresentable {
     
     /// Toggles the AI Chat sidebar for this tab.
     func toggleAIChat(_ collapse: Bool? = nil) {
+        guard collapse == true
+                || PhiPreferences.AISettings.phiAIEnabled.loadValue() else {
+            aiChatCollapsed = true
+            return
+        }
         if let collapse {
             aiChatCollapsed = collapse
         } else {

--- a/Sources/UserInterface/Onboarding/LoginController.swift
+++ b/Sources/UserInterface/Onboarding/LoginController.swift
@@ -32,9 +32,17 @@ struct PostLoginAIEnableIntent {
 
     @discardableResult
     mutating func enableAIIfRequested(
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        supportsAI: Bool = PhiBuildCapabilities.supportsAI
     ) -> Bool {
         guard consume() else { return false }
+        guard supportsAI else {
+            defaults.set(
+                false,
+                forKey: PhiPreferences.AISettings.phiAIEnabled.rawValue
+            )
+            return false
+        }
 
         defaults.set(
             true,
@@ -126,6 +134,12 @@ class LoginController {
     
     @MainActor
     func showLoginWindow() {
+        guard PhiBuildCapabilities.supportsAuthentication else {
+            ApplicationState.shared.enterGuestMode()
+            GuestModePreferences.disableAI()
+            return
+        }
+
         AppLogDebug("🔐 [Login] showLoginWindow called")
         if enterGuestModeInsteadOfOnboardingIfRequested() {
             return
@@ -164,6 +178,10 @@ class LoginController {
 
     @MainActor
     func showLoginWindowToEnableAI() {
+        guard PhiBuildCapabilities.supportsAI else {
+            GuestModePreferences.disableAI()
+            return
+        }
         postLoginAIEnableIntent.request()
         showLoginWindow()
     }
@@ -369,6 +387,15 @@ class LoginController {
     }
     
     func refreshLoginStatusOnLaunching() {
+        guard PhiBuildCapabilities.supportsAuthentication else {
+            ApplicationState.shared.enterGuestMode()
+            NotificationCenter.default.post(
+                name: .loginStatusRefreshCompleted,
+                object: nil
+            )
+            return
+        }
+
         Task { @MainActor in
             if ApplicationState.shared.isGuest,
                !ApplicationState.shared.isGuestMigrationRecoveryInProgress {

--- a/Sources/UserInterface/Preferences/AISettings/AISettingHostingViewController.swift
+++ b/Sources/UserInterface/Preferences/AISettings/AISettingHostingViewController.swift
@@ -41,7 +41,11 @@ final class AISettingHostingViewController: NSViewController {
     override func viewWillAppear() {
         super.viewWillAppear()
         hostingController?.view.needsLayout = true
-        connectorViewModel.loadConnectionsIfNeeded()
+        if PhiBuildCapabilities.supportsAI {
+            connectorViewModel.loadConnectionsIfNeeded()
+        } else {
+            connectorViewModel.suspendForUnauthenticatedAccess()
+        }
     }
 
 }

--- a/Sources/UserInterface/Preferences/AISettings/AISettingView.swift
+++ b/Sources/UserInterface/Preferences/AISettings/AISettingView.swift
@@ -19,13 +19,25 @@ struct AISettingView: View {
     }
 
     private var aiFeaturesAvailable: Bool {
-        phiAIEnabled && !isGuest
+        PhiBuildCapabilities.supportsAI && phiAIEnabled && !isGuest
+    }
+
+    private var canToggleAI: Bool {
+        PhiBuildCapabilities.supportsAI && !isGuest
+    }
+
+    private var shouldShowGuestLoginPrompt: Bool {
+        PhiBuildCapabilities.supportsAI && isGuest
     }
 
     private var aiEnabledBinding: Binding<Bool> {
         Binding(
-            get: { phiAIEnabled },
+            get: { PhiBuildCapabilities.supportsAI && phiAIEnabled },
             set: { newValue in
+                guard PhiBuildCapabilities.supportsAI else {
+                    phiAIEnabled = false
+                    return
+                }
                 if newValue {
                     phiAIEnabled = true
                 } else {
@@ -40,7 +52,8 @@ struct AISettingView: View {
             VStack(alignment: .leading, spacing: 24) {
                 AIMasterControlSection(
                     isOn: aiEnabledBinding,
-                    isGuest: isGuest,
+                    enabled: canToggleAI,
+                    showsLoginPrompt: shouldShowGuestLoginPrompt,
                     loginAction: logInToEnableAI
                 )
                 BrowserMemorySectionView(enabled: aiFeaturesAvailable)
@@ -51,7 +64,9 @@ struct AISettingView: View {
                     connectorViewModel: connectorViewModel,
                     enabled: aiFeaturesAvailable
                 )
-                PhiLinkSettingsSectionView(enabled: phiAIEnabled)
+                PhiLinkSettingsSectionView(
+                    enabled: PhiBuildCapabilities.supportsAI && phiAIEnabled
+                )
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 36)
@@ -60,6 +75,12 @@ struct AISettingView: View {
         .themedBackground(PhiPreferences.fixedWindowBackground)
         .frame(width: 680, height: 561)
         .onChange(of: phiAIEnabled) { oldValue, newValue in
+            guard PhiBuildCapabilities.supportsAI else {
+                if newValue {
+                    phiAIEnabled = false
+                }
+                return
+            }
             if newValue == false {
                 connectorViewModel.disconnectAll()
             }
@@ -108,18 +129,19 @@ struct AISettingView: View {
 
 private struct AIMasterControlSection: View {
     @Binding var isOn: Bool
-    let isGuest: Bool
+    let enabled: Bool
+    let showsLoginPrompt: Bool
     let loginAction: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            if isGuest {
+            if showsLoginPrompt {
                 GuestAILoginPromptRow(loginAction: loginAction)
             }
 
             AIEnableToggleRow(
                 isOn: $isOn,
-                enabled: !isGuest
+                enabled: enabled
             )
         }
     }

--- a/Sources/UserInterface/Preferences/Account/AccountSettingViewController.swift
+++ b/Sources/UserInterface/Preferences/Account/AccountSettingViewController.swift
@@ -144,6 +144,13 @@ class AccountSettingViewController: NSViewController, SettingsPane {
     }
 
     private func setupUI() {
+        #if PHI_OSS_BUILD
+        view.addSubview(defaultBrowserView)
+        defaultBrowserView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(36)
+            make.left.right.equalToSuperview().inset(36)
+        }
+        #else
         // Profile card on the left
         view.addSubview(profileCardView)
         profileCardView.snp.makeConstraints { make in
@@ -232,6 +239,7 @@ class AccountSettingViewController: NSViewController, SettingsPane {
         }
 
         updateAccessPresentation()
+        #endif
     }
 
     private func openAvatarEditor() {

--- a/Sources/UserInterface/Preferences/PhiPreferences.swift
+++ b/Sources/UserInterface/Preferences/PhiPreferences.swift
@@ -199,7 +199,7 @@ extension PhiPreferences {
         var defaultValue: Bool {
             switch self {
             case .phiAIEnabled:
-                return true
+                return PhiBuildCapabilities.supportsAI
             case .enableConnectors:
                 return true
             case .enableConnectorContext:
@@ -216,7 +216,10 @@ extension PhiPreferences {
         }
 
         func loadValue() -> Bool {
-            UserDefaults.standard.bool(forKey: rawValue, default: defaultValue)
+            if self == .phiAIEnabled && !PhiBuildCapabilities.supportsAI {
+                return false
+            }
+            return UserDefaults.standard.bool(forKey: rawValue, default: defaultValue)
         }
 
         static func buildConfig() -> String {
@@ -224,7 +227,7 @@ extension PhiPreferences {
             allCases
                 .filter { $0 != .enableBrowserMemories}
                 .forEach {
-                result[$0.rawValue] = UserDefaults.standard.bool(forKey: $0.rawValue)
+                result[$0.rawValue] = $0.loadValue()
             }
             let data = try? JSONSerialization.data(withJSONObject: result, options: [])
             return String(data: data ?? Data(), encoding: .utf8) ?? "{}"

--- a/Sources/UserInterface/Sidebar/Header/SidebarHeaderView.swift
+++ b/Sources/UserInterface/Sidebar/Header/SidebarHeaderView.swift
@@ -584,6 +584,7 @@ class SidebarHeaderView: NSView, TitlebarAwareHitTestable {
                 .store(in: &cancellables)
         }
 
+        #if !PHI_OSS_BUILD
         // Show the upgrade button once Sparkle reports a downloaded update.
         NotificationCenter.default.publisher(for: .sparkleDidDownloadUpdate)
             .receive(on: RunLoop.main)
@@ -599,6 +600,7 @@ class SidebarHeaderView: NSView, TitlebarAwareHitTestable {
                 self?.hideUpgradeButton()
             }
             .store(in: &cancellables)
+        #endif
 
         #if DEBUG
         applyUITestUpdateOverrideIfNeeded()
@@ -673,7 +675,9 @@ class SidebarHeaderView: NSView, TitlebarAwareHitTestable {
 
     private func upgradeButtonClicked() {
         guard availableUpdateVersion != nil else { return }
+        #if !PHI_OSS_BUILD
         AppController.shared.checkForUpdate(nil)
+        #endif
     }
 
     /// Shows the upgrade button for a downloaded update.

--- a/Sources/UserInterface/Sidebar/SidebarViewController+UpdateReminder.swift
+++ b/Sources/UserInterface/Sidebar/SidebarViewController+UpdateReminder.swift
@@ -3,9 +3,10 @@
 // Use of this source code is governed by an Apache license that can be
 // found in the LICENSE file.
 
+#if !PHI_OSS_BUILD
 import Cocoa
 import SnapKit
-import Sparkle
+
 extension SidebarViewController {
     func showUpdateReminder(version: String) {
         let reminderView = ReminderView(version: version)
@@ -184,3 +185,4 @@ class ReminderView: NSView {
         addTrackingArea(trackingArea)
     }
 }
+#endif

--- a/Sources/UserInterface/Update/PhiSparkleUpdateViewController.swift
+++ b/Sources/UserInterface/Update/PhiSparkleUpdateViewController.swift
@@ -5,6 +5,7 @@
 // found in the LICENSE file.
     
 
+#if !PHI_OSS_BUILD
 import Cocoa
 import Sparkle
 import WebKit
@@ -901,3 +902,4 @@ enum PhiSparkleUpdateWindowMode {
         }
     }
 }
+#endif

--- a/Sources/UserInterface/Update/PhiSparkleUserDriver.swift
+++ b/Sources/UserInterface/Update/PhiSparkleUserDriver.swift
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an Apache license that can be
 // found in the LICENSE file.
 
+#if !PHI_OSS_BUILD
 import Cocoa
 import Sparkle
 import WebKit
@@ -159,3 +160,4 @@ final class PhiSparkleUserDriver: SPUStandardUserDriver {
         return ThemeManager.shared
     }
 }
+#endif

--- a/Tests/PhiBrowserTests/ApplicationStateTests.swift
+++ b/Tests/PhiBrowserTests/ApplicationStateTests.swift
@@ -35,6 +35,35 @@ final class ApplicationStateTests: XCTestCase {
         XCTAssertFalse(state.isAuthenticated)
     }
 
+    func testAuthenticationDisabledAlwaysUsesGuestBrowserAccess() {
+        let state = makeState(supportsAuthentication: false)
+
+        XCTAssertEqual(state.browserAccessState, .guest)
+        XCTAssertTrue(state.canUseBrowser)
+        XCTAssertTrue(state.isGuest)
+        XCTAssertFalse(state.isAuthenticated)
+
+        state.resolveInitialAccess(
+            isAuthenticationBlocked: true,
+            hasRecoverableLoginSession: true,
+            isAuthenticated: true
+        )
+        state.markSignedIn()
+        state.requireLogin()
+        state.clearPersistedGuestChoice()
+
+        XCTAssertEqual(state.browserAccessState, .guest)
+        XCTAssertTrue(state.canUseBrowser)
+        XCTAssertTrue(state.isGuest)
+        XCTAssertFalse(state.isAuthenticated)
+        XCTAssertFalse(state.beginGuestMigrationRecovery())
+        XCTAssertFalse(state.beginGuestAccountPromotion())
+        XCTAssertEqual(
+            makeState(supportsAuthentication: false).browserAccessState,
+            .guest
+        )
+    }
+
     func testGuestChoicePersistsAcrossInstances() {
         let state = makeState()
         state.enterGuestMode()
@@ -262,10 +291,13 @@ final class ApplicationStateTests: XCTestCase {
         wait(for: [stateChanges], timeout: 0.1)
     }
 
-    private func makeState() -> ApplicationState {
+    private func makeState(
+        supportsAuthentication: Bool = true
+    ) -> ApplicationState {
         ApplicationState(
             defaults: defaults,
-            notificationCenter: notificationCenter
+            notificationCenter: notificationCenter,
+            supportsAuthentication: supportsAuthentication
         )
     }
 }

--- a/Tests/PhiBrowserTests/GuestModeUITests.swift
+++ b/Tests/PhiBrowserTests/GuestModeUITests.swift
@@ -60,10 +60,14 @@ final class GuestModeUITests: XCTestCase {
         intent.request()
 
         XCTAssertTrue(intent.isPending)
-        XCTAssertTrue(intent.enableAIIfRequested(defaults: defaults))
+        XCTAssertTrue(
+            intent.enableAIIfRequested(defaults: defaults, supportsAI: true)
+        )
         XCTAssertTrue(defaults.bool(forKey: GuestModePreferences.aiEnabledKey))
         XCTAssertFalse(intent.isPending)
-        XCTAssertFalse(intent.enableAIIfRequested(defaults: defaults))
+        XCTAssertFalse(
+            intent.enableAIIfRequested(defaults: defaults, supportsAI: true)
+        )
     }
 
     func testPostLoginAIEnableIntentCanBeCancelled() {
@@ -74,7 +78,21 @@ final class GuestModeUITests: XCTestCase {
         intent.cancel()
 
         XCTAssertFalse(intent.isPending)
-        XCTAssertFalse(intent.enableAIIfRequested(defaults: defaults))
+        XCTAssertFalse(
+            intent.enableAIIfRequested(defaults: defaults, supportsAI: true)
+        )
+        XCTAssertFalse(defaults.bool(forKey: GuestModePreferences.aiEnabledKey))
+    }
+
+    func testUnsupportedBuildCannotEnableAIFromPostLoginIntent() {
+        var intent = PostLoginAIEnableIntent()
+        defaults.set(true, forKey: GuestModePreferences.aiEnabledKey)
+        intent.request()
+
+        XCTAssertFalse(
+            intent.enableAIIfRequested(defaults: defaults, supportsAI: false)
+        )
+        XCTAssertFalse(intent.isPending)
         XCTAssertFalse(defaults.bool(forKey: GuestModePreferences.aiEnabledKey))
     }
 

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,6 +1,6 @@
 # Analytics
 
-Last updated: 2026-08-04
+Last updated: 2026-08-10
 
 Phi Browser emits product analytics to both [Countly](https://phi-browser-eaade70cfd902.flex.countly.com) (legacy) and [PostHog](https://us.posthog.com/project/385742) (current). Both pipelines run side-by-side; PostHog is the forward-looking source of truth.
 
@@ -10,6 +10,10 @@ Phi Browser emits product analytics to both [Countly](https://phi-browser-eaade7
 | --- | --- | --- |
 | PostHog | `AppController.applicationWillFinishLaunching` (`Sources/Application/AppController.swift`) | `PostHogEnv` → `PostHogGeneratedConfig` (compiled-in constants from `Sources/Utilities/PostHogConfig.generated.swift`) |
 | Countly | `EventTracker.initTracker()` (`Sources/Utilities/EventTrack/EventTracker.swift`) | Hardcoded in source, split by `NIGHTLY_BUILD || DEBUG` |
+
+The `OpenSource` configuration compiles the PostHog initialization block out
+and removes its resource bundle from the final app. See
+[Open-source build](open-source-build.md) for the complete build boundary.
 
 PostHog SDK config uses `captureApplicationLifecycleEvents = true`, so `$app_installed`, `$app_updated`, `$app_opened`, `$app_backgrounded` are auto-captured — these power DAU and retention.
 

--- a/docs/open-source-build.md
+++ b/docs/open-source-build.md
@@ -1,0 +1,118 @@
+# Open-source build
+
+Last updated: 2026-08-10
+
+The `PhiBrowser-OpenSource` scheme builds the existing `PhiBrowser` target with
+the `OpenSource` build configuration. It is not a separate application target.
+This keeps target membership shared while applying the open-source capability
+boundary at compile time and validating the final app bundle after linking.
+
+## `PHI_OSS_BUILD`
+
+`Configs/OpenSource.xcconfig` defines the build setting and forwards it to the
+Swift compiler:
+
+```xcconfig
+PHI_OSS_BUILD = YES
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) PHI_OSS_BUILD
+```
+
+The setting has two purposes:
+
+- Swift code uses `#if PHI_OSS_BUILD` and `#if !PHI_OSS_BUILD` to include or
+  exclude behavior at compile time.
+- Xcode exposes the build setting to build phases as the
+  `PHI_OSS_BUILD` environment variable. The `Prune OpenSource Build` phase
+  runs only when its value is `YES`.
+
+`PHI_OSS_BUILD` is not a runtime preference and must not be added to
+`PhiBrowser-Info.plist`. Code should not attempt to read it from the app bundle.
+Official configurations do not define the condition, so their existing
+behavior follows the `#else` or `#if !PHI_OSS_BUILD` branches.
+
+The configuration also adds `Sparkle.framework` to
+`EXCLUDED_SOURCE_FILE_NAMES`. This is an input-level exclusion; the compile
+guards and final-product checks below remain the authoritative Sparkle
+boundary.
+
+## Capability changes
+
+The flag currently changes these parts of the application:
+
+| Area | Open-source behavior |
+| --- | --- |
+| Updates | Sparkle imports, updater state, initialization, update windows, update reminders, and the **Check for Update** menu item are compiled out. |
+| Authentication | `PhiBuildCapabilities.supportsAuthentication` is `false`. The application remains in Guest mode, Chromium may open without a login, Dock reopen does not show the login window, account information is unavailable, and token requests return an empty value. |
+| AI | `PhiBuildCapabilities.supportsAI` is `false`. The AI preference always reads as disabled, the master switch and dependent settings are disabled, and Chromium is instructed not to enable Phi AI extensions. |
+| Account settings | Only the default-browser section is added to the Account settings pane. Profile, sign-in, guest sign-in notice, sharing, and account controls are omitted. |
+| Crash reporting | `SentryService.setup()` is compiled out, and the Sentry framework is removed from the final app bundle. |
+| Product analytics | PostHog setup and its launch-time snapshot are compiled out, and the PostHog resource bundle is removed from the final app bundle. |
+
+The flag defines startup and capability behavior; it does not promise that
+every source reference to an unavailable SDK is absent. Artifact requirements
+are enforced separately by the pruning phase. It is also not a general network
+kill switch. Any new feature that reaches a Phinomenon-hosted service must add
+an explicit open-source build boundary and corresponding verification.
+
+## `scripts/prune_open_source_build.sh`
+
+The `Prune OpenSource Build` Xcode phase invokes this script after the app has
+been linked and its frameworks and resources have been copied. The phase exits
+immediately for any build where `PHI_OSS_BUILD` is not `YES`, including Canary
+and public builds.
+
+The script accepts one argument: the path to the built `.app`. It then:
+
+1. Validates that the app, its `Contents/MacOS` directory, and its
+   `Info.plist` exist.
+2. Removes these non-open-source runtime components:
+   - `Contents/Frameworks/Sparkle.framework`
+   - `Contents/Frameworks/Sentry.framework`
+   - `Contents/Resources/PostHog_PostHog.bundle`
+3. Verifies that the required `Phi Framework.framework` still exists and that
+   an app executable has a load command for it.
+4. Fails the build if Sparkle content, Sparkle load commands, Sparkle symbols,
+   or a Sentry load command remains in an app executable.
+5. Deletes and verifies the absence of the Sparkle `Info.plist` keys
+   `SUAutomaticallyUpdate`, `SUEnableAutomaticChecks`, `SUFeedURL`,
+   `SUPublicEDKey`, and `SUScheduledCheckInterval`.
+
+The script is intentionally both a pruning step and a build-time regression
+check. When another component must be excluded from the open-source product,
+add its exact bundle path and an appropriate artifact assertion to this script.
+
+Because the open-source scheme shares a target and Swift package graph with
+official builds, package resolution may still fetch or build packages that the
+open-source product does not use. The contract is about the produced app: it
+must not contain or link the excluded runtime components. For Sparkle, the
+script enforces this with bundle, `otool`, and `nm` checks.
+
+## Verification
+
+Build the `PhiBrowser-OpenSource` scheme and inspect the product, not only the
+source or package graph:
+
+```sh
+xcodebuild build \
+  -project Phi.xcodeproj \
+  -scheme PhiBrowser-OpenSource \
+  -destination 'platform=macOS' \
+  -derivedDataPath build/DerivedData-OpenSource
+
+oss_app=build/DerivedData-OpenSource/Build/Products/OpenSource/Phi.app
+
+find "$oss_app" \( -iname '*sparkle*' -o -iname '*sentry*' -o -iname '*posthog*' \)
+otool -L "$oss_app/Contents/MacOS/Phi"
+nm -g "$oss_app/Contents/MacOS/Phi" | rg 'SPU|SUAppcast|Sparkle'
+plutil -p "$oss_app/Contents/Info.plist" | rg 'SU(AutomaticallyUpdate|EnableAutomaticChecks|FeedURL|PublicEDKey|ScheduledCheckInterval)'
+```
+
+The `find`, Sparkle `nm`, and Sparkle plist searches should produce no output,
+and `otool -L` should not contain Sparkle or Sentry. The build phase performs
+the same critical checks and fails the build if those invariants are broken.
+
+The release acceptance check must also launch a clean open-source build and
+confirm through network capture that the default application state makes no
+requests to `*.phibrowser.com`. Build Canary or the relevant official scheme
+separately to confirm that its updater and other official-only components are
+unchanged.

--- a/docs/open-source-build.md
+++ b/docs/open-source-build.md
@@ -15,12 +15,13 @@ Swift compiler:
 ```xcconfig
 PHI_OSS_BUILD = YES
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) PHI_OSS_BUILD
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) PHI_OSS_BUILD=1
 ```
 
 The setting has two purposes:
 
-- Swift code uses `#if PHI_OSS_BUILD` and `#if !PHI_OSS_BUILD` to include or
-  exclude behavior at compile time.
+- Swift and Objective-C code use `#if PHI_OSS_BUILD` and
+  `#if !PHI_OSS_BUILD` to include or exclude behavior at compile time.
 - Xcode exposes the build setting to build phases as the
   `PHI_OSS_BUILD` environment variable. The `Prune OpenSource Build` phase
   runs only when its value is `YES`.
@@ -41,11 +42,14 @@ The flag currently changes these parts of the application:
 
 | Area | Open-source behavior |
 | --- | --- |
+| Application identity | The product uses `com.phibrowser.opensource.Mac`, giving it separate preferences, Application Support, and Chromium user-data storage from Canary and public builds. |
 | Updates | Sparkle imports, updater state, initialization, update windows, update reminders, and the **Check for Update** menu item are compiled out. |
 | Authentication | `PhiBuildCapabilities.supportsAuthentication` is `false`. The application remains in Guest mode, Chromium may open without a login, Dock reopen does not show the login window, account information is unavailable, and token requests return an empty value. |
 | AI | `PhiBuildCapabilities.supportsAI` is `false`. The AI preference always reads as disabled, the master switch and dependent settings are disabled, and Chromium is instructed not to enable Phi AI extensions. |
 | Account settings | Only the default-browser section is added to the Account settings pane. Profile, sign-in, guest sign-in notice, sharing, and account controls are omitted. |
-| Crash reporting | `SentryService.setup()` is compiled out, and the Sentry framework is removed from the final app bundle. |
+| Sentinel | The authenticated Sentinel lifecycle and telemetry publisher are not started, and any bundled Sentinel login item is removed from the final product. |
+| Chromium telemetry | Metrics reporting is set to off by default after Chromium initializes. |
+| Native crash reporting | `SentryService.setup()` is compiled out, and the Sentry framework is removed from the final app bundle. |
 | Product analytics | PostHog setup and its launch-time snapshot are compiled out, and the PostHog resource bundle is removed from the final app bundle. |
 
 The flag defines startup and capability behavior; it does not promise that
@@ -64,15 +68,17 @@ and public builds.
 The script accepts one argument: the path to the built `.app`. It then:
 
 1. Validates that the app, its `Contents/MacOS` directory, and its
-   `Info.plist` exist.
+   `Info.plist` exist, and that the bundle identifier is
+   `com.phibrowser.opensource.Mac`.
 2. Removes these non-open-source runtime components:
    - `Contents/Frameworks/Sparkle.framework`
    - `Contents/Frameworks/Sentry.framework`
    - `Contents/Resources/PostHog_PostHog.bundle`
+   - any bundled Phi Sentinel login item
 3. Verifies that the required `Phi Framework.framework` still exists and that
    an app executable has a load command for it.
 4. Fails the build if Sparkle content, Sparkle load commands, Sparkle symbols,
-   or a Sentry load command remains in an app executable.
+   a Sentry load command, or a bundled Sentinel component remains.
 5. Deletes and verifies the absence of the Sparkle `Info.plist` keys
    `SUAutomaticallyUpdate`, `SUEnableAutomaticChecks`, `SUFeedURL`,
    `SUPublicEDKey`, and `SUScheduledCheckInterval`.

--- a/scripts/prune_open_source_build.sh
+++ b/scripts/prune_open_source_build.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: ${0##*/} <app-path>" >&2
+    exit 2
+fi
+
+app_path=$1
+contents_path="$app_path/Contents"
+macos_path="$contents_path/MacOS"
+info_plist_path="$contents_path/Info.plist"
+
+if [ ! -d "$app_path" ] || [ ! -d "$macos_path" ] || [ ! -f "$info_plist_path" ]; then
+    echo "error: OpenSource app product is incomplete: $app_path" >&2
+    exit 1
+fi
+
+sparkle_framework="$contents_path/Frameworks/Sparkle.framework"
+if [ -e "$sparkle_framework" ]; then
+    /bin/rm -rf "$sparkle_framework"
+fi
+
+phi_framework="$contents_path/Frameworks/Phi Framework.framework"
+if [ ! -d "$phi_framework" ]; then
+    echo "error: required Phi Framework is missing from app product" >&2
+    exit 1
+fi
+
+sparkle_path=$(/usr/bin/find "$app_path" -iname '*sparkle*' -print -quit)
+if [ -n "$sparkle_path" ]; then
+    echo "error: Sparkle content remains in app product: $sparkle_path" >&2
+    exit 1
+fi
+
+phi_framework_linked=NO
+for binary_path in "$macos_path"/*; do
+    [ -f "$binary_path" ] || continue
+    /usr/bin/file "$binary_path" | /usr/bin/grep -q 'Mach-O' || continue
+
+    linked_libraries=$(/usr/bin/otool -L "$binary_path")
+    if printf '%s\n' "$linked_libraries" | /usr/bin/grep -q 'Sparkle.framework'; then
+        echo "error: Sparkle load command remains in $binary_path" >&2
+        exit 1
+    fi
+    if printf '%s\n' "$linked_libraries" | /usr/bin/grep -q 'Phi Framework.framework'; then
+        phi_framework_linked=YES
+    fi
+
+    if /usr/bin/nm -g "$binary_path" 2>/dev/null | /usr/bin/grep -E -q 'SPU|SUAppcast|\$s7Sparkle|_OBJC_(CLASS|METACLASS)_\$_SU'; then
+        echo "error: Sparkle symbol remains in $binary_path" >&2
+        exit 1
+    fi
+done
+
+if [ "$phi_framework_linked" != "YES" ]; then
+    echo "error: required Phi Framework load command is missing" >&2
+    exit 1
+fi
+
+for key in \
+    SUAutomaticallyUpdate \
+    SUEnableAutomaticChecks \
+    SUFeedURL \
+    SUPublicEDKey \
+    SUScheduledCheckInterval
+do
+    /usr/libexec/PlistBuddy -c "Delete :$key" "$info_plist_path" >/dev/null 2>&1 || true
+    if /usr/libexec/PlistBuddy -c "Print :$key" "$info_plist_path" >/dev/null 2>&1; then
+        echo "error: Sparkle Info.plist key remains: $key" >&2
+        exit 1
+    fi
+done
+
+echo "Verified pruned OpenSource product"

--- a/scripts/prune_open_source_build.sh
+++ b/scripts/prune_open_source_build.sh
@@ -17,10 +17,20 @@ if [ ! -d "$app_path" ] || [ ! -d "$macos_path" ] || [ ! -f "$info_plist_path" ]
     exit 1
 fi
 
-sparkle_framework="$contents_path/Frameworks/Sparkle.framework"
-if [ -e "$sparkle_framework" ]; then
-    /bin/rm -rf "$sparkle_framework"
-fi
+remove_component() {
+    component_path=$1
+    if [ -e "$component_path" ]; then
+        /bin/rm -rf "$component_path"
+    fi
+    if [ -e "$component_path" ]; then
+        echo "error: OpenSource component remains in app product: $component_path" >&2
+        exit 1
+    fi
+}
+
+remove_component "$contents_path/Frameworks/Sparkle.framework"
+remove_component "$contents_path/Frameworks/Sentry.framework"
+remove_component "$contents_path/Resources/PostHog_PostHog.bundle"
 
 phi_framework="$contents_path/Frameworks/Phi Framework.framework"
 if [ ! -d "$phi_framework" ]; then
@@ -42,6 +52,10 @@ for binary_path in "$macos_path"/*; do
     linked_libraries=$(/usr/bin/otool -L "$binary_path")
     if printf '%s\n' "$linked_libraries" | /usr/bin/grep -q 'Sparkle.framework'; then
         echo "error: Sparkle load command remains in $binary_path" >&2
+        exit 1
+    fi
+    if printf '%s\n' "$linked_libraries" | /usr/bin/grep -q 'Sentry.framework'; then
+        echo "error: Sentry load command remains in $binary_path" >&2
         exit 1
     fi
     if printf '%s\n' "$linked_libraries" | /usr/bin/grep -q 'Phi Framework.framework'; then

--- a/scripts/prune_open_source_build.sh
+++ b/scripts/prune_open_source_build.sh
@@ -11,9 +11,16 @@ app_path=$1
 contents_path="$app_path/Contents"
 macos_path="$contents_path/MacOS"
 info_plist_path="$contents_path/Info.plist"
+expected_bundle_identifier="com.phibrowser.opensource.Mac"
 
 if [ ! -d "$app_path" ] || [ ! -d "$macos_path" ] || [ ! -f "$info_plist_path" ]; then
     echo "error: OpenSource app product is incomplete: $app_path" >&2
+    exit 1
+fi
+
+bundle_identifier=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$info_plist_path" 2>/dev/null || true)
+if [ "$bundle_identifier" != "$expected_bundle_identifier" ]; then
+    echo "error: OpenSource bundle identifier is '$bundle_identifier', expected '$expected_bundle_identifier'" >&2
     exit 1
 fi
 
@@ -31,6 +38,8 @@ remove_component() {
 remove_component "$contents_path/Frameworks/Sparkle.framework"
 remove_component "$contents_path/Frameworks/Sentry.framework"
 remove_component "$contents_path/Resources/PostHog_PostHog.bundle"
+remove_component "$contents_path/Library/LoginItems/Phi Sentinel.app"
+remove_component "$contents_path/Library/LoginItems/Sentinel.app"
 
 phi_framework="$contents_path/Frameworks/Phi Framework.framework"
 if [ ! -d "$phi_framework" ]; then
@@ -41,6 +50,14 @@ fi
 sparkle_path=$(/usr/bin/find "$app_path" -iname '*sparkle*' -print -quit)
 if [ -n "$sparkle_path" ]; then
     echo "error: Sparkle content remains in app product: $sparkle_path" >&2
+    exit 1
+fi
+
+sentinel_component_path=$(/usr/bin/find "$app_path" \
+    \( -iname '*sentinel*.app' -o -iname '*sentinel*.framework' -o -iname '*sentinel*.bundle' \) \
+    -print -quit)
+if [ -n "$sentinel_component_path" ]; then
+    echo "error: Sentinel component remains in app product: $sentinel_component_path" >&2
     exit 1
 fi
 


### PR DESCRIPTION
### Summary
- Make OpenSource builds guest-only with account, AI, and Phi hosted services disabled.
- Remove Sparkle, Sentry, PostHog, and Sentinel components from OSS products.
- Use an isolated bundle ID and disable Chromium metrics by default while preserving Canary and Release behavior.