### PR TITLE
Add a system share picker: File menu item, address bar menu, and customizable shortcut

### DIFF
--- a/Phi.xcodeproj/project.pbxproj
+++ b/Phi.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		3777EEF42FC4442700C85E41 /* FloatingNewTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3777EEF32FC4442700C85E41 /* FloatingNewTabView.swift */; };
 		377D210F2F51986900A68BE5 /* WebContentContainerViewController+FloatingSidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377D210E2F51986900A68BE5 /* WebContentContainerViewController+FloatingSidebar.swift */; };
 		377D21EC2F52C67300A68BE5 /* WebContentAddressBarMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377D21EB2F52C67300A68BE5 /* WebContentAddressBarMenu.swift */; };
+		3AC0FFEE00000000000000A1 /* PageSharingPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC0FFEE00000000000000A2 /* PageSharingPresenter.swift */; };
 		3787811F2FE942E40028969F /* TimeMachineRollbackPolicy.json in Resources */ = {isa = PBXBuildFile; fileRef = 3787811E2FE942E40028969F /* TimeMachineRollbackPolicy.json */; };
 		378AFF262F78D6780016B334 /* ivy-presto-display-semi-bold.otf in Copy Fonts */ = {isa = PBXBuildFile; fileRef = 378AFF242F78D6530016B334 /* ivy-presto-display-semi-bold.otf */; };
 		378AFF622F78E5EA0016B334 /* BrowserThemeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 378AFF612F78E5EA0016B334 /* BrowserThemeContext.swift */; };
@@ -761,6 +762,7 @@
 		3777EEF32FC4442700C85E41 /* FloatingNewTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingNewTabView.swift; sourceTree = "<group>"; };
 		377D210E2F51986900A68BE5 /* WebContentContainerViewController+FloatingSidebar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebContentContainerViewController+FloatingSidebar.swift"; sourceTree = "<group>"; };
 		377D21EB2F52C67300A68BE5 /* WebContentAddressBarMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebContentAddressBarMenu.swift; sourceTree = "<group>"; };
+		3AC0FFEE00000000000000A2 /* PageSharingPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageSharingPresenter.swift; sourceTree = "<group>"; };
 		3787811E2FE942E40028969F /* TimeMachineRollbackPolicy.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TimeMachineRollbackPolicy.json; sourceTree = "<group>"; };
 		378AFF242F78D6530016B334 /* ivy-presto-display-semi-bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ivy-presto-display-semi-bold.otf"; sourceTree = "<group>"; };
 		378AFF612F78E5EA0016B334 /* BrowserThemeContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserThemeContext.swift; sourceTree = "<group>"; };
@@ -1366,6 +1368,7 @@
 				376195442F5149ED0094A78E /* WebContentHeaderView.swift */,
 				37FC8C912F335942004675B8 /* WebContentProgressBarView.swift */,
 				377D21EB2F52C67300A68BE5 /* WebContentAddressBarMenu.swift */,
+				3AC0FFEE00000000000000A2 /* PageSharingPresenter.swift */,
 			);
 			path = Header;
 			sourceTree = "<group>";
@@ -3407,6 +3410,7 @@
 				37EECF222F0F623A0022A176 /* EmbeddedChatViewController.swift in Sources */,
 				CCEF2CF42E57079000FDDEB2 /* WebContentHeader.swift in Sources */,
 				377D21EC2F52C67300A68BE5 /* WebContentAddressBarMenu.swift in Sources */,
+				3AC0FFEE00000000000000A1 /* PageSharingPresenter.swift in Sources */,
 				CC98F89C2E8BC71800DAD237 /* Settings.swift in Sources */,
 				376CE4092F28917C0093D937 /* NotificationMessageCardView.swift in Sources */,
 				CC2708A92E7A675C00B65AB8 /* Account.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -14382,6 +14382,18 @@
         }
       }
     },
+    "app.fileMenu.sharePage" : {
+      "comment" : "File menu - Share the current page via the macOS share picker",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Share…"
+          }
+        }
+      }
+    },
     "app.helpMenu.exportLogs" : {
       "comment" : "Help menu - Menu item to export Phi and Sentinel logs as a zip archive; visible only when holding Option key",
       "extractionState" : "extracted_with_value",
@@ -69786,6 +69798,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "選取上一個分頁"
+          }
+        }
+      }
+    },
+    "settings.shortcuts.command.sharePage" : {
+      "comment" : "Shortcuts settings - Command title for sharing the current page via the macOS share picker",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Share Page"
           }
         }
       }

--- a/Sources/Application/AppController+Menu.swift
+++ b/Sources/Application/AppController+Menu.swift
@@ -707,12 +707,39 @@ extension AppController {
             }
         }
 
+        // Chromium's File menu ships its own Share submenu on macOS. Phi
+        // replaces it with a single picker-backed item so sharing has one
+        // owner (File menu, address bar menu, and shortcut all route through
+        // PageSharingPresenter). The submenu parent is the only Chromium File
+        // row without a command: its title is localized and its tag is not
+        // stable across Chromium versions, but every other Chromium row
+        // carries an IDC tag and dispatch action while separators identify
+        // themselves — so tag 0 + no action + not a separator is the row.
+        // Removal (not isHidden) so a Chromium-side menu refresh cannot
+        // resurface it without rebuilding the menu, which re-runs this hook.
+        subMenu.items.removeAll { item in
+            !item.isSeparatorItem && item.tag == 0
+                && (item.action == nil || item.submenu != nil)
+        }
+
+        // The removed Share row sat between two separators; collapse the
+        // resulting adjacent pair so the menu doesn't show a double divider.
+        var separatorScanIndex = subMenu.items.count - 1
+        while separatorScanIndex > 0 {
+            if subMenu.items[separatorScanIndex].isSeparatorItem,
+               subMenu.items[separatorScanIndex - 1].isSeparatorItem {
+                subMenu.removeItem(at: separatorScanIndex)
+            }
+            separatorScanIndex -= 1
+        }
+
         // Chromium can replace the main menu wholesale. Remove and reinsert
         // Phi's rows so rebuilding remains idempotent and keeps Kiosk directly
         // below New Incognito Window.
         subMenu.items.removeAll { item in
             item.tag == CommandWrapper.PHI_NEW_KIOSK_WINDOW.rawValue
                 || item.tag == CommandWrapper.PHI_NEW_INCOGNITO_SPACE.rawValue
+                || item.tag == CommandWrapper.PHI_SHARE_PAGE.rawValue
         }
 
         let newKioskWindowItem = NSMenuItem(
@@ -748,6 +775,29 @@ extension AppController {
         }).map { $0 + 1 } ?? subMenu.items.count
         subMenu.insertItem(newKioskWindowItem, at: insertionIndex)
         subMenu.insertItem(newIncognitoSpaceItem, at: insertionIndex + 1)
+
+        let sharePageItem = NSMenuItem(
+            title: NSLocalizedString(
+                "app.fileMenu.sharePage",
+                value: "Share\u{2026}",
+                comment: "File menu - Share the current page via the macOS share picker"
+            ),
+            action: #selector(AppController.sharePageFromMenu(_:)),
+            keyEquivalent: "s"
+        )
+        sharePageItem.keyEquivalentModifierMask = [.control, .option]
+        sharePageItem.tag = CommandWrapper.PHI_SHARE_PAGE.rawValue
+        Shortcuts.updateShortcut(for: sharePageItem)
+        sharePageItem.target = target
+
+        // Same slot Safari uses: directly above Print.
+        if let printIndex = subMenu.items.firstIndex(where: {
+            $0.tag == CommandWrapper.IDC_PRINT.rawValue
+        }) {
+            subMenu.insertItem(sharePageItem, at: printIndex)
+        } else {
+            subMenu.addItem(sharePageItem)
+        }
     }
 
     fileprivate func rebuildDeleteProfileSubmenu(_ menu: NSMenu) {
@@ -1029,6 +1079,11 @@ extension AppController {
             return
         }
         OverlayToastCenter.shared.showURLCopyConfirmation(copiedURLCount: copiedURLCount, in: state)
+    }
+
+    @MainActor
+    @objc func sharePageFromMenu(_ sender: Any?) {
+        MainBrowserWindowControllersManager.shared.activeWindowController?.sharePage(sender)
     }
 
     /// Starts a new AI conversation in the focused tab's sidebar.
@@ -2939,6 +2994,14 @@ extension AppController {
                     : NSLocalizedString("app.editMenu.copySelectedTabURLState", value: "Copy URL", comment: "Edit menu - Single selected-tab URL title when updating menu state")
             }
             return state.hasCopyableSelectedTabURLs
+        }
+        if item.action == #selector(sharePageFromMenu(_:)) {
+            guard let state = MainBrowserWindowControllersManager.shared.getActiveWindowState() else {
+                return false
+            }
+            return MainActor.assumeIsolated {
+                PageSharingPresenter.canShare(tab: state.focusingTab)
+            }
         }
         if item.action == #selector(bookmarkThisTab(_:)) {
             return canBookmarkCurrentTab()

--- a/Sources/CommandDispatcher/CommandDispatcher.swift
+++ b/Sources/CommandDispatcher/CommandDispatcher.swift
@@ -30,6 +30,7 @@ struct CommandDispatcher {
         .PHI_TOGGLE_READER,
         .PHI_NEW_KIOSK_WINDOW,
         .PHI_NEW_INCOGNITO_SPACE,
+        .PHI_SHARE_PAGE,
     ] + CommandWrapper.spaceSelectionCommands
 
     /// Commands swallowed while the focused tab shows the native NTP — it has no
@@ -211,6 +212,12 @@ struct CommandDispatcher {
             let copiedURLCount = state.selectedTabCountForURLCopy
             guard state.copySelectedTabURLs() else { return false }
             OverlayToastCenter.shared.showURLCopyConfirmation(copiedURLCount: copiedURLCount, in: state)
+            return true
+        case .PHI_SHARE_PAGE:
+            guard PageSharingPresenter.canShare(tab: windowController.browserState.focusingTab) else {
+                return false
+            }
+            windowController.sharePage(nil)
             return true
         case .PHI_TOGGLE_READER:
             let state = windowController.browserState

--- a/Sources/UserInterface/MainBrowserWindow/MainBrowserWindowController+Actions.swift
+++ b/Sources/UserInterface/MainBrowserWindow/MainBrowserWindowController+Actions.swift
@@ -53,6 +53,29 @@ extension MainBrowserWindowController {
         return false
     }
     
+    @IBAction func sharePage(_ sender: Any?) {
+        guard let url = PageSharingPresenter.shareableURL(for: browserState.focusingTab),
+              let contentView = window?.contentView else {
+            return
+        }
+        // The header's address bar anchor only exists in layouts that show
+        // navigation at the top. The performance layout has no header, and
+        // an anchor left over from a previous layout is off-window — the
+        // picker would silently not appear — so drop down from the top of
+        // the content view there instead.
+        let headerAnchor = mainSplitViewController.webContentContainerViewController.addressBarAnchorView
+        let headerAnchorUsable = PhiPreferences.GeneralSettings.loadLayoutMode().showsNavigationAtTop
+            && headerAnchor?.window === window
+        if headerAnchorUsable, let headerAnchor {
+            PageSharingPresenter.share(url: url, anchorView: headerAnchor)
+        } else {
+            // A 1×1 rect just inside the top edge: a rect outside the view's
+            // bounds is not a valid popover anchor.
+            let topCenter = NSRect(x: contentView.bounds.midX - 0.5, y: contentView.bounds.maxY - 1, width: 1, height: 1)
+            PageSharingPresenter.share(url: url, anchorView: contentView, relativeTo: topCenter)
+        }
+    }
+
     @IBAction func openLocationBar(_ sender: Any?) {
         var addressView = sender as? NSView
         if addressView == nil,

--- a/Sources/UserInterface/Preferences/Shortcuts/Shortcuts+Custom.swift
+++ b/Sources/UserInterface/Preferences/Shortcuts/Shortcuts+Custom.swift
@@ -84,6 +84,7 @@ extension Shortcuts {
                         .IDC_FOCUS_LOCATION,
                         .IDC_CLOSE_WINDOW,
                         .IDC_CLOSE_TAB,
+                        .PHI_SHARE_PAGE,
                         .IDC_PRINT]
             case .edit:
                 return [.PHI_COPY_URL,
@@ -383,6 +384,7 @@ extension CommandWrapper {
         .PHI_TOGGLE_READER: .init(title: "Toggle Reader View", keywords: ["reader", "reader view", "reading", "article", "distraction free"]),
         .PHI_NEW_KIOSK_WINDOW: .init(title: "New Kiosk Window", keywords: ["new kiosk window", "kiosk", "window"]),
         .PHI_NEW_INCOGNITO_SPACE: .init(title: "New Incognito Space", keywords: ["new incognito space", "incognito", "private", "space"]),
+        .PHI_SHARE_PAGE: .init(title: "Share Page", keywords: ["share", "share page", "share link", "airdrop", "send"]),
         .PHI_SELECT_NEXT_SPACE: .init(title: "Next Space", keywords: ["space", "next space", "forward"]),
         .PHI_SELECT_PREVIOUS_SPACE: .init(title: "Previous Space", keywords: ["space", "previous space", "backward"]),
         .PHI_SELECT_SPACE_0: .init(title: "Go to Space 1", keywords: ["space", "space1"]),

--- a/Sources/UserInterface/Preferences/Shortcuts/Shortcuts.swift
+++ b/Sources/UserInterface/Preferences/Shortcuts/Shortcuts.swift
@@ -130,6 +130,7 @@ enum CommandWrapper: Int, Equatable {
     case PHI_TOGGLE_READER           = 90021
     case PHI_NEW_KIOSK_WINDOW        = 90022
     case PHI_NEW_INCOGNITO_SPACE     = 90023
+    case PHI_SHARE_PAGE              = 90024
 
     // System Preserved
     case IDS_HIDE_OTHERS_MAC         = 110
@@ -599,6 +600,7 @@ extension Shortcuts {
         .PHI_TOGGLE_READER: .init(characters: "r", modifiers: [.command, .option]),
         .PHI_NEW_KIOSK_WINDOW: .init(characters: "n", modifiers: [.command, .option]),
         .PHI_NEW_INCOGNITO_SPACE: .init(characters: "n", modifiers: [.control, .shift]),
+        .PHI_SHARE_PAGE: .init(characters: "s", modifiers: [.control, .option]),
 
         // System Preserved Shortcuts
         .IDS_HIDE_OTHERS_MAC: .init(characters: "h", modifiers: [.command, .option]),

--- a/Sources/UserInterface/Preferences/Shortcuts/ShortcutsViewModel.swift
+++ b/Sources/UserInterface/Preferences/Shortcuts/ShortcutsViewModel.swift
@@ -183,6 +183,8 @@ private extension CommandWrapper {
             return NSLocalizedString("settings.shortcuts.command.closeTab", value: "Close Tab", comment: "Shortcuts settings - Command title for closing the current tab")
         case .IDC_PRINT:
             return NSLocalizedString("settings.shortcuts.command.printPage", value: "Print…", comment: "Shortcuts settings - Command title for printing the current page")
+        case .PHI_SHARE_PAGE:
+            return NSLocalizedString("settings.shortcuts.command.sharePage", value: "Share Page", comment: "Shortcuts settings - Command title for sharing the current page via the macOS share picker")
         case .PHI_COPY_URL:
             return NSLocalizedString("settings.shortcuts.command.copyURL", value: "Copy URL", comment: "Shortcuts settings - Command title for copying the current URL")
         case .PHI_TOGGLE_READER:

--- a/Sources/UserInterface/WebContent/Header/PageSharingPresenter.swift
+++ b/Sources/UserInterface/WebContent/Header/PageSharingPresenter.swift
@@ -1,0 +1,139 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import Foundation
+import AppKit
+
+/// Shares a tab's page URL through the system sharing services. Single owner
+/// for every share entry point — the File menu item and keyboard shortcut show
+/// the `NSSharingServicePicker`, and the address bar menu lists the same
+/// services in a Share submenu.
+@MainActor
+final class PageSharingPresenter: NSObject {
+    /// Menu item target that also travels as the item's `representedObject`,
+    /// which keeps it alive for the menu's lifetime (`NSMenuItem.target` is
+    /// unretained).
+    private final class ServiceMenuTarget: NSObject {
+        private let service: NSSharingService
+        private let items: [Any]
+
+        init(service: NSSharingService, items: [Any]) {
+            self.service = service
+            self.items = items
+        }
+
+        @objc func performShare(_ sender: NSMenuItem) {
+            service.perform(withItems: items)
+        }
+    }
+
+    /// AppKit does not retain the picker while it is on screen; dropping the
+    /// reference before the user chooses a service dismisses the menu. The
+    /// active presenter therefore holds itself here until the picker reports
+    /// a choice (or dismissal) through its delegate.
+    private static var activePresenter: PageSharingPresenter?
+
+    private let picker: NSSharingServicePicker
+
+    private init(items: [Any]) {
+        picker = NSSharingServicePicker(items: items)
+        super.init()
+        picker.delegate = self
+    }
+
+    /// The URL a tab shares: Reader pages resolve to their source page, and
+    /// the result carries the same branding as Copy URL.
+    static func shareableURL(for tab: Tab?) -> URL? {
+        guard var urlString = tab?.url, !urlString.isEmpty else { return nil }
+        urlString = ReaderExtensionBridge.sourceURLString(fromReaderPageURL: urlString) ?? urlString
+        return URL(string: URLProcessor.phiBrandEnsuredUrlString(urlString))
+    }
+
+    static func canShare(tab: Tab?) -> Bool {
+        shareableURL(for: tab) != nil
+    }
+
+    /// Shows the picker below `rect` in `anchorView` (the whole view when
+    /// `rect` is omitted).
+    static func share(url: URL, anchorView: NSView, relativeTo rect: NSRect = .zero) {
+        let presenter = PageSharingPresenter(items: [url])
+        activePresenter = presenter
+        presenter.picker.show(relativeTo: rect, of: anchorView, preferredEdge: .minY)
+    }
+
+    /// A submenu listing the sharing services available for `tab`'s page, for
+    /// hosting inside another menu. Falls back to a disabled placeholder row
+    /// when the tab has nothing shareable or no service accepts the URL.
+    ///
+    /// `NSSharingServicePicker.standardShareMenuItem` presents the picker
+    /// panel rather than listing services inline, so the services are
+    /// enumerated directly here.
+    static func shareSubmenu(for tab: Tab?) -> NSMenu {
+        let submenu = NSMenu(title: NSLocalizedString("browser.addressBarMenu.shareSubmenu.title", value: "Share", comment: "Address bar menu - Share submenu title"))
+
+        guard let url = shareableURL(for: tab) else {
+            submenu.addItem(placeholderItem(
+                title: NSLocalizedString("browser.addressBarMenu.shareSubmenu.invalidURLPlaceholder", value: "No share actions available", comment: "Address bar menu - Placeholder when the current URL cannot be shared")
+            ))
+            return submenu
+        }
+
+        let items: [Any] = [url]
+        let services = NSSharingService.sharingServices(forItems: items)
+            .filter { !isReadingList($0) }
+        guard !services.isEmpty else {
+            submenu.addItem(placeholderItem(
+                title: NSLocalizedString("browser.addressBarMenu.shareSubmenu.noServicesPlaceholder", value: "No share actions available", comment: "Address bar menu - Placeholder when no sharing services are available")
+            ))
+            return submenu
+        }
+
+        for service in services {
+            let target = ServiceMenuTarget(service: service, items: items)
+            let item = NSMenuItem(
+                title: service.title,
+                action: #selector(ServiceMenuTarget.performShare(_:)),
+                keyEquivalent: ""
+            )
+            item.image = service.image
+            item.target = target
+            item.representedObject = target
+            submenu.addItem(item)
+        }
+        return submenu
+    }
+
+    private static func placeholderItem(title: String) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
+        return item
+    }
+
+    /// Safari's Reading List has no meaning from inside another browser.
+    private nonisolated static func isReadingList(_ service: NSSharingService) -> Bool {
+        service.title == NSSharingService(named: .addToSafariReadingList)?.title
+    }
+}
+
+extension PageSharingPresenter: NSSharingServicePickerDelegate {
+    nonisolated func sharingServicePicker(
+        _ sharingServicePicker: NSSharingServicePicker,
+        sharingServicesForItems items: [Any],
+        proposedSharingServices proposedServices: [NSSharingService]
+    ) -> [NSSharingService] {
+        proposedServices.filter { !PageSharingPresenter.isReadingList($0) }
+    }
+
+    nonisolated func sharingServicePicker(
+        _ sharingServicePicker: NSSharingServicePicker,
+        didChoose service: NSSharingService?
+    ) {
+        // `service` is nil when the picker is dismissed without a choice;
+        // either way the picker is off screen and can be released.
+        MainActor.assumeIsolated {
+            PageSharingPresenter.activePresenter = nil
+        }
+    }
+}

--- a/Sources/UserInterface/WebContent/Header/WebContentAddressBarMenu.swift
+++ b/Sources/UserInterface/WebContent/Header/WebContentAddressBarMenu.swift
@@ -21,10 +21,6 @@ final class WebContentAddressBarMenuPresenter {
         }
     }
 
-    private static let excludedSharingServiceNames: Set<String> = [
-        "com.apple.share.System.add-to-safari-reading-list"
-    ]
-
     static func present(
         browserState: BrowserState?,
         currentTab: Tab?,
@@ -67,50 +63,6 @@ final class WebContentAddressBarMenuPresenter {
             return item
         }
 
-        func buildShareSubmenu(urlString: String?) -> NSMenu {
-            let submenu = NSMenu(title: NSLocalizedString("browser.addressBarMenu.shareSubmenu.title", value: "Share", comment: "Address bar menu - Share submenu title"))
-            guard
-                let urlString,
-                let url = URL(string: urlString)
-            else {
-                let unavailableItem = NSMenuItem(
-                    title: NSLocalizedString("browser.addressBarMenu.shareSubmenu.invalidURLPlaceholder", value: "No share actions available", comment: "Address bar menu - Placeholder when the current URL cannot be shared"),
-                    action: nil,
-                    keyEquivalent: ""
-                )
-                unavailableItem.isEnabled = false
-                submenu.addItem(unavailableItem)
-                return submenu
-            }
-
-            let services = NSSharingService.sharingServices(forItems: [url])
-                .filter { !isReadingListSharingService($0) }
-            if services.isEmpty {
-                let unavailableItem = NSMenuItem(
-                    title: NSLocalizedString("browser.addressBarMenu.shareSubmenu.noServicesPlaceholder", value: "No share actions available", comment: "Address bar menu - Placeholder when no sharing services are available"),
-                    action: nil,
-                    keyEquivalent: ""
-                )
-                unavailableItem.isEnabled = false
-                submenu.addItem(unavailableItem)
-                return submenu
-            }
-
-            for service in services {
-                let item = NSMenuItem(title: service.title, action: nil, keyEquivalent: "")
-                item.image = service.image
-                let target = MenuActionTarget {
-                    service.perform(withItems: [url])
-                }
-                actionTargets.append(target)
-                item.target = target
-                item.action = #selector(MenuActionTarget.performAction(_:))
-                submenu.addItem(item)
-            }
-
-            return submenu
-        }
-        
         @MainActor
         func buildExtensionsSubmenu() -> NSMenu {
             let submenu = NSMenu(title: NSLocalizedString("browser.addressBarMenu.extensionsSubmenu.title", value: "Extensions", comment: "Address bar menu - Extensions submenu title"))
@@ -214,6 +166,16 @@ final class WebContentAddressBarMenuPresenter {
             submenu.addItem(moreSettingsItem)
 
             return submenu
+        }
+
+        // Share lives in this menu rather than as a standalone address bar
+        // action; the File menu item and shortcut offer the same services.
+        let shareItem = addMenuItem(
+            title: NSLocalizedString("browser.addressBarMenu.shareSubmenu.title", value: "Share", comment: "Address bar menu - Share submenu title"),
+            image: menuSymbol(named: "square.and.arrow.up")
+        )
+        MainActor.assumeIsolated {
+            shareItem.submenu = PageSharingPresenter.shareSubmenu(for: resolvedTab)
         }
 
         menu.addItem(.separator())
@@ -383,23 +345,6 @@ final class WebContentAddressBarMenuPresenter {
 
     private static func menuSymbol(named systemName: String) -> NSImage? {
         NSImage(systemSymbolName: systemName, accessibilityDescription: nil)
-    }
-
-    private static func isReadingListSharingService(_ service: NSSharingService) -> Bool {
-        let nameSelector = NSSelectorFromString("name")
-        if service.responds(to: nameSelector),
-           let unmanaged = service.perform(nameSelector),
-           let name = unmanaged.takeUnretainedValue() as? String,
-           excludedSharingServiceNames.contains(name) {
-            return true
-        }
-
-        let loweredTitle = service.title.lowercased()
-        if loweredTitle.contains("reading list") {
-            return true
-        }
-
-        return false
     }
 
     private static func shouldShowSecuritySection(for rawURLString: String) -> Bool {

--- a/Tests/PhiBrowserTests/PhiBrowserTests.swift
+++ b/Tests/PhiBrowserTests/PhiBrowserTests.swift
@@ -78,6 +78,20 @@ final class PhiBrowserTests: XCTestCase {
         )
     }
 
+    func testSharePageShortcutIsCustomizableFromFileShortcuts() {
+        XCTAssertEqual(
+            Shortcuts.DefaultShortcuts[.PHI_SHARE_PAGE],
+            ShortcutsKey(characters: "s", modifiers: [.control, .option])
+        )
+        XCTAssertTrue(
+            Shortcuts.Group.file.commands.contains(.PHI_SHARE_PAGE)
+        )
+        XCTAssertEqual(
+            CommandWrapper.PHI_SHARE_PAGE.displayName,
+            "Share Page"
+        )
+    }
+
     func testKioskGlobalShortcutDefaultsOffAndFormatsCurrentShortcut() {
         XCTAssertFalse(
             PhiPreferences.GeneralSettings
@@ -347,6 +361,63 @@ final class PhiBrowserTests: XCTestCase {
         XCTAssertEqual(customizedIncognitoSpaceItem.keyEquivalent, "i")
         XCTAssertEqual(
             customizedIncognitoSpaceItem.keyEquivalentModifierMask,
+            [.command, .control]
+        )
+    }
+
+    func testFileMenuInstallsSharePageAbovePrintAndRemovesChromiumShareSubmenu() throws {
+        let previousOverrides = Shortcuts.overridedShortcuts
+        defer { Shortcuts.overridedShortcuts = previousOverrides }
+        Shortcuts.overridedShortcuts.removeValue(forKey: .PHI_SHARE_PAGE)
+
+        let menu = NSMenu(title: "File")
+        menu.addItem(.separator())
+        let chromiumShareItem = NSMenuItem(title: "Share", action: nil, keyEquivalent: "")
+        chromiumShareItem.submenu = NSMenu(title: "Share")
+        menu.addItem(chromiumShareItem)
+        menu.addItem(.separator())
+        let printItem = NSMenuItem(title: "Print…", action: nil, keyEquivalent: "")
+        printItem.tag = CommandWrapper.IDC_PRINT.rawValue
+        menu.addItem(printItem)
+
+        AppController.installOrUpdateFileMenuItems(in: menu, target: nil)
+        AppController.installOrUpdateFileMenuItems(in: menu, target: nil)
+
+        let shareItems = menu.items.filter {
+            $0.tag == CommandWrapper.PHI_SHARE_PAGE.rawValue
+        }
+        let shareItem = try XCTUnwrap(shareItems.first)
+        let shareIndex = try XCTUnwrap(menu.items.firstIndex(of: shareItem))
+        let printIndex = try XCTUnwrap(menu.items.firstIndex(of: printItem))
+
+        XCTAssertEqual(shareItems.count, 1)
+        XCTAssertEqual(shareIndex, printIndex - 1)
+        XCTAssertEqual(
+            shareItem.action,
+            NSSelectorFromString("sharePageFromMenu:")
+        )
+        XCTAssertEqual(shareItem.keyEquivalent, "s")
+        XCTAssertEqual(shareItem.keyEquivalentModifierMask, [.control, .option])
+        XCTAssertFalse(shareItem.isHidden)
+        XCTAssertFalse(menu.items.contains(chromiumShareItem))
+        for index in 1..<menu.items.count {
+            XCTAssertFalse(
+                menu.items[index].isSeparatorItem && menu.items[index - 1].isSeparatorItem,
+                "adjacent separators left behind at index \(index)"
+            )
+        }
+
+        Shortcuts.overridedShortcuts[.PHI_SHARE_PAGE] = ShortcutsKey(
+            characters: "u",
+            modifiers: [.command, .control]
+        )
+        AppController.installOrUpdateFileMenuItems(in: menu, target: nil)
+        let customizedItem = try XCTUnwrap(menu.items.first {
+            $0.tag == CommandWrapper.PHI_SHARE_PAGE.rawValue
+        })
+        XCTAssertEqual(customizedItem.keyEquivalent, "u")
+        XCTAssertEqual(
+            customizedItem.keyEquivalentModifierMask,
             [.command, .control]
         )
     }


### PR DESCRIPTION
## What

Adds page sharing via macOS' native `NSSharingServicePicker` (the same panel Safari's share button shows), reachable three ways:

- **File menu**: a new *Share…* item directly above *Print…*
- **Address bar menu**: a *Share* submenu listing the available sharing services
- **Keyboard**: ⌃⌥S by default, customizable in Settings → Shortcuts → File (new `PHI_SHARE_PAGE` command)

All three route through a single new `PageSharingPresenter`. The File menu item and shortcut show the picker (the presenter holds the picker's lone strong reference while it is on screen and releases it via the picker delegate); the address bar menu lists the same services inline. Reader pages share their source URL (via `ReaderExtensionBridge`), and the shared URL gets the same branding as Copy URL (`URLProcessor.phiBrandEnsuredUrlString`). Safari's Reading List is filtered out in both paths via the public `.addToSafariReadingList` service name.

## Notes

- Chromium's own File ▸ Share submenu is removed during the File-menu hook so sharing has one owner. It is identified structurally (the only non-separator File row with tag 0 and no action — its title is localized and its command tag isn't stable across Chromium versions); the resulting adjacent separators are collapsed. The hook stays remove-then-insert idempotent.
- The address bar submenu enumerates services with `NSSharingService.sharingServices(forItems:)`. Its stated replacement, `NSSharingServicePicker.standardShareMenuItem`, opens the picker panel rather than providing a submenu, so it does not fit the menu.
- In the performance layout the header anchor is off-window; the picker then drops down from the content view's top edge.
- The menu item is disabled (validated) when the focused tab has no shareable URL; the shortcut falls through in that case.
- Localization: two new `en`-only catalog entries per `docs/i18n/localization-guidelines.md`; the existing `browser.addressBarMenu.shareSubmenu.*` entries (already translated) are reused for the submenu.

## Testing

- New unit tests: default shortcut + settings registration, and File-menu install idempotency (share item sits above Print, Chromium share submenu removed, no adjacent separators, shortcut override applies on rebuild)
- `PhiBrowserTests` green on the OpenSource scheme (apart from two pre-existing copy-vs-catalog mismatches on `main`)
- Manually verified in the OpenSource build across balanced, comfortable, and performance layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)