### PR TITLE
fix: acknowledge native image preview requests

### DIFF
--- a/Sources/Notifications/MessageCard/ExtensionMessageRouter.swift
+++ b/Sources/Notifications/MessageCard/ExtensionMessageRouter.swift
@@ -91,7 +91,7 @@ final class ExtensionMessageRouter {
 
         register(type: "imagePreview") { context in
             ImagePreviewMessageHandler.handle(context)
-            return nil
+            return nil  // The handler replies after presentation or validation failure.
         }
 
         register(type: "showDialog") { context in

--- a/Sources/UserInterface/ImagePreview/ImagePreviewModels.swift
+++ b/Sources/UserInterface/ImagePreview/ImagePreviewModels.swift
@@ -245,24 +245,47 @@ private struct LegacyImagePreviewBridgeItem: Decodable {
 
 enum ImagePreviewMessageHandler {
     static func handle(_ context: ExtensionMessageContext) {
-        do {
-            let request = try JSONDecoder().decode(ImagePreviewBridgeRequest.self, from: Data(context.payload.utf8))
-            let items = ImagePreviewItem.items(
-                fromAddressStrings: request.itemAddresses,
-                authorizedPhiAgentSenderID: context.senderId
-            )
-
-            guard let controller = MainBrowserWindowControllersManager.shared.controller(for: request.windowId) ?? MainBrowserWindowControllersManager.shared.activeWindowController
-            else {
-                AppLogWarn("[ImagePreview] Window not found for id: \(request.windowId)")
-                return
+        Task { @MainActor in
+            handle(context, messenger: ExtensionMessaging.shared) { windowID, items, currentIndex in
+                guard let controller = MainBrowserWindowControllersManager.shared.controller(for: windowID)
+                    ?? MainBrowserWindowControllersManager.shared.activeWindowController else {
+                    return false
+                }
+                controller.browserState.imagePreviewState.open(items: items, currentIndex: currentIndex)
+                return true
             }
-
-            Task { @MainActor in
-                controller.browserState.imagePreviewState.open(items: items, currentIndex: request.currentIndex)
-            }
-        } catch {
-            AppLogError("[ImagePreview] Failed to decode extension payload: \(error)\nRaw payload: \(context.payload.prefix(500))")
         }
+    }
+
+    /// Acknowledges presentation, not image loading or dismissal. Every request
+    /// settles through its own reply channel, never an extension broadcast.
+    @MainActor
+    static func handle(
+        _ context: ExtensionMessageContext,
+        messenger: ExtensionMessagingProtocol,
+        openPreview: (Int, [ImagePreviewItem], Int) -> Bool
+    ) {
+        let request: ImagePreviewBridgeRequest
+        do {
+            request = try JSONDecoder().decode(ImagePreviewBridgeRequest.self, from: Data(context.payload.utf8))
+        } catch {
+            // Payloads may contain private image URLs or inline image bytes.
+            messenger.sendError("Invalid image preview payload", requestId: context.requestId)
+            return
+        }
+
+        let items = ImagePreviewItem.items(
+            fromAddressStrings: request.itemAddresses,
+            authorizedPhiAgentSenderID: context.senderId
+        )
+        guard !items.isEmpty else {
+            messenger.sendError("No image preview items provided", requestId: context.requestId)
+            return
+        }
+        guard openPreview(request.windowId, items, request.currentIndex) else {
+            messenger.sendError("Image preview window unavailable", requestId: context.requestId)
+            return
+        }
+        messenger.sendResponse("{}", requestId: context.requestId)
     }
 }

--- a/Tests/PhiBrowserTests/ImagePreviewMessageHandlerTests.swift
+++ b/Tests/PhiBrowserTests/ImagePreviewMessageHandlerTests.swift
@@ -1,0 +1,141 @@
+// Copyright 2026 Phinomenon Inc.
+//
+// Use of this source code is governed by an Apache license that can be
+// found in the LICENSE file.
+
+import XCTest
+@testable import Phi
+
+@MainActor
+final class ImagePreviewMessageHandlerTests: XCTestCase {
+    private final class TestMessenger: ExtensionMessagingProtocol {
+        var responses: [(response: String, requestId: String)] = []
+        var errors: [(error: String, requestId: String)] = []
+        var broadcasts: [(type: String, payload: String)] = []
+
+        func sendResponse(_ response: String, requestId: String) {
+            responses.append((response, requestId))
+        }
+
+        func sendError(_ error: String, requestId: String) {
+            errors.append((error, requestId))
+        }
+
+        func broadcast(type: String, payload: String) {
+            broadcasts.append((type, payload))
+        }
+    }
+
+    private func context(_ payload: String, requestID: String = "preview-request") -> ExtensionMessageContext {
+        ExtensionMessageContext(type: "imagePreview", payload: payload,
+                                requestId: requestID, senderId: "test-extension")
+    }
+
+    func testRepliesOnceAfterOpeningWithoutWaitingForImageLoading() {
+        let messenger = TestMessenger()
+        var opens = 0
+        ImagePreviewMessageHandler.handle(
+            context(#"{"windowId":42,"items":["https://example.com/image.png"],"currentIndex":0}"#),
+            messenger: messenger
+        ) { windowID, items, index in
+            opens += 1
+            XCTAssertEqual(windowID, 42)
+            XCTAssertEqual(items.count, 1)
+            XCTAssertEqual(items.first?.source, .remoteURL(URL(string: "https://example.com/image.png")!))
+            XCTAssertEqual(index, 0)
+            XCTAssertTrue(messenger.responses.isEmpty, "Do not acknowledge before opening the preview")
+            return true
+        }
+
+        XCTAssertEqual(opens, 1)
+        XCTAssertEqual(messenger.responses.count, 1)
+        XCTAssertEqual(messenger.responses.first?.response, "{}")
+        XCTAssertEqual(messenger.responses.first?.requestId, "preview-request")
+        XCTAssertTrue(messenger.errors.isEmpty)
+        XCTAssertTrue(messenger.broadcasts.isEmpty)
+    }
+
+    func testUnavailableWindowRejectsOnceInsteadOfTimingOut() {
+        let messenger = TestMessenger()
+        var opens = 0
+        ImagePreviewMessageHandler.handle(
+            context(#"{"windowId":42,"items":["https://example.com/image.png"],"currentIndex":0}"#),
+            messenger: messenger
+        ) { _, _, _ in
+            opens += 1
+            return false
+        }
+
+        XCTAssertEqual(opens, 1)
+        XCTAssertTrue(messenger.responses.isEmpty)
+        XCTAssertEqual(messenger.errors.count, 1)
+        XCTAssertEqual(messenger.errors.first?.error, "Image preview window unavailable")
+        XCTAssertEqual(messenger.errors.first?.requestId, "preview-request")
+        XCTAssertTrue(messenger.broadcasts.isEmpty)
+    }
+
+    func testMalformedPayloadsRejectWithoutOpeningOrEchoingPrivateData() {
+        for payload in [
+            "not JSON",
+            #"{"windowId":"invalid","items":["https://private.example/image?token=secret"],"currentIndex":0}"#,
+            #"{"windowId":42,"items":[17],"currentIndex":0}"#,
+            #"{"windowId":42,"items":["https://example.com/image.png"]}"#,
+        ] {
+            let messenger = TestMessenger()
+            ImagePreviewMessageHandler.handle(context(payload), messenger: messenger) { _, _, _ in
+                XCTFail("Malformed payload must not open a preview")
+                return true
+            }
+
+            XCTAssertTrue(messenger.responses.isEmpty)
+            XCTAssertEqual(messenger.errors.count, 1)
+            XCTAssertEqual(messenger.errors.first?.error, "Invalid image preview payload")
+            XCTAssertEqual(messenger.errors.first?.requestId, "preview-request")
+            XCTAssertTrue(messenger.broadcasts.isEmpty)
+        }
+    }
+
+    func testEmptyAndBlankItemsRejectWithoutOpening() {
+        for items in [#"[]"#, #"["", "  "]"#] {
+            let messenger = TestMessenger()
+            let payload = #"{"windowId":42,"items":\#(items),"currentIndex":0}"#
+            ImagePreviewMessageHandler.handle(context(payload), messenger: messenger) { _, _, _ in
+                XCTFail("Empty previews must not be acknowledged as opened")
+                return true
+            }
+
+            XCTAssertTrue(messenger.responses.isEmpty)
+            XCTAssertEqual(messenger.errors.count, 1)
+            XCTAssertEqual(messenger.errors.first?.error, "No image preview items provided")
+            XCTAssertEqual(messenger.errors.first?.requestId, "preview-request")
+            XCTAssertTrue(messenger.broadcasts.isEmpty)
+        }
+    }
+
+    func testLegacyItemsRemainSupportedAndIndexIsPassedToPreviewState() {
+        let messenger = TestMessenger()
+        let payload = #"{"windowId":42,"items":[{"source":{"type":"url","url":"https://example.com/one.png"}},{"type":"file","path":"/tmp/preview-fixture.png"}],"currentIndex":99}"#
+        ImagePreviewMessageHandler.handle(context(payload), messenger: messenger) { _, items, index in
+            XCTAssertEqual(items.count, 2)
+            XCTAssertEqual(items[0].source, .remoteURL(URL(string: "https://example.com/one.png")!))
+            XCTAssertEqual(items[1].source, .localFile(URL(fileURLWithPath: "/tmp/preview-fixture.png")))
+            XCTAssertEqual(index, 99, "BrowserImagePreviewState still owns index clamping")
+            return true
+        }
+
+        XCTAssertEqual(messenger.responses.count, 1)
+        XCTAssertTrue(messenger.errors.isEmpty)
+        XCTAssertTrue(messenger.broadcasts.isEmpty)
+    }
+
+    func testRepliesStayScopedToEachRequest() {
+        let messenger = TestMessenger()
+        let payload = #"{"windowId":42,"items":["https://example.com/image.png"],"currentIndex":0}"#
+        ImagePreviewMessageHandler.handle(context(payload, requestID: "first"), messenger: messenger) { _, _, _ in true }
+        ImagePreviewMessageHandler.handle(context(payload, requestID: "second"), messenger: messenger) { _, _, _ in false }
+
+        XCTAssertEqual(messenger.responses.map(\.requestId), ["first"])
+        XCTAssertEqual(messenger.errors.map(\.requestId), ["second"])
+        XCTAssertTrue(messenger.broadcasts.isEmpty)
+    }
+}

--- a/docs/service-broker-extension-boundary.md
+++ b/docs/service-broker-extension-boundary.md
@@ -139,6 +139,45 @@ Packet-capture verification must identify the Stable and Canary phi-agent ports 
 
 ## Native image previews
 
+### Request acknowledgement
+
+As of 2026-09-07, `imagePreview` settles each request through
+`ExtensionMessaging` after main-actor presentation: `{}` confirms that the
+preview state was opened, not that image loading finished or the user dismissed
+it. Invalid payloads, empty image lists, and unavailable windows reject the
+request explicitly. Error replies do not echo image URLs, inline bytes, or raw
+payloads. No reply is broadcast.
+
+This fixes the missing acknowledgement behind Sidecar's image-preview
+`Request to app timed out` reports (SIDECAR-E): the router returned `nil` for an
+asynchronous reply, but the handler never sent one, even when presentation
+succeeded. The extension must not swallow all native timeouts or retry opening
+the preview, since a timeout does not prove that presentation failed.
+
+The wire payload, legacy object-form items, requested-window/active-window
+selection, preview-state index clamping, file authorization, and image loading
+remain unchanged. No Sidecar or Sentinel update is required for the reply fix;
+old browser builds still exhibit the missing acknowledgement until updated.
+The separate SIDECAR-E conversation-load timeout and SIDECAR-C Runner discovery
+failures are not resolved by this change.
+
+`ImagePreviewMessageHandlerTests` injects the existing messaging boundary and a
+presentation closure, so success/error routing can be tested without opening a
+browser window or touching authentication. Cover exactly one request-scoped
+reply after presentation, explicit failures, legacy items, and no broadcasts.
+Validation on 2026-09-07: Xcode 26.6 `build-for-testing` with
+`PhiBrowser-canary` and `CODE_SIGNING_ALLOWED=NO` passed, including the new
+XCTest file. All six tests also executed successfully in an isolated SwiftPM
+fixture reusing the actual source and test files, with browser window/messaging
+and broker-authorization dependencies stubbed. This verifies reply logic, not
+live bridge delivery or authorization. The normal application-hosted XCTest
+suite and native smoke test were not run, to avoid launching the user's browser.
+A subsequent approved native smoke test should confirm a real Sidecar preview
+opens and its promise settles without waiting for the bridge timeout; image
+loading failures must remain visible inside the native preview.
+
+### Image loading and authorization
+
 The Sidecar may send a normalized relative phi-agent file address, under `/api/v1/files/` or `/v1/files/`, to the existing native image-preview message. This address is privileged only when the message sender exactly matches the pinned Canary Sidecar ID.
 
 For an authorized file address, `ImagePreviewLoader` asks `ServiceBrokerExtensionProtocol` to fetch the bytes from phi-agent through the negotiated service-broker UDS. The loader passes an opaque authenticated scope containing the account identity and auth revision. The protocol requires the current immutable shared-auth snapshot to match that exact scope, derives the socket/runtime from that snapshot's account, supplies that snapshot's access token as a Bearer credential, and pins `X-Phi-Extension-ID` to the authorized sender. Path validation and the negotiated non-streaming response-size limit are applied before image decoding.


### PR DESCRIPTION
## Summary

- Settle each image-preview request after presentation or with an explicit payload/window error, instead of leaving Sidecar waiting for a timeout.
- Reply only through the request channel; preserve legacy payloads, authorization, window selection, and image loading.
- Add exactly-once reply tests and document that acknowledgement confirms presentation, not image download completion.

## Validation

- Passed: Xcode 26.6 build-for-testing with signing disabled; six isolated Swift tests.
- Application-hosted tests and live browser smoke testing were not run. No deployment.
- This does not resolve SIDECAR-C or SIDECAR-E's separate conversation-load timeout.
