### PR TITLE
feat: track Phi Link pairing adoption

### DIFF
--- a/Sources/UserInterface/Preferences/IMChannels/IMChannelsViewModel.swift
+++ b/Sources/UserInterface/Preferences/IMChannels/IMChannelsViewModel.swift
@@ -258,6 +258,7 @@ final class IMChannelsViewModel {
 
             if session.status == "paired" {
                 await stopPolling()
+                await FirstTimeActionTracker.capture(.phiLinkPaired)
                 await loadPairings()
                 await MainActor.run {
                     activeSession = nil

--- a/Sources/Utilities/FirstTimeActionTracker.swift
+++ b/Sources/Utilities/FirstTimeActionTracker.swift
@@ -13,6 +13,7 @@ enum FirstTimeAction: String, CaseIterable {
     case memoryOpened = "memory_opened"
     case agentTask = "agent_task"
     case connectorConnected = "connector_connected"
+    case phiLinkPaired = "phi_link_paired"
 }
 
 @MainActor

--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -122,7 +122,7 @@ are out of scope.
 | `import_types_selected` | The user commits an import; emitted once per selected source with normalized `types`. File imports use an empty array because Chromium detects their contents | `Onboarding/Importer/BrowserDataImporter.swift` |
 | `import_started` | The importer accepts a non-reentrant run and locks its target; includes sorted `source_browsers` | `Onboarding/Importer/BrowserDataImporter.swift` |
 | `import_finished` | All selected Chromium sources and deferred bookmark persistence finish; includes aggregate success, stable failed sources, duration, and an optional low-cardinality `error_code` | `Onboarding/Importer/BrowserDataImporter.swift` |
-| `first_time_action` | An eligible product action first succeeds on this installation; `action` is one of `space_created`, `ai_sidebar_opened`, `import_finished`, `memory_opened`, `agent_task`, or `connector_connected`, with `seconds_since_install` | `Utilities/FirstTimeActionTracker.swift` |
+| `first_time_action` | An eligible product action first succeeds on this installation; `action` is one of `space_created`, `ai_sidebar_opened`, `import_finished`, `memory_opened`, `agent_task`, `connector_connected`, or `phi_link_paired`, with `seconds_since_install` | `Utilities/FirstTimeActionTracker.swift` |
 | `space_created` | A user-created Space succeeds; includes `total_spaces` and whether it uses a non-default profile | `Sidebar/Spaces/CreateSpacePanel.swift` |
 | `profile_created` | A non-fallback profile is successfully created; includes `total_profiles` | `States/ProfileManager.swift` |
 | `space_profile_changed` | A validated Space profile change begins; includes `total_profiles` | `States/Space/SpaceManager.swift` |


### PR DESCRIPTION
## Summary

- track the first successful official Phi Link pairing as `first_time_action` with `action=phi_link_paired`
- reuse the existing per-installation deduplication and PostHog privacy behavior
- do not capture message send/receive activity or pairing identifiers

This is the `dev` follow-up to #116, which was merged into `release/2.8.0`.

## Verification

- `xcodebuild -project Phi.xcodeproj -scheme PhiBrowser -configuration Debug -destination platform=macOS build CODE_SIGNING_ALLOWED=NO`
- `git diff --check`

Targeted unit-test execution was attempted, but the local test runner exited before running tests because `Phi Framework` could not be linked.