### PR TITLE
Stop logging missing-window warnings for unmanaged Chromium app windows

### DIFF
--- a/Sources/ChromiumBridge/PhiChromiumCoordinator.swift
+++ b/Sources/ChromiumBridge/PhiChromiumCoordinator.swift
@@ -661,6 +661,10 @@ extension PhiChromiumCoordinator: PhiChromiumBridgeDelegate {
                 || browserType == .agentSpace || browserType == .kiosk
                 || browserType == .kioskIncognito else {
             AppLogInfo("🌐 [Chromium] Ignoring unsupported window type: \(browserType.rawValue)")
+            // The framework keeps routing tab and extension events for this
+            // window (e.g. the Phi Chat web-app window); let EventBus drop them
+            // quietly instead of logging a missing window for each one.
+            MainBrowserWindowControllersManager.shared.registerUnmanagedWindow(window, windowId: Int(windowId))
             return
         }
 

--- a/Sources/States/EventBus.swift
+++ b/Sources/States/EventBus.swift
@@ -187,6 +187,9 @@ class EventBus {
     private func handleWindowEvent<T: AppEvent>(_ event: T, windowId: Int) {
         guard let browserState = MainBrowserWindowControllersManager.shared
             .getBrowserState(for: windowId) else {
+            if MainBrowserWindowControllersManager.shared.isUnmanagedWindow(windowId) {
+                return
+            }
             AppLogWarn("Window not found for id: \(windowId)")
             return
         }

--- a/Sources/UserInterface/MainBrowserWindow/MainBrowserWindowControllersManager.swift
+++ b/Sources/UserInterface/MainBrowserWindow/MainBrowserWindowControllersManager.swift
@@ -52,6 +52,13 @@ class MainBrowserWindowControllersManager: MainBrowserWindowLookup {
     }
 
     static let shared = MainBrowserWindowControllersManager()
+
+    /// Chromium windows the shell deliberately leaves unmanaged: browser types
+    /// that never get a `MainBrowserWindowController`, such as web-app windows
+    /// (Phi Chat, hosted by its macOS app shim). Bridge events scoped to these
+    /// ids are expected and must not be reported as missing windows.
+    private var unmanagedWindowIds: Set<Int> = []
+    private var unmanagedWindowCloseObservers: [Int: NSObjectProtocol] = [:]
     private(set) var activeWindowController: MainBrowserWindowController? {
         didSet {
             guard oldValue !== activeWindowController else { return }
@@ -863,6 +870,33 @@ class MainBrowserWindowControllersManager: MainBrowserWindowLookup {
     
     func getBrowserState(for browserId: Int) -> BrowserState? {
         return windowControllers.first(where: { $0.windowId == browserId })?.browserState
+    }
+
+    /// Records a Chromium window the shell will not manage so that
+    /// window-scoped bridge events for it are dropped quietly until it closes.
+    func registerUnmanagedWindow(_ window: NSWindow, windowId: Int) {
+        unmanagedWindowIds.insert(windowId)
+        if let previous = unmanagedWindowCloseObservers[windowId] {
+            NotificationCenter.default.removeObserver(previous)
+        }
+        unmanagedWindowCloseObservers[windowId] = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            self?.unregisterUnmanagedWindow(windowId)
+        }
+    }
+
+    func isUnmanagedWindow(_ windowId: Int) -> Bool {
+        unmanagedWindowIds.contains(windowId)
+    }
+
+    private func unregisterUnmanagedWindow(_ windowId: Int) {
+        unmanagedWindowIds.remove(windowId)
+        if let observer = unmanagedWindowCloseObservers.removeValue(forKey: windowId) {
+            NotificationCenter.default.removeObserver(observer)
+        }
     }
 
     func controller(for windowId: Int) -> MainBrowserWindowController? {


### PR DESCRIPTION
Chromium keeps routing tab and extension events for windows the shell deliberately leaves unmanaged, such as the Phi Chat web-app window (`ChromiumBrowserTypeApp`) hosted by its macOS app shim. Each of those events logged `EventBus: Window not found for id`, dozens of lines per chat session.

The coordinator now registers ignored window ids with `MainBrowserWindowControllersManager`, `EventBus` drops their events silently, and the registration is cleared on `NSWindow.willCloseNotification`. No behaviour change for managed windows.

Verified with an Xcode Debug build of `PhiBrowser-canary`. Context: the Phi Chat web app lands in chromium `feature/phi-r150-chat-app-shim`; a shim-launched browser (`--no-startup-window`) relies on the shell creating no Space for app windows, which this change keeps as is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKbGGUPH32i2c78S5Wacj6
