### PR TITLE
fix(service-broker): batch WebSocket pulls and apply backpressure instead of killing the channel

### DIFF
--- a/Sources/Networking/ServiceBroker/ServiceBrokerChannelStore.swift
+++ b/Sources/Networking/ServiceBroker/ServiceBrokerChannelStore.swift
@@ -7,6 +7,15 @@ import Foundation
 
 actor ServiceBrokerChannelStore {
     private static let maximumQueuedEvents = 128
+    /// One `broker.ws.pull` costs a full round trip across the extension bridge,
+    /// so a pull drains as much of the queue as these limits allow rather than a
+    /// single event. phi-agent emits one frame per model delta, and a per-frame
+    /// round trip cannot keep up with a long streamed reply.
+    private static let maximumEventsPerPull = 64
+    private static let maximumBytesPerPull = 512 * 1024
+    /// The queue depth a paused WebSocket read loop resumes at. Halving the
+    /// high-water marks keeps a resumed loop from stalling again immediately.
+    private static let lowWaterQueuedEvents = maximumQueuedEvents / 2
 
     typealias HTTPStreamOpener = @Sendable (BrokerHTTPRequest) async throws -> BrokerHTTPStreamSource
     typealias WebSocketOpener = @Sendable (String, [String: String]) async throws -> BrokerWebSocketSource
@@ -48,6 +57,10 @@ actor ServiceBrokerChannelStore {
         var activityGeneration: UInt64 = 0
         var idleTask: Task<Void, Never>?
         var readTask: Task<Void, Never>?
+        /// Set while the read loop is parked at the high-water mark. Resumed by
+        /// a pull that drains below the low-water mark, and by every terminal
+        /// transition so the loop can observe the channel and exit.
+        var readGate: CheckedContinuation<Void, Never>?
     }
 
     private enum Channel {
@@ -255,13 +268,26 @@ actor ServiceBrokerChannelStore {
         }
 
         guard channel.queue.isEmpty else {
-            let event = channel.queue.removeFirst()
-            channel.queuedBytes -= event.byteCount
+            var events = [BrokerWebSocketEvent]()
+            var batchBytes = 0
+            while let next = channel.queue.first {
+                let nextBytes = next.byteCount
+                guard events.isEmpty
+                    || (events.count < Self.maximumEventsPerPull
+                        && batchBytes + nextBytes <= Self.maximumBytesPerPull) else { break }
+                channel.queue.removeFirst()
+                channel.queuedBytes -= nextBytes
+                batchBytes += nextBytes
+                events.append(next)
+                if next.isTerminal { break }
+            }
             channels[channelID] = .webSocket(channel)
             if channel.terminal && channel.queue.isEmpty {
                 removeChannel(channelID)
+            } else {
+                resumeReadGateIfDrained(channelID: channelID)
             }
-            return BrokerWebSocketPullResponse(event: event)
+            return BrokerWebSocketPullResponse(events: events)
         }
 
         return await withCheckedContinuation { continuation in
@@ -397,6 +423,8 @@ actor ServiceBrokerChannelStore {
     private func readWebSocket(channelID: String, source: BrokerWebSocketSource) async {
         do {
             while true {
+                await awaitReadCapacity(channelID: channelID)
+                guard isReadable(channelID: channelID) else { return }
                 let event = try await source.receive()
                 receiveWebSocketEvent(event, channelID: channelID)
                 switch event {
@@ -429,22 +457,54 @@ actor ServiceBrokerChannelStore {
             if terminal { removeChannel(channelID) } else { touchWebSocket(channelID: channelID) }
             return
         }
-        if !terminal {
-            guard channel.queue.count < Self.maximumQueuedEvents,
-                  channel.queuedBytes <= configuration.unacknowledgedWindowBytes - event.byteCount else {
-                channels[channelID] = .webSocket(channel)
-                failWebSocket(
-                    channelID: channelID,
-                    code: .flowControlTimeout,
-                    message: "Channel backpressure limit exceeded."
-                )
-                return
-            }
-        }
+        // The event was already read off the socket, so it is always enqueued —
+        // it may push the queue past the high-water mark. `awaitReadCapacity`
+        // then parks the read loop until a pull drains the queue, which lets the
+        // kernel socket buffer, and in turn the broker, feel the backpressure.
         channel.terminal = terminal
         channel.queue.append(event)
         channel.queuedBytes += event.byteCount
         channels[channelID] = .webSocket(channel)
+    }
+
+    /// Parks the WebSocket read loop while the channel sits at or above its
+    /// high-water mark. Only the channel's own read loop calls this, so at most
+    /// one continuation is ever stored.
+    private func awaitReadCapacity(channelID: String) async {
+        guard case .webSocket(let channel) = channels[channelID],
+              !channel.terminal,
+              isAtHighWater(channel) else { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            guard case .webSocket(var stored) = channels[channelID], !stored.terminal else {
+                continuation.resume()
+                return
+            }
+            stored.readGate = continuation
+            channels[channelID] = .webSocket(stored)
+        }
+    }
+
+    /// A parked read loop is released by expiry, failure and removal as well as
+    /// by drainage, so it must re-check the channel before reading again.
+    private func isReadable(channelID: String) -> Bool {
+        guard case .webSocket(let channel) = channels[channelID] else { return false }
+        return !channel.terminal
+    }
+
+    private func isAtHighWater(_ channel: WebSocketChannel) -> Bool {
+        channel.queue.count >= Self.maximumQueuedEvents
+            || channel.queuedBytes >= configuration.unacknowledgedWindowBytes
+    }
+
+    private func resumeReadGateIfDrained(channelID: String) {
+        guard case .webSocket(var channel) = channels[channelID],
+              channel.readGate != nil,
+              channel.queue.count <= Self.lowWaterQueuedEvents,
+              channel.queuedBytes <= configuration.unacknowledgedWindowBytes / 2 else { return }
+        let gate = channel.readGate
+        channel.readGate = nil
+        channels[channelID] = .webSocket(channel)
+        gate?.resume()
     }
 
     private func failWebSocket(channelID: String, error: Error) {
@@ -464,11 +524,18 @@ actor ServiceBrokerChannelStore {
         channel.terminal = true
         channel.queue.removeAll(keepingCapacity: false)
         channel.queuedBytes = 0
+        // Take the gate out of the stored channel before any removal so it is
+        // resumed exactly once, whichever branch runs.
+        let gate = channel.readGate
+        channel.readGate = nil
+        let pending = channel.pendingPull
+        channel.pendingPull = nil
         let event = BrokerWebSocketEvent.failure(code: code, message: message)
         let source = channel.source
         let closeCode: UInt16 = code == .protocolError ? 1002 : 1011
         Task { await source.close(code: closeCode, reason: message) }
-        if let pending = channel.pendingPull {
+        if let pending {
+            channels[channelID] = .webSocket(channel)
             pending.timeoutTask.cancel()
             pending.continuation.resume(returning: BrokerWebSocketPullResponse(event: event))
             removeChannel(channelID)
@@ -476,6 +543,7 @@ actor ServiceBrokerChannelStore {
             channel.queue.append(event)
             channels[channelID] = .webSocket(channel)
         }
+        gate?.resume()
     }
 
     private func timeoutHTTPPull(channelID: String, token: UUID) {
@@ -564,16 +632,23 @@ actor ServiceBrokerChannelStore {
     private func removeChannel(_ channelID: String) -> Channel? {
         guard let channel = channels.removeValue(forKey: channelID) else { return nil }
         switch channel {
-        case .http(let channel):
-            channel.readTask?.cancel()
-            channel.idleTask?.cancel()
-            channel.pendingPull?.timeoutTask.cancel()
-        case .webSocket(let channel):
-            channel.readTask?.cancel()
-            channel.idleTask?.cancel()
-            channel.pendingPull?.timeoutTask.cancel()
+        case .http(let http):
+            http.readTask?.cancel()
+            http.idleTask?.cancel()
+            http.pendingPull?.timeoutTask.cancel()
+            return channel
+        case .webSocket(var webSocket):
+            webSocket.readTask?.cancel()
+            webSocket.idleTask?.cancel()
+            webSocket.pendingPull?.timeoutTask.cancel()
+            // Cancelling the read task does not resume a parked continuation, so
+            // release the gate here: expiry, close and failure all remove the
+            // channel, and the released loop then observes it is gone and exits.
+            let gate = webSocket.readGate
+            webSocket.readGate = nil
+            gate?.resume()
+            return .webSocket(webSocket)
         }
-        return channel
     }
 
     private func validateConfiguration() throws {
@@ -604,5 +679,12 @@ private extension BrokerWebSocketEvent {
     var byteCount: Int {
         if case .frame(_, let frame) = self { return frame.data.count }
         return 0
+    }
+
+    var isTerminal: Bool {
+        switch self {
+        case .close, .failure: true
+        case .frame, .timeout: false
+        }
     }
 }

--- a/Sources/Networking/ServiceBroker/ServiceBrokerExtensionProtocol.swift
+++ b/Sources/Networking/ServiceBroker/ServiceBrokerExtensionProtocol.swift
@@ -397,7 +397,7 @@ actor ServiceBrokerExtensionProtocol {
                     )
                     throw error
                 }
-                return try encode(pulled.event)
+                return try encode(pulled.events)
 
             case "broker.ws.close":
                 let request = try decode(
@@ -736,6 +736,17 @@ actor ServiceBrokerExtensionProtocol {
     }
 
     private func encode(_ event: BrokerPullEvent) throws -> ServiceBrokerExtensionReply {
+        try success(["events": [try encoded(event)]])
+    }
+
+    /// One reply carries every event the pull drained, in order. The extension
+    /// already iterates `events` and checks each sequence, so a batch needs no
+    /// extension change.
+    private func encode(_ events: [BrokerWebSocketEvent]) throws -> ServiceBrokerExtensionReply {
+        try success(["events": try events.map(encoded)])
+    }
+
+    private func encoded(_ event: BrokerPullEvent) throws -> [String: Any] {
         let encoded: [String: Any]
         switch event {
         case .data(let sequence, let data):
@@ -750,10 +761,10 @@ actor ServiceBrokerExtensionProtocol {
         case .failure(let code, let message):
             encoded = ["type": "error", "code": code.rawValue, "message": message]
         }
-        return try success(["events": [encoded]])
+        return encoded
     }
 
-    private func encode(_ event: BrokerWebSocketEvent) throws -> ServiceBrokerExtensionReply {
+    private func encoded(_ event: BrokerWebSocketEvent) throws -> [String: Any] {
         let encoded: [String: Any]
         switch event {
         case .frame(let sequence, let frame):
@@ -775,7 +786,7 @@ actor ServiceBrokerExtensionProtocol {
         case .failure(let code, let message):
             encoded = ["type": "error", "code": code.rawValue, "message": message]
         }
-        return try success(["events": [encoded]])
+        return encoded
     }
 
     private func success(_ result: [String: Any]) throws -> ServiceBrokerExtensionReply {

--- a/Sources/Networking/ServiceBroker/ServiceBrokerTypes.swift
+++ b/Sources/Networking/ServiceBroker/ServiceBrokerTypes.swift
@@ -250,6 +250,10 @@ enum NativeBrokerErrorCode: String, Codable, Equatable, Sendable {
     case channelNotFound = "channel_not_found"
     case ownerMismatch = "owner_mismatch"
     case pullAlreadyPending = "pull_already_pending"
+    /// Reachable for HTTP stream channels only. A WebSocket channel that fills
+    /// its queue pauses its upstream read loop instead of failing, so this code
+    /// is never produced for `broker.ws.pull`. It stays part of the stable
+    /// extension error set.
     case flowControlTimeout = "flow_control_timeout"
     case upstreamError = "upstream_error"
     case protocolError = "protocol_error"
@@ -302,7 +306,17 @@ struct BrokerWebSocketOpenResponse: Equatable, Sendable {
 }
 
 struct BrokerWebSocketPullResponse: Equatable, Sendable {
-    let event: BrokerWebSocketEvent
+    /// The events one pull drained, in queue order and with contiguous frame
+    /// sequences. Never empty, and a terminal event is always the last element.
+    let events: [BrokerWebSocketEvent]
+
+    init(events: [BrokerWebSocketEvent]) {
+        self.events = events
+    }
+
+    init(event: BrokerWebSocketEvent) {
+        events = [event]
+    }
 }
 
 struct ServiceBrokerChannelConfiguration: Equatable, Sendable {

--- a/Tests/PhiBrowserTests/ServiceBroker/ServiceBrokerChannelStoreTests.swift
+++ b/Tests/PhiBrowserTests/ServiceBroker/ServiceBrokerChannelStoreTests.swift
@@ -244,15 +244,13 @@ final class ServiceBrokerChannelStoreTests: XCTestCase {
             sequence: 0, BrokerWebSocketFrame(kind: .binary, data: Data([1, 2, 3]))))
         socket.receive(.close(code: 1000, reason: "done"))
 
-        let frame = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
-        let close = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+        let pulled = try await drainUntilTerminal(store, channelID: opened.channelID)
 
         XCTAssertEqual(socket.sentFrames, [outgoing])
-        XCTAssertEqual(
-            frame.event,
-            .frame(sequence: 0, BrokerWebSocketFrame(kind: .binary, data: Data([1, 2, 3])))
-        )
-        XCTAssertEqual(close.event, .close(code: 1000, reason: "done"))
+        XCTAssertEqual(pulled, [
+            .frame(sequence: 0, BrokerWebSocketFrame(kind: .binary, data: Data([1, 2, 3]))),
+            .close(code: 1000, reason: "done"),
+        ])
     }
 
     func testWebSocketTerminalCloseSurvivesAFullDataQueue() async throws {
@@ -278,12 +276,10 @@ final class ServiceBrokerChannelStoreTests: XCTestCase {
         }
         socket.receive(.close(code: 1000, reason: "done"))
 
-        var terminal: BrokerWebSocketEvent?
-        for _ in 0...128 {
-            terminal = try await store.pullWebSocket(
-                owner: owner, channelID: opened.channelID).event
-        }
-        XCTAssertEqual(terminal, .close(code: 1000, reason: "done"))
+        let drained = try await drainUntilTerminal(store, channelID: opened.channelID)
+
+        XCTAssertEqual(drained.count, 129)
+        XCTAssertEqual(drained.last, .close(code: 1000, reason: "done"))
     }
 
     func testWebSocketFramesHaveChannelOwnedSequenceNumbers() async throws {
@@ -296,13 +292,12 @@ final class ServiceBrokerChannelStoreTests: XCTestCase {
         socket.receive(.frame(
             sequence: 1, BrokerWebSocketFrame(kind: .text, data: Data("two".utf8))))
 
-        let first = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
-        let second = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+        let events = try await collectEvents(store, channelID: opened.channelID, count: 2)
 
-        XCTAssertEqual(first.event, .frame(
-            sequence: 0, BrokerWebSocketFrame(kind: .text, data: Data("one".utf8))))
-        XCTAssertEqual(second.event, .frame(
-            sequence: 1, BrokerWebSocketFrame(kind: .text, data: Data("two".utf8))))
+        XCTAssertEqual(events, [
+            .frame(sequence: 0, BrokerWebSocketFrame(kind: .text, data: Data("one".utf8))),
+            .frame(sequence: 1, BrokerWebSocketFrame(kind: .text, data: Data("two".utf8))),
+        ])
         try await store.closeWebSocket(
             owner: owner, channelID: opened.channelID, code: 1000, reason: nil)
     }
@@ -351,7 +346,7 @@ final class ServiceBrokerChannelStoreTests: XCTestCase {
             owner: owner, channelID: opened.channelID, code: 1000, reason: "done")
 
         let result = try await pull.value
-        XCTAssertEqual(result.event, .close(code: 1000, reason: "done"))
+        XCTAssertEqual(result.events, [.close(code: 1000, reason: "done")])
         XCTAssertTrue(socket.isClosed)
         await assertChannelError(.channelNotFound) {
             _ = try await store.pullWebSocket(owner: self.owner, channelID: opened.channelID)
@@ -397,8 +392,197 @@ final class ServiceBrokerChannelStoreTests: XCTestCase {
         }
     }
 
+    func testWebSocketPullDrainsQueuedEventsAsOneBatch() async throws {
+        let socket = FakeBrokerWebSocket()
+        let store = makeWebSocketStore(socket: socket)
+        let opened = try await store.openWebSocket(
+            owner: owner, path: "/ws/phi-agent/execute", headers: [:])
+        let queued = (0..<5).map { textFrame(sequence: UInt64($0), body: "delta-\($0)") }
+        queued.forEach { socket.receive($0) }
+        await socket.waitUntilReceiveCalls(queued.count + 1)
+
+        let pulled = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+
+        XCTAssertEqual(pulled.events, queued)
+        try await store.closeWebSocket(
+            owner: owner, channelID: opened.channelID, code: 1000, reason: nil)
+    }
+
+    func testWebSocketBatchStopsAtThePerPullEventLimit() async throws {
+        let socket = FakeBrokerWebSocket()
+        let store = makeWebSocketStore(socket: socket, unacknowledgedWindowBytes: 64 * 1024)
+        let opened = try await store.openWebSocket(
+            owner: owner, path: "/ws/phi-agent/execute", headers: [:])
+        let queued = (0..<70).map { textFrame(sequence: UInt64($0), body: "x") }
+        queued.forEach { socket.receive($0) }
+        await socket.waitUntilReceiveCalls(queued.count + 1)
+
+        let first = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+        let second = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+
+        XCTAssertEqual(first.events, Array(queued[0..<64]))
+        XCTAssertEqual(second.events, Array(queued[64...]))
+        try await store.closeWebSocket(
+            owner: owner, channelID: opened.channelID, code: 1000, reason: nil)
+    }
+
+    func testWebSocketBatchStopsAtThePerPullByteLimit() async throws {
+        let socket = FakeBrokerWebSocket()
+        let store = makeWebSocketStore(
+            socket: socket,
+            webSocketMessageBytes: 1024 * 1024,
+            unacknowledgedWindowBytes: 4 * 1024 * 1024
+        )
+        let opened = try await store.openWebSocket(
+            owner: owner, path: "/ws/phi-agent/execute", headers: [:])
+        let queued = (0..<3).map {
+            BrokerWebSocketEvent.frame(
+                sequence: UInt64($0),
+                BrokerWebSocketFrame(kind: .binary, data: Data(repeating: UInt8($0), count: 200 * 1024))
+            )
+        }
+        queued.forEach { socket.receive($0) }
+        await socket.waitUntilReceiveCalls(queued.count + 1)
+
+        let first = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+        let second = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+
+        XCTAssertEqual(first.events, Array(queued[0..<2]))
+        XCTAssertEqual(second.events, Array(queued[2...]))
+        try await store.closeWebSocket(
+            owner: owner, channelID: opened.channelID, code: 1000, reason: nil)
+    }
+
+    func testWebSocketBatchEndsAtATerminalEvent() async throws {
+        let socket = FakeBrokerWebSocket()
+        let store = makeWebSocketStore(socket: socket)
+        let opened = try await store.openWebSocket(
+            owner: owner, path: "/ws/phi-agent/execute", headers: [:])
+        let queued = (0..<3).map { textFrame(sequence: UInt64($0), body: "delta-\($0)") }
+            + [.close(code: 1000, reason: "done")]
+        queued.forEach { socket.receive($0) }
+        await socket.waitUntilReceiveCalls(queued.count)
+        try await Task.sleep(for: .milliseconds(50))
+
+        let pulled = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+
+        XCTAssertEqual(pulled.events, queued)
+        await assertChannelError(.channelNotFound) {
+            _ = try await store.pullWebSocket(owner: self.owner, channelID: opened.channelID)
+        }
+    }
+
+    func testWebSocketPullOnAnEmptyQueueReturnsASingleEvent() async throws {
+        let socket = FakeBrokerWebSocket()
+        let pendingPull = AsyncSignal()
+        let store = makeWebSocketStore(socket: socket, pendingPull: pendingPull)
+        let opened = try await store.openWebSocket(
+            owner: owner, path: "/ws/phi-agent/execute", headers: [:])
+        let pull = Task { try await store.pullWebSocket(owner: owner, channelID: opened.channelID) }
+        await pendingPull.wait()
+        socket.receive(textFrame(sequence: 0, body: "one"))
+        socket.receive(textFrame(sequence: 1, body: "two"))
+
+        let result = try await pull.value
+
+        XCTAssertEqual(result.events, [textFrame(sequence: 0, body: "one")])
+        try await store.closeWebSocket(
+            owner: owner, channelID: opened.channelID, code: 1000, reason: nil)
+    }
+
+    func testWebSocketHighWaterPausesReadsInsteadOfFailingTheChannel() async throws {
+        let socket = FakeBrokerWebSocket()
+        let store = makeWebSocketStore(socket: socket, unacknowledgedWindowBytes: 64 * 1024)
+        let opened = try await store.openWebSocket(
+            owner: owner, path: "/ws/phi-agent/execute", headers: [:])
+        let queued = (0..<200).map { textFrame(sequence: UInt64($0), body: "x") }
+        queued.forEach { socket.receive($0) }
+
+        await socket.waitUntilReceiveCalls(128)
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertEqual(socket.receiveCallCount, 128)
+        XCTAssertFalse(socket.isClosed)
+
+        let first = try await store.pullWebSocket(owner: owner, channelID: opened.channelID)
+        XCTAssertEqual(first.events, Array(queued[0..<64]))
+
+        await socket.waitUntilReceiveCalls(192)
+        XCTAssertFalse(socket.isClosed)
+        try await store.closeWebSocket(
+            owner: owner, channelID: opened.channelID, code: 1000, reason: nil)
+    }
+
+    func testWebSocketIdleExpiryReleasesAPausedReadLoop() async throws {
+        let idleGate = AsyncGate()
+        let socket = FakeBrokerWebSocket()
+        let store = makeWebSocketStore(
+            socket: socket,
+            unacknowledgedWindowBytes: 64 * 1024,
+            idleTimeoutSleeper: { _ in await idleGate.enter() }
+        )
+        let opened = try await store.openWebSocket(
+            owner: owner, path: "/ws/phi-agent/execute", headers: [:])
+        (0..<200).forEach { socket.receive(textFrame(sequence: UInt64($0), body: "x")) }
+        await socket.waitUntilReceiveCalls(128)
+        await idleGate.waitUntilEntered()
+        XCTAssertFalse(socket.isClosed)
+
+        await idleGate.release()
+        await socket.waitUntilClosed()
+
+        await assertChannelError(.channelNotFound) {
+            _ = try await store.pullWebSocket(owner: self.owner, channelID: opened.channelID)
+        }
+    }
+
     private func request() -> BrokerHTTPRequest {
         BrokerHTTPRequest(service: .phiAgent, path: "/stream")
+    }
+
+    private func textFrame(sequence: UInt64, body: String) -> BrokerWebSocketEvent {
+        .frame(sequence: sequence, BrokerWebSocketFrame(kind: .text, data: Data(body.utf8)))
+    }
+
+    /// Pulls until a terminal event arrives and returns every event in order.
+    /// A batch may only end with a terminal event, never carry one in the middle.
+    private func drainUntilTerminal(
+        _ store: ServiceBrokerChannelStore,
+        channelID: String,
+        maximumPulls: Int = 64,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> [BrokerWebSocketEvent] {
+        var collected = [BrokerWebSocketEvent]()
+        for _ in 0..<maximumPulls {
+            let batch = try await store.pullWebSocket(owner: owner, channelID: channelID).events
+            XCTAssertFalse(batch.isEmpty, "A pull must return at least one event.", file: file, line: line)
+            XCTAssertFalse(
+                batch.dropLast().contains(where: \.isTerminal),
+                "A batch must stop at its terminal event.",
+                file: file,
+                line: line
+            )
+            collected.append(contentsOf: batch)
+            if batch.last?.isTerminal == true { return collected }
+        }
+        XCTFail("No terminal event after \(maximumPulls) pulls.", file: file, line: line)
+        return collected
+    }
+
+    private func collectEvents(
+        _ store: ServiceBrokerChannelStore,
+        channelID: String,
+        count: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> [BrokerWebSocketEvent] {
+        var collected = [BrokerWebSocketEvent]()
+        while collected.count < count {
+            let batch = try await store.pullWebSocket(owner: owner, channelID: channelID).events
+            XCTAssertFalse(batch.isEmpty, "A pull must return at least one event.", file: file, line: line)
+            collected.append(contentsOf: batch)
+        }
+        return collected
     }
 
     private func makeStore(
@@ -432,6 +616,8 @@ final class ServiceBrokerChannelStoreTests: XCTestCase {
 
     private func makeWebSocketStore(
         socket: FakeBrokerWebSocket,
+        webSocketMessageBytes: Int = 1_024,
+        unacknowledgedWindowBytes: Int = 1_024,
         pendingPull: AsyncSignal? = nil,
         idleTimeoutSleeper: @escaping ServiceBrokerChannelStore.PullTimeoutSleeper = { duration in
             try await Task.sleep(for: duration)
@@ -440,8 +626,8 @@ final class ServiceBrokerChannelStoreTests: XCTestCase {
         ServiceBrokerChannelStore(
             configuration: ServiceBrokerChannelConfiguration(
                 bridgeChunkBytes: 64,
-                webSocketMessageBytes: 1_024,
-                unacknowledgedWindowBytes: 1_024,
+                webSocketMessageBytes: webSocketMessageBytes,
+                unacknowledgedWindowBytes: unacknowledgedWindowBytes,
                 pullTimeout: .seconds(1),
                 idleTimeout: .seconds(1)
             ),
@@ -458,6 +644,7 @@ private final class FakeBrokerWebSocket: @unchecked Sendable {
     private var incoming = [Result<BrokerWebSocketEvent, Error>]()
     private var outgoing = [BrokerWebSocketFrame]()
     private var closed = false
+    private var receiveCalls = 0
     private let closeGate: AsyncGate?
 
     init(closeGate: AsyncGate? = nil) {
@@ -487,11 +674,31 @@ private final class FakeBrokerWebSocket: @unchecked Sendable {
         return closed
     }
 
+    /// How many times the channel store's read loop has asked for a frame. The
+    /// counter is raised before the call can return, so observing call `n + 1`
+    /// proves the first `n` events were already handed to the store.
+    var receiveCallCount: Int {
+        condition.lock()
+        defer { condition.unlock() }
+        return receiveCalls
+    }
+
     func waitUntilClosed() async {
         await withCheckedContinuation { continuation in
             DispatchQueue.global().async { [self] in
                 condition.lock()
                 while !closed { condition.wait() }
+                condition.unlock()
+                continuation.resume()
+            }
+        }
+    }
+
+    func waitUntilReceiveCalls(_ count: Int) async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async { [self] in
+                condition.lock()
+                while receiveCalls < count { condition.wait() }
                 condition.unlock()
                 continuation.resume()
             }
@@ -522,6 +729,8 @@ private final class FakeBrokerWebSocket: @unchecked Sendable {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global().async { [self] in
                 condition.lock()
+                receiveCalls += 1
+                condition.broadcast()
                 while incoming.isEmpty && !closed { condition.wait() }
                 let result = incoming.isEmpty
                     ? Result<BrokerWebSocketEvent, Error>.failure(ServiceBrokerWebSocketError.cancelled)
@@ -659,6 +868,15 @@ private actor AsyncGate {
         let waiters = releaseWaiters
         releaseWaiters.removeAll()
         waiters.forEach { $0.resume() }
+    }
+}
+
+private extension BrokerWebSocketEvent {
+    var isTerminal: Bool {
+        switch self {
+        case .close, .failure: true
+        case .frame, .timeout: false
+        }
     }
 }
 

--- a/Tests/PhiBrowserTests/ServiceBroker/ServiceBrokerExtensionProtocolTests.swift
+++ b/Tests/PhiBrowserTests/ServiceBroker/ServiceBrokerExtensionProtocolTests.swift
@@ -1468,6 +1468,36 @@ final class ServiceBrokerExtensionProtocolTests: XCTestCase {
         XCTAssertEqual(closed.error?.code, "channel_not_found")
     }
 
+    func testWebSocketPullEncodesEveryEventOfADrainedBatch() async throws {
+        let queued = (0..<4).map {
+            BrokerWebSocketEvent.frame(
+                sequence: UInt64($0),
+                BrokerWebSocketFrame(kind: .text, data: Data("delta-\($0)".utf8))
+            )
+        }
+        let socket = FakeProtocolWebSocket(events: queued)
+        let store = makeStore(webSocket: socket)
+        let handler = makeHandler(channelStore: store)
+        let opened = await handler.handle(
+            type: "broker.ws.open",
+            payload: #"{"path":"/ws/phi-agent/execute"}"#,
+            senderID: allowedSender
+        )
+        let channelID = try XCTUnwrap(try successResult(opened)["channelId"] as? String)
+        await socket.waitUntilReceiveCalls(queued.count + 1)
+
+        let pulled = await pull(type: "broker.ws.pull", channelID: channelID, handler: handler)
+
+        let events = try XCTUnwrap(try successResult(pulled)["events"] as? [[String: Any]])
+        XCTAssertEqual(events.count, queued.count)
+        XCTAssertEqual(events.map { $0["sequence"] as? Int }, [0, 1, 2, 3])
+        XCTAssertEqual(events.map { $0["type"] as? String }, ["text", "text", "text", "text"])
+        XCTAssertEqual(
+            events.map { $0["data"] as? String },
+            (0..<4).map { Data("delta-\($0)".utf8).base64EncodedString() }
+        )
+    }
+
     func testKensingtonCanOpenItsAuthorizedPhiAgentWebSocketPath() async throws {
         let socket = FakeProtocolWebSocket(events: [])
         let recorder = BrokerWebSocketOpenRecorder()
@@ -2002,6 +2032,8 @@ private actor FakeProtocolWebSocket {
     private var events: [BrokerWebSocketEvent]
     private var sent = [BrokerWebSocketFrame]()
     private var waiters = [CheckedContinuation<BrokerWebSocketEvent, Never>]()
+    private var receiveCalls = 0
+    private var callWaiters = [(count: Int, continuation: CheckedContinuation<Void, Never>)]()
 
     init(events: [BrokerWebSocketEvent]) {
         self.events = events
@@ -2019,6 +2051,14 @@ private actor FakeProtocolWebSocket {
         sent
     }
 
+    /// Waits until the channel store's read loop has asked for its `count`-th
+    /// frame. Call `n + 1` starts only after event `n` was queued, so this is a
+    /// race-free way to observe a full queue.
+    func waitUntilReceiveCalls(_ count: Int) async {
+        if receiveCalls >= count { return }
+        await withCheckedContinuation { callWaiters.append((count, $0)) }
+    }
+
     func enqueue(_ event: BrokerWebSocketEvent) {
         if !waiters.isEmpty {
             waiters.removeFirst().resume(returning: event)
@@ -2032,6 +2072,10 @@ private actor FakeProtocolWebSocket {
     }
 
     private func next() async -> BrokerWebSocketEvent {
+        receiveCalls += 1
+        let ready = callWaiters.filter { $0.count <= receiveCalls }
+        callWaiters.removeAll { $0.count <= receiveCalls }
+        ready.forEach { $0.continuation.resume() }
         if !events.isEmpty {
             return events.removeFirst()
         }

--- a/docs/service-broker-extension-boundary.md
+++ b/docs/service-broker-extension-boundary.md
@@ -36,7 +36,7 @@ Replies use the request-scoped `sendMessageToApp` return value because the exist
 - A successful UDS connect is not proof of broker identity. Before sending a request, credential, or WebSocket handshake byte, the browser requires the peer uid to match its effective uid and validates the `LOCAL_PEERPID` process against the signed `service-broker` code requirement for Team ID `87DQ3HMK5G`. Failure is terminal and never falls back to another transport.
 - The browser enforces the broker's negotiated request, response, streaming, and WebSocket limits.
 - Chromium keeps the legacy 1 MiB native-message JSON limit for non-broker traffic. `broker.*` envelopes admit exactly `ceil(16 MiB / 3) * 4 + 64 KiB` bytes so a negotiated 16 MiB raw request plus bounded base64/JSON overhead reaches the browser protocol; the Mac layer remains the semantic and decoded-size enforcement point.
-- Each HTTP connect/write/response-head sequence, and each WebSocket handshake, send, and close, has one monotonic 30-second I/O budget. The WebSocket receive budget is 30 seconds since the last inbound frame of any kind — data, continuation, ping, or pong — and after 10 seconds of read silence the browser sends its own WebSocket ping, so an idle-but-alive channel stays open while a dead peer is still detected within 30 seconds. The Sentinel broker answers these bridge-side pings itself, so keepalive never depends on the upstream service. Streaming HTTP body reads have no per-read deadline, matching Chromium fetch semantics; they are bounded only by cancellation, EOF, and the channel idle timer. Swift task cancellation closes the UDS descriptor so a stalled peer cannot leave a detached poll/read/write running indefinitely.
+- Each HTTP connect/write/response-head sequence, and each WebSocket handshake, send, and close, has one monotonic 30-second I/O budget. The WebSocket receive budget is 30 seconds since the last inbound frame of any kind — data, continuation, ping, or pong — and after 10 seconds of read silence the browser sends its own WebSocket ping, so an idle-but-alive channel stays open while a dead peer is still detected within 30 seconds. The Sentinel broker answers these bridge-side pings itself, so keepalive never depends on the upstream service. Both the receive budget and the ping timer live inside one `receive()` call, so a channel paused by backpressure is not being timed and does not ping: it is by definition a channel whose peer is producing faster than the bridge drains, and the channel idle timer, not the receive budget, bounds how long it may stay paused. Streaming HTTP body reads have no per-read deadline, matching Chromium fetch semantics; they are bounded only by cancellation, EOF, and the channel idle timer. Swift task cancellation closes the UDS descriptor so a stalled peer cannot leave a detached poll/read/write running indefinitely.
 - `/broker` is reserved for broker-owned management routes. Only `broker.http.request` admits exact `GET /broker/healthz` with no body and maps it to broker service path `/healthz`. Query suffixes, encoded spellings, path variations, other methods, bodies, streaming attempts, `/broker/version`, and every other extension-supplied `/broker` path are rejected.
 - `broker.capabilities` is the explicit bridge handshake. After exact sender
   authorization and payload validation, the browser reads Sentinel's current
@@ -120,6 +120,17 @@ directly.
 
 Ordinary readiness and bounded HTTP calls use `broker.http.request`. Streaming HTTP and WebSocket calls use sender-owned opaque channels with one outstanding long-pull at a time. A pull waits for data, a terminal event, an error, or a bounded timeout; timeout keeps the channel alive and permits the next pull.
 
+A pull reply always carries an ordered `events` array, and a WebSocket pull fills
+it with as much of the channel queue as fits: at most **64 events** and at most
+**512 KiB** of frame payload, always at least one event, and never past a
+terminal event. One pull is a full round trip across the extension bridge, while
+phi-agent emits one frame per model delta, so a one-event-per-pull channel cannot
+keep up with a long streamed reply. Sequence numbers stay contiguous and in
+order across a batch, so the extension's per-frame sequence check is unchanged;
+the array shape is the shape it has always parsed. A pull that finds the queue
+empty still waits and returns the single event that ends the wait. HTTP stream
+pulls remain one chunk per pull — `bridgeChunkBytes` already batches there.
+
 Every generic request captures one nonempty immutable shared-auth snapshot before runtime resolution. The runtime account must match that snapshot, and channel ownership includes the exact extension ID, account ID, and opaque auth revision. After every asynchronous transport or channel operation, the protocol revalidates the complete snapshot before returning the request-scoped reply. Logout, account change, or same-account token rotation therefore rejects an in-flight result; a channel created by an older revision cannot be reused by the newer revision. The current Chromium sender API does not expose a distinct browser profile identity, so the owner profile field remains unset until that identity is carried across the bridge.
 
 End, close, failure, explicit cancel/close, idle expiry, UDS loss, and browser shutdown are terminal. Once the terminal event has been delivered, the channel is removed. Later pull, send, cancel, or close requests return `channel_not_found`; they cannot resurrect the channel.
@@ -128,6 +139,20 @@ Terminal HTTP and WebSocket events are not ordinary queued data: EOF, close,
 and failure remain enqueueable when the 128-event data window is full. This
 preserves the actual terminal reason instead of replacing it with a synthetic
 flow-control timeout.
+
+A WebSocket channel that fills its queue applies backpressure instead of dying.
+The high-water mark is 128 queued events or the negotiated
+`unacknowledged_window_bytes`, whichever comes first. On reaching it the browser
+stops reading the upstream socket — it does not close it, fail the channel, or
+drop the frame that crossed the mark, which was already read and is queued. The
+kernel socket buffer then fills and the broker, and through it phi-agent, feels
+the stall. Reads resume as soon as pulls bring the queue back to half of both
+marks. `flow_control_timeout` is therefore unreachable for `broker.ws.pull`; it
+stays in the stable error set and remains the HTTP-stream behaviour, where a
+producer that outruns its queue still fails the channel. The 60-second idle
+timer is the safety net for a paused channel: an extension that stops pulling
+still expires it, which tears down the upstream socket and releases the paused
+read loop.
 
 The exact stable extension error set is `unauthorized_sender`, `unsupported_message`, `invalid_payload`, `invalid_path`, `unsupported_method`, `invalid_base64`, `request_too_large`, `response_too_large`, `channel_not_found`, `owner_mismatch`, `pull_already_pending`, `flow_control_timeout`, `upstream_error`, and `protocol_error`. These codes are protocol failures, including transport failures normalized as `upstream_error` and malformed upstream/protocol state normalized as `protocol_error`. HTTP statuses such as `401` remain successful broker envelopes so Sidecar can perform its normal token refresh. Only the capability handshake may select legacy discovery. After protocol support is confirmed, a bridge or business error is terminal for transport selection and must never fall back to loopback TCP.
 


### PR DESCRIPTION
## Why

Confirmed in Canary on 2026-09-03 (with phi-ai #410's instrumentation): long streamed Sidecar replies die with `NativeBrokerError: flow_control_timeout: Channel backpressure limit exceeded.` The native `ServiceBrokerChannelStore` fails a WebSocket channel the moment 128 events are queued with no pull pending, while `broker.ws.pull` returns exactly one event per bridge round trip (11 in-process hops, including a `DispatchQueue.main` hop). phi-agent emits one frame per model delta, so a 41 162-char reply (>10 000 frames) cannot be drained one round trip at a time and the channel is killed mid-stream although broker and phi-agent are healthy. Background: knowledge base `60-knowledge-items/pitfalls/service-broker-websocket-no-keepalive-30s-native-deadline.md`.

## What

- **Batched pull.** `pullWebSocket` drains the queue into one `events` array: up to 64 events / 512 KiB of payload, always at least one, never past a terminal event; sequences stay contiguous. An empty queue still waits and returns the single event that ends the wait. The extension already iterates `events` and checks each sequence, so no phi-ai change is required. HTTP stream pulls are unchanged (`bridgeChunkBytes` batches there).
- **Backpressure instead of a kill.** At the high-water mark (128 events or the negotiated window) the read loop parks on a per-channel continuation instead of failing the channel; the frame that crossed the mark stays queued. Reads resume once pulls bring the queue to half of both marks. Failure, close, cancel and idle expiry all release the gate exactly once. `flow_control_timeout` is now unreachable for WebSocket channels and stays HTTP-only.
- Docs: `docs/service-broker-extension-boundary.md`.

## Tests

Added to `ServiceBrokerChannelStoreTests`: batch drain order, per-pull event and byte limits, batch ends at a terminal event, single event on an empty queue, high-water pauses reads without failing or closing the socket and resumes after a pull, idle expiry releases a paused read loop. `ServiceBrokerExtensionProtocolTests`: the JSON envelope carries a whole batch with sequences. Existing WebSocket tests moved to the `events` array.

## Verification

Compiled with `xcodebuild build-for-testing -project Phi.xcodeproj -scheme PhiBrowser -destination 'platform=macOS,arch=arm64'` (TEST BUILD SUCCEEDED). The unit tests have NOT been executed yet because the test host launches Phi and collides with the live Phi apps on the dev machine; run:

```
xcodebuild test-without-building -project Phi.xcodeproj -scheme PhiBrowser \
  -destination 'platform=macOS,arch=arm64' \
  -derivedDataPath build/dd-backpressure \
  -only-testing:PhiBrowserTests/ServiceBrokerChannelStoreTests \
  -only-testing:PhiBrowserTests/ServiceBrokerExtensionProtocolTests \
  -only-testing:PhiBrowserTests/ServiceBrokerWebSocketTests
```

Draft until that run is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvkPshwTfj16oheuQKVzHY