### PR TITLE
i18n: Advanced settings tab and open tab indicators for all 8 locales (2.10.0)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -60620,6 +60620,54 @@
             "state" : "new",
             "value" : "Show a dot on inactive pinned tabs and bookmarks that are currently open."
           }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在当前已打开但非活动的固定标签页和书签上显示圆点。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在目前已開啟但非使用中的釘選分頁與書籤上顯示小圓點。"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "現在開いている非アクティブな固定タブとブックマークにドットを表示します。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 열려 있지만 활성 상태가 아닌 고정된 탭과 북마크에 점을 표시해요."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Affiche un point sur les onglets épinglés inactifs et les favoris actuellement ouverts."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zeigt einen Punkt auf inaktiven angehefteten Tabs und Lesezeichen an, die gerade geöffnet sind."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toon een stip op inactieve vastgezette tabbladen en bladwijzers die momenteel geopend zijn."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Muestra un punto en las pestañas fijadas inactivas y en los marcadores que están abiertos actualmente."
+          }
         }
       }
     },
@@ -60631,6 +60679,54 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Show open tab indicators"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为打开的标签页显示指示灯"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "為開啟的分頁顯示指示燈"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "開いているタブのインジケーターを表示"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "열린 탭 표시기 보기"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afficher les indicateurs d'onglets ouverts"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indikatoren für offene Tabs anzeigen"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Toon indicatoren voor geopende tabbladen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mostrar indicadores de pestañas abiertas"
           }
         }
       }
@@ -61843,6 +61939,54 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Advanced"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "高级"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "進階"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "詳細"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "고급"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avancés"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erweitert"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Geavanceerd"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avanzado"
           }
         }
       }


### PR DESCRIPTION
Translations for the 3 strings from 6d1f7b1. The Advanced tab title uses each locale's standard Apple/Chrome settings word (高级 / 進階 / 詳細 / 고급 / Erweitert / Avancés / Avanzado / Geavanceerd, verified online per locale), and the indicator toggle mirrors Apple's own Dock show-indicators phrasing where the locale has one (zh/ko independently converged on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)